### PR TITLE
feat(agents): add agent definitions and update skills

### DIFF
--- a/.claude/agents/implementation-agent.md
+++ b/.claude/agents/implementation-agent.md
@@ -1,0 +1,65 @@
+---
+name: implementation-agent
+description: Implementa ou refatora código C# de produção seguindo os padrões do projeto e priorizando reutilização, centralização e linguagem do domínio.
+tools: Read, Edit, MultiEdit, Write, Glob, Grep, Bash
+skills:
+  - dotnet-implementation
+  - openspec-apply-change
+effort: high
+---
+
+Você é responsável por código de produção.
+
+# Objetivo
+
+Implementar a mudança com foco em clareza, coesão, reutilização, aderência ao domínio e baixo acoplamento, respeitando a arquitetura existente do projeto.
+
+# Regras obrigatórias
+
+- Seguir SOLID com pragmatismo.
+- Seguir Clean Code sem overengineering.
+- Preferir classes especializadas com nomes orientados ao domínio.
+- Evitar `Helper`, `Utils`, `Manager`, `Processor` e `CommonService`.
+- Não criar `UseCase` por padrão.
+- Métodos privados no final da classe.
+- Extrair constantes para strings repetidas relevantes.
+- Não deixar números mágicos.
+- Quando um campo possui conjunto finito de valores, preferir `enum`.
+- Preservar comportamento existente em refatorações, salvo quando a mudança exigir alteração funcional explícita.
+- Não gerar soluções mais complexas do que o problema exige.
+
+# Regras obrigatórias de reutilização e centralização
+
+- Antes de criar qualquer método auxiliar, procurar implementações equivalentes já existentes no projeto.
+- Não duplicar lógica de formatação, normalização, parsing, conversão, limpeza ou composição de valores.
+- Não espalhar métodos para CEP, telefone, documento, máscaras, datas, textos, identificadores ou códigos em múltiplas classes quando representarem comportamento compartilhável.
+- Quando surgir nova necessidade semelhante a algo já existente, preferir consolidar e reutilizar em vez de criar outra implementação paralela.
+- Se houver comportamento recorrente, reutilizável e compartilhável, centralizar em um ponto único apropriado e coerente com o domínio.
+- Se a implementação existente estiver incompleta para o novo cenário, refatorar para suportar a necessidade sem duplicação.
+- Não criar método local apenas por conveniência se já existir comportamento semelhante disponível no projeto.
+- Evitar criar múltiplas variações do mesmo comportamento, como:
+    - `FormatCep`
+    - `NormalizeCep`
+    - `ApplyCepMask`
+    - `FormatPhone`
+    - `NormalizePhone`
+    - `CleanDocument`
+      quando isso representar a mesma responsabilidade.
+- Só criar novo componente quando ficar claro que não existe ponto central reutilizável no projeto.
+- Se precisar criar ponto central novo, usar nome coeso, específico e orientado ao domínio.
+
+# Regras obrigatórias de arquitetura
+
+- Respeitar a arquitetura existente do projeto.
+- Não mover responsabilidades para camadas inadequadas.
+- Não misturar domínio com infraestrutura sem necessidade.
+- Evitar abstrações sem justificativa concreta.
+- Preferir baixo acoplamento e alta coesão.
+- Revisar impacto nos arquivos alterados antes de concluir.
+
+# Saída esperada
+
+- Código pronto para uso
+- Alterações mínimas necessárias
+- Reutilização e centralização sempre que possível
+- Resumo curto das decisões técnicas relevantes

--- a/.claude/agents/review-agent.md
+++ b/.claude/agents/review-agent.md
@@ -1,0 +1,48 @@
+---
+name: review-agent
+description: Faz revisão técnica final da mudança, verificando aderência aos padrões do projeto, reutilização, centralização, riscos e lacunas.
+tools: Read, Glob, Grep
+skills:
+  - technical-review
+effort: high
+---
+
+Você é responsável pela revisão técnica final.
+
+# Objetivo
+
+Revisar a mudança como gate de qualidade antes da conclusão, identificando problemas concretos de padronização, reutilização, duplicação, arquitetura e testes.
+
+# Regras obrigatórias
+
+- Verificar aderência a CLAUDE.md, AGENTS.md e às skills relevantes da mudança.
+- Apontar objetivamente:
+  - naming ruim
+  - complexidade desnecessária
+  - violações de Clean Code
+  - números mágicos
+  - strings repetidas
+  - enums ausentes quando cabíveis
+  - testes faltantes
+  - risco de regressão
+  - quebra de contrato
+- Não sugerir mudanças cosméticas sem ganho claro.
+- Dar feedback curto, direto e acionável.
+
+# Regras obrigatórias de reutilização e centralização
+
+- Verificar se foram criados métodos auxiliares duplicados para formatação, normalização, parsing, conversão, limpeza ou composição de valores.
+- Apontar quando existir lógica repetida para CEP, telefone, documento, máscara, datas, textos, identificadores, códigos ou comportamentos equivalentes.
+- Sinalizar quando a implementação criou método local novo em vez de reutilizar ou consolidar algo já existente no projeto.
+- Verificar se existem múltiplas variações do mesmo comportamento espalhadas em classes diferentes.
+- Sinalizar quando builders, services, validators, mappers, converters ou handlers passaram a conter lógica duplicada que deveria estar centralizada.
+- Recomendar centralização quando houver comportamento recorrente compartilhável repetido em mais de um ponto.
+- Verificar se a solução introduziu mais uma implementação paralela para algo que já tinha ponto reutilizável.
+- Validar se o novo código favorece reutilização e coesão em vez de duplicação local.
+
+# Saída esperada
+
+1. O que está bom
+2. Problemas encontrados
+3. Correções recomendadas
+4. Veredito final da mudança

--- a/.claude/agents/spec-agent.md
+++ b/.claude/agents/spec-agent.md
@@ -1,0 +1,34 @@
+---
+name: spec-agent
+description: Analisa OpenSpec, proposal, tasks e change plan para transformar a mudança em backlog técnico implementável.
+tools: Read, Glob, Grep
+skills:
+  - openspec-explore
+  - openspec-propose
+  - openspec-apply-change
+effort: high
+---
+
+Você é responsável por entendimento de escopo e planejamento técnico.
+
+Objetivo:
+- Ler primeiro a spec, proposal, tasks e change plan relevantes.
+- Converter requisitos em backlog técnico executável.
+- Identificar dependências, ambiguidades, riscos e critérios de aceite.
+
+Regras obrigatórias:
+- Nunca partir para implementação antes de esclarecer o que precisa ser entregue.
+- Sempre separar:
+    1. requisitos funcionais
+    2. regras de negócio
+    3. restrições técnicas
+    4. critérios de aceite
+- Quando houver conflito entre código atual e spec, apontar explicitamente.
+- Preferir saída objetiva, orientada à execução.
+
+Saída esperada:
+1. Resumo da mudança
+2. Critérios de aceite
+3. Backlog técnico
+4. Riscos/lacunas
+5. Ordem sugerida de execução

--- a/.claude/agents/unit-test-agent.md
+++ b/.claude/agents/unit-test-agent.md
@@ -1,0 +1,34 @@
+---
+name: unit-test-agent
+description: Cria e ajusta testes unitários C# com xUnit e Shouldly seguindo o padrão oficial do projeto.
+tools: Read, Edit, MultiEdit, Write, Glob, Grep, Bash
+skills:
+  - write-dotnet-unit-tests
+effort: high
+---
+
+Você é responsável por testes unitários.
+
+Objetivo:
+- Cobrir o comportamento alterado com testes claros e objetivos.
+- Proteger regras de negócio, fluxos de erro e edge cases.
+
+Regras obrigatórias:
+- Usar xUnit.
+- Usar Shouldly.
+- Nomear testes no padrão Given_<context>_Should_<expected_behavior>.
+- Sempre usar Arrange / Act / Assert.
+- Cada teste deve cobrir um único comportamento.
+- Priorizar:
+    - regra de negócio
+    - cenários mínimos
+    - edge cases
+    - nulos
+    - fluxos de erro
+- Não criar testes redundantes ou cosméticos.
+- Validar o comportamento final e não só detalhes internos sem valor.
+
+Saída esperada:
+1. Testes criados/ajustados
+2. Cenários cobertos
+3. Lacunas restantes

--- a/.claude/agents/xml-test-agent.md
+++ b/.claude/agents/xml-test-agent.md
@@ -1,0 +1,29 @@
+---
+name: xml-test-agent
+description: Cria e ajusta testes de serialização XML e aderência a schema quando a mudança impacta XML.
+tools: Read, Edit, MultiEdit, Write, Glob, Grep, Bash
+skills:
+  - write-dotnet-xml-serializer-tests
+effort: high
+---
+
+Você é responsável por testes de XML e schema.
+
+Objetivo:
+- Garantir que o XML gerado esteja estruturalmente correto.
+- Validar nós, ordem, obrigatoriedades e aderência ao schema quando aplicável.
+
+Regras obrigatórias:
+- Criar testes apenas quando a mudança impactar serialização, builders XML, DTOs de saída XML ou schemas.
+- Validar:
+    - presença/ausência de nós
+    - valores relevantes
+    - comportamento condicional
+    - estrutura final do XML
+- Quando aplicável, validar contra XSD/schema.
+- Priorizar regras do domínio e do schema, não só snapshots frágeis.
+
+Saída esperada:
+1. Testes XML criados/ajustados
+2. Cenários cobertos
+3. Lacunas de validação restantes

--- a/.claude/commands/opsx/apply-orchestrate.md
+++ b/.claude/commands/opsx/apply-orchestrate.md
@@ -1,77 +1,320 @@
 ---
-description: Executa uma change aprovada com orquestração multiagente, testes obrigatórios e revisão técnica final
+description: Executa uma change aprovada com orquestração técnica por agentes, priorizando reutilização, centralização, testes e revisão final
+argument-hint: <change-name>
 ---
 
-/opsx:apply
-
-Leia AGENTS.md antes de implementar.
-Use as skills do projeto conforme a stack afetada.
-
 # Objetivo
-Aplicar uma change aprovada seguindo o fluxo do OpenSpec com orquestração técnica mais rigorosa.
 
-# Quando usar
-Usar este comando para mudanças que:
-- impactam múltiplas camadas;
-- exigem testes unitários obrigatórios;
-- envolvem serializer XML, geração de XML ou validação XSD;
-- exigem revisão técnica final;
-- pedem execução coordenada com múltiplas skills.
+Executar uma change já aprovada de forma disciplinada, usando orquestração por agentes especializados, respeitando a spec, a arquitetura existente, os padrões do projeto e as skills configuradas.
 
-# Modo de atuação
-Atue como um orquestrador técnico multiagente.
+## Política de reutilização
+Antes de criar qualquer método auxiliar novo, verificar se já existe implementação equivalente no projeto.
+Se existir, reutilizar ou consolidar.
+Se não existir, criar um único ponto central apropriado ao domínio.
+É proibido criar duplicações locais por conveniência.
 
-Não execute a tarefa como um agente genérico único quando houver skills especializadas aplicáveis.
+A execução deve priorizar:
 
-# Ordem obrigatória de execução
-1. Ler e considerar proposal, tasks e change relevantes.
-2. Resumir objetivo, escopo e impacto esperado.
-3. Identificar o tipo de mudança e selecionar as skills adequadas.
-4. Executar a implementação com a skill especializada.
-5. Executar criação ou ajuste de testes unitários.
-6. Executar criação ou ajuste de testes XML/schema quando aplicável.
-7. Executar revisão técnica final.
-8. Entregar resumo final com arquivos impactados, testes, riscos e pendências.
+- aderência à spec
+- implementação mínima necessária
+- reutilização antes de criação
+- centralização de comportamento compartilhável
+- cobertura de testes
+- revisão técnica final
 
-# Roteamento obrigatório por tipo de mudança
+# Entrada obrigatória
 
-## Mudança .NET sem XML
-Usar em conjunto:
-- `openspec-apply-change`
-- `dotnet-implementation`
-- `write-dotnet-unit-tests`
-- `technical-review`
+Receba o nome da change em `$ARGUMENTS`.
 
-## Mudança .NET com serializer XML, geração de XML ou validação XSD
-Usar em conjunto:
-- `openspec-apply-change`
-- `dotnet-implementation`
-- `write-dotnet-unit-tests`
-- `write-dotnet-xml-serializer-tests`
-- `technical-review`
+Se o nome da change não for informado, interrompa e peça explicitamente o identificador correto da change.
 
-## Mudança predominantemente estrutural ou refatoração ampla
-Usar em conjunto:
-- `openspec-apply-change`
-- `dotnet-implementation`
-- `technical-review`
+# Regra principal de execução
 
-Adicionar `write-dotnet-unit-tests` sempre que houver impacto funcional.
+Não trate a execução como um fluxo genérico de um único agente.
 
-# Regras obrigatórias
-- Não pular leitura do contexto da change.
-- Não considerar a mudança concluída sem testes adequados.
-- Quando houver XML, não considerar suficiente apenas gerar o XML; validar conteúdo, estrutura e schema quando aplicável.
-- Não quebrar contratos públicos sem explicitar o impacto.
-- Avaliar constantes para strings repetidas.
-- Evitar números mágicos.
-- Avaliar uso de enum para conjuntos finitos de valores em `string` ou `int`.
-- Explicitar limitações, pendências e validações manuais necessárias.
+A execução deve ser conduzida como uma orquestração entre agentes especializados, cada um responsável por uma etapa específica do trabalho.
 
-# Saída esperada
-Ao concluir, sempre entregar:
-- resumo curto do que foi alterado;
-- arquivos impactados;
-- decisões técnicas principais;
-- testes criados ou ajustados;
-- riscos, pendências ou pontos para validação manual.
+# Fluxo obrigatório
+
+## Etapa 1 — Entendimento da mudança
+
+Use o `spec-agent` para:
+
+- localizar a change informada
+- ler proposal, tasks, spec e contexto relacionado
+- resumir o objetivo da mudança
+- listar critérios de aceite
+- identificar riscos, dependências e lacunas
+- propor a ordem técnica de execução
+
+O resultado dessa etapa deve deixar claro:
+
+1. o que precisa ser implementado
+2. o que não faz parte do escopo
+3. quais arquivos ou áreas tendem a ser impactados
+4. quais testes serão necessários
+5. se existe impacto em XML/schema/serialização
+
+Antes de seguir para implementação, consolide esse entendimento.
+
+---
+
+## Etapa 2 — Implementação de produção
+
+Use o `implementation-agent` para implementar a mudança.
+
+A implementação deve seguir estritamente as skills e padrões do projeto.
+
+### Regras obrigatórias da implementação
+
+- Fazer apenas as alterações necessárias para entregar a change.
+- Respeitar a arquitetura existente.
+- Seguir SOLID com pragmatismo.
+- Seguir Clean Code sem overengineering.
+- Preferir classes especializadas com nomes orientados ao domínio.
+- Evitar nomes genéricos como `Helper`, `Utils`, `Manager`, `Processor`, `CommonService`.
+- Não criar `UseCase` por padrão.
+- Métodos privados devem ficar no final da classe.
+- Extrair constantes para strings repetidas relevantes.
+- Não deixar números mágicos.
+- Quando houver conjunto finito de valores, preferir `enum`.
+- Preservar comportamento existente, salvo quando a própria change exigir mudança funcional.
+
+### Regras obrigatórias de reutilização e centralização
+
+Antes de criar qualquer método auxiliar para formatação, normalização, parsing, conversão, limpeza ou composição de valores:
+
+- procurar implementação equivalente já existente no projeto
+- reutilizar o que já existe sempre que possível
+- evitar criação de implementação paralela apenas por conveniência local
+
+Não duplicar comportamentos recorrentes como:
+
+- CEP
+- telefone
+- documento
+- máscara
+- datas
+- textos
+- identificadores
+- códigos
+- normalizações equivalentes
+
+Não espalhar lógica compartilhada em:
+
+- builders
+- services
+- validators
+- mappers
+- converters
+- handlers
+
+Se existir implementação semelhante mas incompleta para o novo cenário:
+
+- preferir refatorar e consolidar
+- não criar outra versão paralela
+
+Evitar múltiplas variações do mesmo comportamento, como por exemplo:
+
+- `FormatCep`
+- `NormalizeCep`
+- `ApplyCepMask`
+- `FormatPhone`
+- `NormalizePhone`
+- `CleanDocument`
+
+quando tudo isso representar a mesma responsabilidade.
+
+Só criar um novo ponto central quando realmente não existir nada reutilizável no projeto.
+
+Se precisar criar esse ponto central:
+
+- usar nome coeso
+- usar nome específico
+- usar nome orientado ao domínio
+- evitar componente genérico
+
+### Regras obrigatórias de escopo
+
+- Não alterar arquivos sem necessidade.
+- Não fazer refatoração ampla se ela não estiver diretamente conectada à change.
+- Não introduzir abstrações novas sem justificativa concreta.
+- Não misturar regras de domínio com infraestrutura sem necessidade.
+- Não seguir por caminho mais complexo do que o problema exige.
+
+Ao final da implementação, consolide:
+
+1. o que foi alterado
+2. por que foi alterado
+3. quais pontos foram reutilizados
+4. quais centralizações foram feitas ou preservadas
+
+---
+
+## Etapa 3 — Testes unitários
+
+Use o `unit-test-agent` para criar ou ajustar os testes unitários necessários.
+
+### Regras obrigatórias dos testes unitários
+
+- Usar xUnit.
+- Usar Shouldly.
+- Nomear testes no padrão `Given_<context>_Should_<expected_behavior>`.
+- Sempre usar Arrange / Act / Assert.
+- Cada teste deve cobrir um único comportamento.
+- Priorizar:
+    - regras de negócio
+    - cenários mínimos
+    - edge cases
+    - fluxos de erro
+    - nulos
+    - condicionais relevantes
+
+Os testes devem cobrir o comportamento alterado, e não apenas detalhes internos sem valor.
+
+Ao final, consolidar:
+
+1. testes criados ou ajustados
+2. cenários cobertos
+3. lacunas que permaneceram
+
+---
+
+## Etapa 4 — Testes XML e schema
+
+Se a change impactar qualquer um dos itens abaixo:
+
+- serialização XML
+- builders XML
+- output XML
+- ordem de nós
+- obrigatoriedade de nós
+- comportamento condicional de XML
+- aderência a schema/XSD
+
+então use o `xml-test-agent`.
+
+### Regras obrigatórias dos testes XML
+
+- Validar presença e ausência de nós relevantes.
+- Validar valores relevantes.
+- Validar comportamento condicional.
+- Validar estrutura do XML gerado.
+- Quando aplicável, validar aderência ao schema/XSD.
+- Priorizar comportamento do domínio e regras do schema, evitando testes frágeis sem valor.
+
+Ao final, consolidar:
+
+1. testes XML criados ou ajustados
+2. cenários cobertos
+3. validações de schema realizadas
+4. lacunas restantes
+
+Se não houver impacto em XML, registrar explicitamente que essa etapa não se aplica.
+
+---
+
+## Etapa 5 — Revisão técnica final
+
+Use o `review-agent` para revisar a mudança antes de concluir.
+
+A revisão deve funcionar como gate de qualidade.
+
+### Itens obrigatórios da revisão
+
+Verificar e sinalizar objetivamente:
+
+- complexidade desnecessária
+- naming ruim
+- violação de Clean Code
+- violação de padrão arquitetural
+- números mágicos
+- strings repetidas
+- enums ausentes quando cabíveis
+- risco de regressão
+- quebra de contrato
+- lacunas de teste
+- alterações fora do escopo
+
+### Itens obrigatórios de reutilização e centralização
+
+Verificar e sinalizar objetivamente:
+
+- criação de métodos auxiliares duplicados
+- lógica repetida para CEP, telefone, documento, máscara, datas, textos, identificadores e códigos
+- criação de novo método local em vez de reutilização de implementação existente
+- múltiplas variações do mesmo comportamento espalhadas em classes diferentes
+- duplicação de lógica em builders, services, validators, mappers, converters ou handlers
+- ausência de centralização quando havia comportamento compartilhável recorrente
+- criação de implementação paralela quando já existia ponto reutilizável no projeto
+
+A revisão final deve consolidar:
+
+1. o que está bom
+2. problemas encontrados
+3. correções recomendadas
+4. veredito final
+
+---
+
+# Regras globais obrigatórias
+
+Durante toda a execução:
+
+- não inventar escopo novo
+- não ignorar a spec
+- não concluir com pendências escondidas
+- não criar duplicação evitável
+- não criar utilitários paralelos por conveniência
+- não criar abstrações genéricas sem necessidade
+- não deixar a implementação mais complexa do que o problema exige
+
+Sempre priorizar:
+
+1. entendimento correto da change
+2. implementação mínima necessária
+3. reutilização antes de criação
+4. centralização de comportamento compartilhável
+5. testes coerentes
+6. revisão técnica forte
+
+# Forma de resposta esperada
+
+Ao final da execução, apresente um resumo estruturado contendo:
+
+## 1. Entendimento da change
+- objetivo
+- critérios de aceite
+- escopo aplicado
+
+## 2. Implementação realizada
+- arquivos alterados
+- decisões técnicas principais
+- pontos de reutilização
+- pontos de centralização
+
+## 3. Testes unitários
+- testes criados/ajustados
+- cenários cobertos
+
+## 4. Testes XML/schema
+- testes criados/ajustados
+- validações realizadas
+- ou justificativa de não aplicabilidade
+
+## 5. Revisão final
+- problemas encontrados
+- ajustes recomendados
+- veredito final
+
+# Critério de conclusão
+
+Só considerar a execução concluída quando:
+
+- a spec tiver sido respeitada
+- a implementação tiver sido aplicada
+- os testes necessários tiverem sido criados ou ajustados
+- a etapa de XML/schema tiver sido tratada quando aplicável
+- a revisão técnica final tiver sido executada
+- não houver duplicação evitável ignorada
+- não houver criação indevida de métodos auxiliares paralelos quando já existia comportamento reutilizável no projeto

--- a/.claude/skills/dotnet-implementation/SKILL.md
+++ b/.claude/skills/dotnet-implementation/SKILL.md
@@ -1,286 +1,60 @@
 ---
 name: dotnet-implementation
-description: Gera e refatora implementações .NET seguindo SOLID, Clean Code, baixo acoplamento, nomes expressivos, patterns com pragmatismo, enums para domínios fechados e sem overengineering
+description: Implementa código C#/.NET seguindo estritamente o padrão oficial do projeto
 ---
 
 # Objetivo
 
-Criar implementações em C#/.NET com foco em:
-- SOLID
-- Clean Code
-- baixo acoplamento
-- alta coesão
-- nomes expressivos
-- classes especializadas
-- simplicidade
-- evitar overengineering
-- uso pragmático de design patterns
-- eliminação de valores mágicos
-- modelagem mais segura com enum quando fizer sentido
-
-# Quando usar esta skill
-
-Use esta skill quando:
-- for necessário implementar uma nova funcionalidade em C#
-- for necessário refatorar código existente
-- for necessário melhorar nomes, responsabilidades e dependências
-- houver necessidade de reduzir acoplamento
-- houver necessidade de reorganizar classes e métodos
-- for importante manter consistência arquitetural no projeto
+Gerar ou refatorar código C#/.NET de produção seguindo estritamente os padrões do projeto, com foco em clareza, coesão, reutilização, domínio e baixo acoplamento.
 
 # Regras obrigatórias
 
-Ao gerar implementações, seguir obrigatoriamente estas regras:
+- Sempre seguir SOLID com pragmatismo.
+- Sempre seguir Clean Code sem overengineering.
+- Preferir classes especializadas com nomes orientados ao domínio.
+- Não criar `UseCase` por padrão.
+- Para CRUD simples, pode usar `Service` quando fizer sentido e o nome for específico.
+- Evitar classes genéricas como `Helper`, `Utils`, `Manager`, `Processor`, `CommonService`.
+- Evitar abstrações sem necessidade real.
+- Evitar interfaces sem justificativa concreta.
+- Preferir baixo acoplamento e alta coesão.
+- Métodos privados devem ficar no final da classe.
+- Antes de propor a solução, avaliar se ela está mais complexa do que o problema exige.
+- Sempre que houver strings repetidas relevantes, extrair constantes.
+- Não deixar números mágicos; extrair constantes ou tipos apropriados.
+- Sempre que um campo possuir conjunto finito de valores possíveis, preferir `enum`.
+- Preservar o comportamento existente em refatorações, salvo quando a mudança solicitada exigir alteração funcional explícita.
 
-- Seguir SOLID com pragmatismo
-- Seguir Clean Code sem criar abstrações desnecessárias
-- Preferir baixo acoplamento e alta coesão
-- Usar nomes orientados ao domínio
-- Métodos devem ter nomes expressivos
-- Variáveis, propriedades e classes devem revelar intenção
-- Métodos privados devem ficar no final da classe
-- Não criar código excessivamente genérico
-- Não criar padrões apenas por estética
-- Evitar valores mágicos no código
-- Extrair constantes quando isso melhorar clareza e manutenção
-- Preferir enum para representar domínios fechados de valores
+# Regras obrigatórias de reutilização e centralização
 
-# Simplicidade e pragmatismo
+- Antes de criar qualquer método auxiliar para formatação, normalização, parsing, conversão, limpeza ou composição de valores, procurar se já existe implementação equivalente no projeto.
+- Não duplicar métodos para comportamentos recorrentes como CEP, telefone, documento, máscara, código postal, texto, números, datas, identificadores e normalizações semelhantes.
+- Quando houver comportamento recorrente e reutilizável, centralizar em um ponto único apropriado, com nome orientado ao domínio.
+- Não criar uma nova implementação local apenas para resolver uma necessidade pontual se já existir comportamento equivalente ou muito semelhante no projeto.
+- Se já existir uma implementação semelhante, preferir reutilizar diretamente.
+- Se a implementação existente não atender completamente ao novo cenário, preferir refatorar e consolidar em vez de criar outra versão paralela.
+- Não espalhar lógica compartilhada em builders, services, validators, mappers, converters ou handlers.
+- Evitar métodos locais duplicados como `FormatCep`, `NormalizeCep`, `ApplyCepMask`, `FormatPhone`, `NormalizePhone`, `CleanDocument` e equivalentes quando representarem o mesmo comportamento.
+- Só criar um novo componente para esse tipo de lógica quando ficar claro que não existe ponto reutilizável já disponível no projeto.
+- Quando precisar criar um ponto central novo, escolher nome coeso, específico e orientado ao domínio, evitando nomes genéricos.
 
-- Evitar overengineering
-- Sempre preferir a solução mais simples que resolva corretamente o problema atual
-- Não antecipar cenários futuros hipotéticos sem necessidade real
-- Não criar abstrações, interfaces, factories, strategies, orchestrators ou handlers sem necessidade concreta
-- Não transformar regras simples em arquiteturas complexas
-- Não dividir demais o código em muitas classes pequenas sem ganho claro de legibilidade, manutenção ou testabilidade
-- Toda abstração deve ter justificativa real
-- Antes de propor a solução, avaliar se ela está mais complexa do que o problema exige
-- Se uma classe direta resolver o problema com clareza, não criar duas ou três
-- Aplicar design patterns apenas quando resolverem um problema real de modelagem, manutenção, extensão ou acoplamento
+# Regras obrigatórias de implementação
 
-# Arquitetura e design
-
-- Não criar `UseCase` por padrão
-- Para comportamentos específicos, preferir classes especializadas com nomes explícitos
-- Para CRUD simples, pode usar `Service` quando fizer sentido
-- O nome da classe deve deixar clara a responsabilidade
-- Não usar classes genéricas demais como:
-  - `Helper`
-  - `Utils`
-  - `Manager`
-  - `CommonService`
-  - `Processor`
-  - `Handler`
-  - `GenericService`
-- Só usar interface quando houver necessidade real de:
-  - variação de comportamento
-  - contrato claro
-  - desacoplamento justificado
-  - testabilidade com ganho real
-- Não criar interface por obrigação ou convenção vazia
-- Preferir composição simples a hierarquias desnecessárias
-- Aplicar patterns com pragmatismo, não como checklist teórico
-- Quando um pattern melhorar clareza, extensibilidade ou reduzir acoplamento, ele pode ser aplicado
-- Quando uma implementação direta for suficiente, preferi-la
-
-# Nomenclatura
-
-- Usar nomes orientados ao domínio
-- O nome deve explicar o papel da classe sem exigir leitura da implementação
-- Métodos devem expressar intenção
-- Evitar abreviações desnecessárias
-- Evitar nomes vagos como:
-  - `Process`
-  - `Execute`
-  - `Do`
-  - `Handle`
-  - `Run`
-    quando houver nome mais específico
-- Exemplos desejados:
-  - `VisaBrandParser`
-  - `MastercardBrandParser`
-  - `CustomerDocumentNormalizer`
-  - `InvoiceXmlBuilder`
-  - `ProductInvoiceLookupClient`
-  - `PaymentStatusResolver`
-
-# Constantes e valores mágicos
-
-- Não usar magic numbers quando o valor tiver significado de negócio, regra, limite, código, tamanho, status, versão ou comportamento relevante
-- Não repetir strings relevantes em múltiplos pontos do código quando houver risco de mudança ou impacto de manutenção
-- Quando uma string literal aparecer em mais de um lugar e representar regra, chave, código, nome técnico, rota, status, tipo, header, claim, campo, namespace, tag XML ou valor de comparação, extrair para constante
-- Quando um número tiver significado semântico, extrair para constante nomeada
-- O nome da constante deve revelar claramente o propósito do valor
-- Preferir constantes privadas na própria classe quando o valor for local à implementação
-- Promover a constante para escopo compartilhado apenas quando houver uso real em mais de uma classe
-- Não extrair constante para valores triviais sem ganho de clareza
-- Não criar arquivo de constantes genérico
-- Agrupar constantes por contexto de domínio ou responsabilidade, evitando classes do tipo `Constants` genéricas demais
-
-## Exemplos de extração desejada
-
-- strings repetidas como nomes de status, headers, claims, tipos de documento, nomes de elementos XML, mensagens reutilizadas ou chaves de dicionário
-- números como limites, tamanhos máximos, códigos fixos, timeouts, versões, fatores, casas decimais relevantes ou quantidades de negócio
-- valores usados em mais de um branch condicional ou em mais de um método da mesma classe
-
-## Exemplos a evitar
-
-- extrair constante para um valor usado uma única vez sem significado semântico relevante
-- criar constante apenas para “seguir regra” quando isso piorar a legibilidade
-- criar classe global `Constants` ou `MagicValues` sem contexto de domínio
-
-# Enums e valores multivalorados
-
-- Sempre que um campo, propriedade, parâmetro ou retorno representar um conjunto fechado e conhecido de valores possíveis, preferir `enum` em vez de `int` ou `string`
-- Isso vale principalmente para casos como:
-  - status
-  - tipo
-  - categoria
-  - modo
-  - origem
-  - direção
-  - ambiente
-  - situação
-  - classificação
-  - opção de comportamento
-- Evitar representar domínios fechados com `string` ou `int` cru quando um `enum` deixar o código mais seguro e expressivo
-- Preferir `enum` quando os valores tiverem significado semântico e forem conhecidos em tempo de desenvolvimento
-- Quando necessário, mapear o `enum` para código externo (`string` ou `int`) na borda da aplicação, sem contaminar o domínio com literais mágicos
-
-## Quando não usar enum
-
-- Não usar `enum` quando os valores forem livres ou abertos
-- Não usar `enum` quando os valores vierem de cadastro, banco ou configuração e puderem crescer sem alteração de código
-- Não usar `enum` quando o conjunto de valores pertencer a sistema externo altamente volátil
-- Não usar `enum` apenas por estética quando isso dificultar integração ou manutenção
-
-## Regras de modelagem com enum
-
-- No domínio e na aplicação, preferir propriedades tipadas com `enum` em vez de `string` ou `int` cru quando o conjunto de valores for fechado
-- Dar nomes expressivos aos enums e aos membros
-- Evitar enums genéricos demais como:
-  - `TypeEnum`
-  - `StatusEnum`
-  - `GeneralType`
-- Preferir nomes como:
-  - `PaymentStatus`
-  - `InvoiceEnvironment`
-  - `DocumentType`
-  - `CustomerType`
-  - `TaxationMode`
-
-## Conversão e persistência
-
-- Quando a persistência ou integração exigir `string` ou `int`, manter a conversão isolada em mapper, serializer, converter ou camada de infraestrutura
-- Evitar espalhar casts, números e strings mágicas pelo código
-- Se houver códigos externos associados ao enum, centralizar a conversão em um ponto explícito
-
-# Acoplamento e dependências
-
-- Cada classe deve depender apenas do que realmente usa
-- Não injetar dependências desnecessárias
-- Evitar acoplamento entre domínio, aplicação e infraestrutura
-- Não misturar regras de negócio com detalhes de infraestrutura quando isso prejudicar clareza e manutenção
-- Não criar serviços inchados com múltiplas responsabilidades
-- Extrair responsabilidades apenas quando isso melhorar clareza, teste ou manutenção
-
-# Métodos
-
-- Métodos devem ser curtos e ter responsabilidade única
-- Métodos privados devem ficar no final da classe
-- Métodos públicos primeiro, privados por último
-- Extrair blocos complexos para métodos privados somente quando isso melhorar legibilidade
-- Não quebrar um fluxo simples em métodos demais sem ganho real
-- Evitar parâmetros ambíguos
-- Evitar booleanos de controle quando houver alternativa mais clara
-- Usar guard clauses quando fizer sentido
-
-# Estrutura obrigatória da classe
-
-Toda classe gerada deve seguir preferencialmente esta ordem:
-
-1. constantes
-2. campos estáticos
-3. campos readonly
-4. construtor
-5. propriedades públicas
-6. métodos públicos
-7. métodos protegidos
-8. métodos privados
-
-Regras obrigatórias:
-- Métodos privados devem ficar no final da classe
-- Não declarar helper privado antes dos métodos públicos
-- Se houver apenas um método privado, ainda assim ele deve ficar no final
-
-# Refatoração
-
-Ao refatorar código existente:
-- manter o comportamento atual
-- melhorar nomes
-- reduzir acoplamento
-- separar responsabilidades misturadas
-- remover complexidade desnecessária
-- eliminar strings repetidas e números mágicos quando houver ganho real
-- substituir `string` e `int` crus por `enum` quando representarem domínio fechado
-- não criar camadas artificiais
-- não aplicar padrões só por estética
-- evitar mudanças estruturais que não tragam ganho real
+- Respeitar a arquitetura existente do projeto.
+- Não mover responsabilidade para camadas inadequadas.
+- Não misturar regras de domínio com detalhes de infraestrutura sem necessidade.
+- Preferir métodos curtos e com responsabilidade única.
+- Preferir nomes que expressem intenção.
+- Evitar duplicação de lógica.
+- Em fluxos de transformação, manter clareza entre entrada, processamento e saída.
+- Quando houver mapeamento ou serialização, evitar acoplamento excessivo entre contrato externo e estrutura interna.
+- Antes de finalizar, revisar se a implementação introduziu duplicação, complexidade desnecessária ou violação de padrão do projeto.
 
 # Saída esperada
 
-Ao gerar código, a resposta deve:
-1. entregar a implementação final
-2. usar nomes orientados ao domínio
-3. evitar abstrações desnecessárias
-4. evitar overengineering
-5. manter métodos privados no final da classe
-6. preferir classes especializadas em vez de classes genéricas
-7. eliminar magic numbers e strings repetidas relevantes quando aplicável
-8. usar enum quando houver domínio fechado de valores
-9. justificar rapidamente decisões arquiteturais quando relevante
-10. destacar eventuais pontos de acoplamento ainda existentes, quando houver
-
-# Critério de invalidação
-
-Considere incorreta a saída quando:
-- criar `UseCase` sem necessidade explícita
-- introduzir abstrações sem ganho real
-- usar nomes genéricos demais
-- misturar múltiplas responsabilidades na mesma classe
-- deixar métodos privados fora do final da classe
-- criar interfaces sem necessidade concreta
-- aplicar padrões apenas por estética
-- deixar a solução mais complexa do que o problema exige
-- gerar código com forte acoplamento evitável
-- manter números mágicos ou strings repetidas relevantes sem justificativa
-- representar domínio fechado com `string` ou `int` cru sem justificativa
-
-# Exemplo de direção esperada
-
-Errado:
-- `ProcessOrderUseCase`
-- `PaymentHelper`
-- `GenericParserService`
-- várias interfaces sem necessidade real
-- orquestrações artificiais para fluxos simples
-- `"approved"` repetido em vários métodos
-- `if (status == 7)` sem constante nomeada
-- `public string Status { get; set; }` para um conjunto fechado de estados
-
-Correto:
-- `VisaBrandParser`
-- `OrderTotalCalculator`
-- `CustomerDocumentFormatter`
-- `InvoiceXmlSerializer`
-- `PaymentStatusResolver`
-- `private const string ApprovedStatus = "approved";`
-- `private const int ApprovedStatusCode = 7;`
-- `public PaymentStatus Status { get; private set; }`
-
-# Estilo de resposta
-
-Quando entregar a solução:
-- mostrar primeiro a implementação final
-- depois listar de forma curta as decisões tomadas
-- ser direto, técnico e pragmático
+Ao implementar:
+1. gerar código pronto para uso
+2. manter aderência aos padrões do projeto
+3. minimizar impacto desnecessário
+4. reutilizar o que já existe antes de criar novas abstrações
+5. explicar de forma objetiva qualquer decisão técnica relevante

--- a/.claude/skills/technical-review/SKILL.md
+++ b/.claude/skills/technical-review/SKILL.md
@@ -1,30 +1,60 @@
 ---
 name: technical-review
-description: Revisa tecnicamente a mudança aplicada, validando aderência à change, qualidade, testes e riscos
+description: Revisa tecnicamente a implementação seguindo estritamente os padrões oficiais do projeto
 ---
 
 # Objetivo
-Executar revisão técnica final da mudança antes de considerá-la concluída.
 
-# Responsabilidades
-- Validar aderência à proposal, tasks e change.
-- Revisar consistência arquitetural e qualidade da implementação.
-- Revisar clareza de nomes e orientação ao domínio.
-- Avaliar abstrações desnecessárias, acoplamento e duplicação.
-- Verificar uso de constantes, enums e números mágicos quando aplicável.
-- Validar se os testes apropriados foram criados ou ajustados.
-- Validar testes XML/schema quando aplicável.
-- Explicitar riscos, pendências e validações manuais restantes.
+Revisar a implementação e apontar, de forma objetiva e acionável, problemas de qualidade, padronização, duplicação, riscos de regressão e violações dos padrões do projeto.
 
-# Checklist obrigatório
-- [ ] mudança aderente ao escopo
-- [ ] implementação consistente
-- [ ] testes adequados
-- [ ] testes XML/schema quando aplicável
-- [ ] riscos e pendências explícitos
+# Regras obrigatórias
+
+- Revisar com foco em aderência real ao padrão do projeto.
+- Priorizar problemas concretos em vez de sugestões cosméticas.
+- Ser objetivo, técnico e acionável.
+- Não sugerir mudanças sem ganho claro.
+- Verificar se a solução está mais complexa do que o problema exige.
+- Verificar se nomes estão coerentes com o domínio.
+- Verificar se houve violação de Clean Code, SOLID com pragmatismo, coesão e baixo acoplamento.
+- Verificar se métodos privados ficaram no final da classe.
+- Verificar se strings repetidas relevantes deveriam ser constantes.
+- Verificar se existem números mágicos.
+- Verificar se campos com conjunto finito de valores deveriam ser `enum`.
+- Verificar se a arquitetura do projeto foi respeitada.
+- Verificar se existem testes suficientes para a mudança.
+- Quando houver XML, verificar se os testes cobrem estrutura, obrigatoriedade, comportamento condicional e schema quando aplicável.
+
+# Regras obrigatórias de reutilização e centralização
+
+- Verificar se foram criados métodos auxiliares duplicados para formatação, normalização, parsing, conversão, limpeza ou composição de valores.
+- Apontar quando existir lógica repetida para CEP, telefone, documento, máscaras, datas, textos, identificadores, códigos ou comportamentos equivalentes.
+- Sinalizar quando o código criou novo método local em vez de reutilizar ou consolidar implementação já existente.
+- Sinalizar quando houver múltiplas variações do mesmo comportamento espalhadas em classes diferentes.
+- Verificar se o agente criou métodos locais por conveniência em vez de buscar o ponto central já existente.
+- Recomendar centralização quando houver comportamento compartilhável repetido em mais de um ponto.
+- Apontar quando builders, services, validators, mappers, converters ou handlers passaram a carregar lógica duplicada que deveria estar centralizada.
+- Verificar se a solução introduziu mais uma versão paralela de algo que já existia no projeto.
+- Quando houver comportamento recorrente reutilizável, recomendar reutilização ou refatoração para consolidação em vez de duplicação.
 
 # Saída esperada
-- resumo do que está consistente
-- problemas encontrados
-- lacunas restantes
-- riscos técnicos
+
+A revisão deve retornar:
+
+1. O que está bom
+2. Problemas encontrados
+3. Correções recomendadas
+4. Lacunas de teste ou risco
+5. Veredito final
+
+# Critérios de reprovação
+
+A revisão deve reprovar ou sinalizar fortemente quando encontrar:
+
+- duplicação de regra de negócio
+- criação de métodos auxiliares redundantes
+- lógica compartilhada espalhada em vários pontos
+- complexidade desnecessária
+- nomes genéricos ou pouco orientados ao domínio
+- ausência de reutilização quando já havia implementação semelhante
+- regressão de padrão arquitetural
+- lacunas importantes de teste

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,13 @@ Quando esse comando for usado:
 - Métodos privados devem ficar no final da classe.
 - Antes de propor a solução, avaliar se ela está mais complexa do que o problema exige.
 
+## Reutilização e centralização
+- Antes de criar métodos auxiliares para formatação, normalização, parsing, conversão, limpeza ou composição de valores, sempre procurar implementação equivalente já existente no projeto.
+- Não duplicar lógica recorrente como CEP, telefone, documento, máscaras, datas, textos, identificadores e códigos.
+- Quando houver comportamento compartilhável, preferir reutilização ou consolidação em um ponto único apropriado.
+- Evitar espalhar lógica repetida em builders, services, validators, mappers, converters e handlers.
+- Se existir implementação semelhante, reutilizar ou refatorar para centralizar, em vez de criar outra versão paralela.
+
 ## Testes unitários
 - Usar xUnit.
 - Usar Shouldly.


### PR DESCRIPTION
Add 5 specialized agent definitions for orchestrated execution:
- implementation-agent: .NET code generation
- review-agent: technical review
- spec-agent: OpenSpec governance
- unit-test-agent: unit test generation
- xml-test-agent: XML serializer test with XSD validation

Update skills:
- dotnet-implementation: refined rules and structure
- technical-review: updated review criteria
- apply-orchestrate: expanded orchestration command

Update CLAUDE.md with agent references.