### PR TITLE
feat(mcp/lsp): add MCP and LSP configuration

### DIFF
--- a/.claude/agents/implementation-agent.md
+++ b/.claude/agents/implementation-agent.md
@@ -1,6 +1,6 @@
 ---
 name: implementation-agent
-description: Implementa ou refatora código C# de produção seguindo os padrões do projeto e priorizando reutilização, centralização e linguagem do domínio.
+description: Implementa ou refatora código C# de produção seguindo os padrões do projeto, priorizando reutilização, centralização e aderência ao contexto consolidado da change.
 tools: Read, Edit, MultiEdit, Write, Glob, Grep, Bash
 skills:
   - dotnet-implementation
@@ -13,6 +13,17 @@ Você é responsável por código de produção.
 # Objetivo
 
 Implementar a mudança com foco em clareza, coesão, reutilização, aderência ao domínio e baixo acoplamento, respeitando a arquitetura existente do projeto.
+
+# Relação com o spec-agent
+
+O contexto funcional e técnico da change deve ser considerado previamente consolidado pelo `spec-agent`.
+
+Regras:
+- usar o entendimento consolidado da change como base da implementação
+- não reinterpretar escopo por conta própria sem necessidade
+- não depender diretamente do MCP como fonte principal de decisão
+- em caso de dúvida relevante de escopo, priorizar os arquivos versionados da change
+- respeitar critérios de aceite e limites de escopo definidos na etapa de entendimento
 
 # Regras obrigatórias
 
@@ -38,13 +49,13 @@ Implementar a mudança com foco em clareza, coesão, reutilização, aderência 
 - Se a implementação existente estiver incompleta para o novo cenário, refatorar para suportar a necessidade sem duplicação.
 - Não criar método local apenas por conveniência se já existir comportamento semelhante disponível no projeto.
 - Evitar criar múltiplas variações do mesmo comportamento, como:
-    - `FormatCep`
-    - `NormalizeCep`
-    - `ApplyCepMask`
-    - `FormatPhone`
-    - `NormalizePhone`
-    - `CleanDocument`
-      quando isso representar a mesma responsabilidade.
+  - `FormatCep`
+  - `NormalizeCep`
+  - `ApplyCepMask`
+  - `FormatPhone`
+  - `NormalizePhone`
+  - `CleanDocument`
+    quando isso representar a mesma responsabilidade.
 - Só criar novo componente quando ficar claro que não existe ponto central reutilizável no projeto.
 - Se precisar criar ponto central novo, usar nome coeso, específico e orientado ao domínio.
 

--- a/.claude/agents/review-agent.md
+++ b/.claude/agents/review-agent.md
@@ -1,6 +1,6 @@
 ---
 name: review-agent
-description: Faz revisão técnica final da mudança, verificando aderência aos padrões do projeto, reutilização, centralização, riscos e lacunas.
+description: Faz revisão técnica final da mudança, verificando aderência aos padrões do projeto, ao escopo consolidado pelo spec-agent, reutilização, centralização, riscos e lacunas.
 tools: Read, Glob, Grep
 skills:
   - technical-review
@@ -11,7 +11,18 @@ Você é responsável pela revisão técnica final.
 
 # Objetivo
 
-Revisar a mudança como gate de qualidade antes da conclusão, identificando problemas concretos de padronização, reutilização, duplicação, arquitetura e testes.
+Revisar a mudança como gate de qualidade antes da conclusão, identificando problemas concretos de padronização, reutilização, duplicação, arquitetura, testes e aderência ao escopo.
+
+# Relação com o spec-agent
+
+A revisão deve considerar como referência o contexto consolidado pelo `spec-agent`.
+
+Regras:
+- validar se a implementação respeitou o escopo da change
+- validar se os critérios de aceite foram cobertos
+- sinalizar quando a implementação extrapolar o entendimento consolidado da mudança
+- não usar MCP como fonte principal de validação quando houver arquivos versionados da change
+- priorizar proposal, tasks e spec local como fonte de verdade
 
 # Regras obrigatórias
 
@@ -26,6 +37,7 @@ Revisar a mudança como gate de qualidade antes da conclusão, identificando pro
   - testes faltantes
   - risco de regressão
   - quebra de contrato
+  - alterações fora do escopo
 - Não sugerir mudanças cosméticas sem ganho claro.
 - Dar feedback curto, direto e acionável.
 

--- a/.claude/agents/spec-agent.md
+++ b/.claude/agents/spec-agent.md
@@ -1,6 +1,6 @@
 ---
 name: spec-agent
-description: Analisa OpenSpec, proposal, tasks e change plan para transformar a mudança em backlog técnico implementável.
+description: Analisa OpenSpec, proposal, tasks e change plan para transformar a mudança em backlog técnico implementável, usando MCP de spec como apoio quando disponível.
 tools: Read, Glob, Grep
 skills:
   - openspec-explore
@@ -11,24 +11,56 @@ effort: high
 
 Você é responsável por entendimento de escopo e planejamento técnico.
 
-Objetivo:
-- Ler primeiro a spec, proposal, tasks e change plan relevantes.
-- Converter requisitos em backlog técnico executável.
-- Identificar dependências, ambiguidades, riscos e critérios de aceite.
+# Objetivo
 
-Regras obrigatórias:
+Ler a change e transformar seu conteúdo em backlog técnico executável, identificando requisitos, critérios de aceite, dependências, riscos e ordem de execução.
+
+# Uso do MCP de spec
+
+Quando o MCP de spec estiver disponível no projeto, ele deve ser tratado como fonte complementar de apoio ao entendimento da change.
+
+O MCP pode ajudar em tarefas como:
+- localizar contexto adicional de spec
+- enriquecer leitura de proposal e tasks
+- ajudar na interpretação da intenção da mudança
+- apoiar entendimento de fluxo spec-driven
+
+Regras para uso do MCP:
+- usar o MCP como apoio, não como dependência exclusiva
+- priorizar sempre os artefatos oficiais da change no repositório
+- não ignorar proposal, tasks e spec local por causa do MCP
+- se houver divergência entre o MCP e os arquivos da change, considerar os arquivos versionados como fonte principal
+- se o MCP não estiver disponível, continuar o fluxo normalmente sem bloquear a análise
+
+# Regras obrigatórias
+
 - Nunca partir para implementação antes de esclarecer o que precisa ser entregue.
-- Sempre separar:
-    1. requisitos funcionais
-    2. regras de negócio
-    3. restrições técnicas
-    4. critérios de aceite
+- Sempre ler primeiro os artefatos da change.
+- Sempre separar claramente:
+  1. requisitos funcionais
+  2. regras de negócio
+  3. restrições técnicas
+  4. critérios de aceite
 - Quando houver conflito entre código atual e spec, apontar explicitamente.
+- Quando houver conflito entre MCP e arquivos versionados da change, priorizar os arquivos versionados.
 - Preferir saída objetiva, orientada à execução.
+- Não inventar escopo novo.
+- Não assumir requisitos que não estejam sustentados por spec, proposal, tasks ou contexto técnico claro.
 
-Saída esperada:
+# Fluxo esperado
+
+1. Localizar a change ativa.
+2. Ler proposal, tasks, spec delta e demais arquivos associados.
+3. Usar MCP de spec como apoio complementar, quando disponível.
+4. Consolidar entendimento da mudança.
+5. Produzir backlog técnico implementável.
+6. Apontar riscos, lacunas e ordem sugerida de execução.
+
+# Saída esperada
+
 1. Resumo da mudança
 2. Critérios de aceite
 3. Backlog técnico
-4. Riscos/lacunas
+4. Riscos e lacunas
 5. Ordem sugerida de execução
+6. Observação se o MCP foi usado como apoio ou não

--- a/.claude/agents/unit-test-agent.md
+++ b/.claude/agents/unit-test-agent.md
@@ -1,6 +1,6 @@
 ---
 name: unit-test-agent
-description: Cria e ajusta testes unitários C# com xUnit e Shouldly seguindo o padrão oficial do projeto.
+description: Cria e ajusta testes unitários C# com xUnit e Shouldly, cobrindo o comportamento da change com base no contexto consolidado pelo spec-agent.
 tools: Read, Edit, MultiEdit, Write, Glob, Grep, Bash
 skills:
   - write-dotnet-unit-tests
@@ -9,26 +9,44 @@ effort: high
 
 Você é responsável por testes unitários.
 
-Objetivo:
-- Cobrir o comportamento alterado com testes claros e objetivos.
-- Proteger regras de negócio, fluxos de erro e edge cases.
+# Objetivo
 
-Regras obrigatórias:
+Cobrir o comportamento alterado pela change com testes claros, objetivos e alinhados ao escopo definido.
+
+# Relação com o spec-agent
+
+Os testes devem ser derivados do comportamento esperado consolidado pelo `spec-agent`.
+
+Regras:
+- cobrir o comportamento realmente esperado da change
+- priorizar critérios de aceite e regras explícitas da mudança
+- não criar cenários fora do escopo sem justificativa clara
+- usar proposal, tasks e spec local como base principal
+
+# Regras obrigatórias
+
 - Usar xUnit.
 - Usar Shouldly.
-- Nomear testes no padrão Given_<context>_Should_<expected_behavior>.
+- Nomear testes no padrão `Given_<context>_Should_<expected_behavior>`.
 - Sempre usar Arrange / Act / Assert.
 - Cada teste deve cobrir um único comportamento.
 - Priorizar:
-    - regra de negócio
-    - cenários mínimos
-    - edge cases
-    - nulos
-    - fluxos de erro
+  - regra de negócio
+  - cenários mínimos
+  - edge cases
+  - nulos
+  - fluxos de erro
 - Não criar testes redundantes ou cosméticos.
 - Validar o comportamento final e não só detalhes internos sem valor.
 
-Saída esperada:
-1. Testes criados/ajustados
+# Regras obrigatórias de escopo
+
+- Não criar testes para comportamentos não alterados sem motivo claro.
+- Não ampliar a cobertura para fora da change apenas por conveniência.
+- Se houver dúvida sobre o comportamento esperado, priorizar o entendimento consolidado da change e os arquivos versionados.
+
+# Saída esperada
+
+1. Testes criados ou ajustados
 2. Cenários cobertos
 3. Lacunas restantes

--- a/.claude/agents/xml-test-agent.md
+++ b/.claude/agents/xml-test-agent.md
@@ -1,6 +1,6 @@
 ---
 name: xml-test-agent
-description: Cria e ajusta testes de serialização XML e aderência a schema quando a mudança impacta XML.
+description: Cria e ajusta testes de serialização XML e aderência a schema quando a change impacta XML, com base no contexto consolidado pelo spec-agent.
 tools: Read, Edit, MultiEdit, Write, Glob, Grep, Bash
 skills:
   - write-dotnet-xml-serializer-tests
@@ -9,21 +9,39 @@ effort: high
 
 Você é responsável por testes de XML e schema.
 
-Objetivo:
-- Garantir que o XML gerado esteja estruturalmente correto.
-- Validar nós, ordem, obrigatoriedades e aderência ao schema quando aplicável.
+# Objetivo
 
-Regras obrigatórias:
+Garantir que o XML gerado esteja estruturalmente correto e alinhado ao impacto real da change.
+
+# Relação com o spec-agent
+
+Os testes XML devem refletir o impacto da change conforme consolidado pelo `spec-agent`.
+
+Regras:
+- validar apenas os comportamentos XML realmente afetados pela change
+- usar spec, tasks e critérios de aceite como base principal
+- não ampliar a cobertura para fora do escopo sem necessidade clara
+- quando houver dúvida entre MCP e arquivos versionados, priorizar os arquivos versionados
+
+# Regras obrigatórias
+
 - Criar testes apenas quando a mudança impactar serialização, builders XML, DTOs de saída XML ou schemas.
 - Validar:
-    - presença/ausência de nós
-    - valores relevantes
-    - comportamento condicional
-    - estrutura final do XML
-- Quando aplicável, validar contra XSD/schema.
-- Priorizar regras do domínio e do schema, não só snapshots frágeis.
+  - presença e ausência de nós
+  - valores relevantes
+  - comportamento condicional
+  - estrutura final do XML
+- Quando aplicável, validar contra XSD ou schema.
+- Priorizar regras do domínio e do schema, não apenas snapshots frágeis.
 
-Saída esperada:
-1. Testes XML criados/ajustados
+# Regras obrigatórias de escopo
+
+- Não criar cobertura XML sem relação clara com a change.
+- Não expandir o escopo de schema/testing além do necessário para validar a mudança.
+- Se a change não impactar XML, registrar explicitamente que esta etapa não se aplica.
+
+# Saída esperada
+
+1. Testes XML criados ou ajustados
 2. Cenários cobertos
 3. Lacunas de validação restantes

--- a/.claude/commands/opsx/apply-orchestrate.md
+++ b/.claude/commands/opsx/apply-orchestrate.md
@@ -1,5 +1,5 @@
 ---
-description: Executa uma change aprovada com orquestração técnica por agentes, priorizando reutilização, centralização, testes e revisão final
+description: Executa uma change aprovada com orquestração técnica por agentes, priorizando reutilização, centralização, testes, uso complementar de MCP de spec e revisão final
 argument-hint: <change-name>
 ---
 
@@ -34,6 +34,17 @@ Não trate a execução como um fluxo genérico de um único agente.
 
 A execução deve ser conduzida como uma orquestração entre agentes especializados, cada um responsável por uma etapa específica do trabalho.
 
+# Uso do MCP de spec
+
+Quando o MCP de spec estiver disponível no projeto, ele deve ser usado como apoio complementar principalmente na etapa de entendimento da change.
+
+Regras:
+- o MCP não substitui os arquivos oficiais da change
+- proposal, tasks e spec local continuam sendo a fonte principal
+- o MCP deve ser usado para enriquecer contexto, não para sobrescrever a change
+- se houver divergência entre o MCP e os arquivos versionados da change, priorizar os arquivos versionados
+- a execução não deve falhar apenas porque o MCP não está disponível
+
 # Fluxo obrigatório
 
 ## Etapa 1 — Entendimento da mudança
@@ -42,6 +53,7 @@ Use o `spec-agent` para:
 
 - localizar a change informada
 - ler proposal, tasks, spec e contexto relacionado
+- usar o MCP de spec como apoio complementar, quando disponível
 - resumir o objetivo da mudança
 - listar critérios de aceite
 - identificar riscos, dependências e lacunas
@@ -54,6 +66,7 @@ O resultado dessa etapa deve deixar claro:
 3. quais arquivos ou áreas tendem a ser impactados
 4. quais testes serão necessários
 5. se existe impacto em XML/schema/serialização
+6. se o MCP foi usado como apoio ou não
 
 Antes de seguir para implementação, consolide esse entendimento.
 
@@ -163,12 +176,12 @@ Use o `unit-test-agent` para criar ou ajustar os testes unitários necessários.
 - Sempre usar Arrange / Act / Assert.
 - Cada teste deve cobrir um único comportamento.
 - Priorizar:
-    - regras de negócio
-    - cenários mínimos
-    - edge cases
-    - fluxos de erro
-    - nulos
-    - condicionais relevantes
+  - regras de negócio
+  - cenários mínimos
+  - edge cases
+  - fluxos de erro
+  - nulos
+  - condicionais relevantes
 
 Os testes devem cobrir o comportamento alterado, e não apenas detalhes internos sem valor.
 
@@ -286,6 +299,7 @@ Ao final da execução, apresente um resumo estruturado contendo:
 - objetivo
 - critérios de aceite
 - escopo aplicado
+- uso ou não do MCP como apoio
 
 ## 2. Implementação realizada
 - arquivos alterados

--- a/.claude/commands/opsx/apply.md
+++ b/.claude/commands/opsx/apply.md
@@ -1,0 +1,152 @@
+---
+name: "OPSX: Apply"
+description: Implement tasks from an OpenSpec change (Experimental)
+category: Workflow
+tags: [workflow, artifacts, experimental]
+---
+
+Implement tasks from an OpenSpec change.
+
+**Input**: Optionally specify a change name (e.g., `/opsx:apply add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - Context file paths (varies by schema)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using `/opsx:continue`
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+4. **Read context files**
+
+   Read the files listed in `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! You can archive this change with `/opsx:archive`.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.claude/commands/opsx/archive.md
+++ b/.claude/commands/opsx/archive.md
@@ -1,0 +1,157 @@
+---
+name: "OPSX: Archive"
+description: Archive a completed change in the experimental workflow
+category: Workflow
+tags: [workflow, archive, experimental]
+---
+
+Archive a completed change in the experimental workflow.
+
+**Input**: Optionally specify a change name after `/opsx:archive` (e.g., `/opsx:archive add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Check for delta specs at `openspec/changes/<name>/specs/`. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create the archive directory if it doesn't exist:
+   ```bash
+   mkdir -p openspec/changes/archive
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move the change directory to archive
+
+   ```bash
+   mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Spec sync status (synced / sync skipped / no delta specs)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success (No Delta Specs)**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** No delta specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success With Warnings**
+
+```
+## Archive Complete (with warnings)
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** Sync skipped (user chose to skip)
+
+**Warnings:**
+- Archived with 2 incomplete artifacts
+- Archived with 3 incomplete tasks
+- Delta spec sync was skipped (user chose to skip)
+
+Review the archive if this was not intentional.
+```
+
+**Output On Error (Archive Exists)**
+
+```
+## Archive Failed
+
+**Change:** <change-name>
+**Target:** openspec/changes/archive/YYYY-MM-DD-<name>/
+
+Target archive directory already exists.
+
+**Options:**
+1. Rename the existing archive
+2. Delete the existing archive if it's a duplicate
+3. Wait until a different date to archive
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use the Skill tool to invoke `openspec-sync-specs` (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.claude/commands/opsx/explore.md
+++ b/.claude/commands/opsx/explore.md
@@ -1,0 +1,173 @@
+---
+name: "OPSX: Explore"
+description: "Enter explore mode - think through ideas, investigate problems, clarify requirements"
+category: Workflow
+tags: [workflow, explore, experimental, thinking]
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+**Input**: The argument after `/opsx:explore` is whatever the user wants to think about. Could be:
+- A vague idea: "real-time collaboration"
+- A specific problem: "the auth system is getting unwieldy"
+- A change name: "add-dark-mode" (to explore in context of that change)
+- A comparison: "postgres vs sqlite for this"
+- Nothing (just enter explore mode)
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│   ┌────────┐         ┌────────┐        │
+│   │ State  │────────▶│ State  │        │
+│   │   A    │         │   B    │        │
+│   └────────┘         └────────┘        │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+If the user mentioned a specific change name, read its artifacts for context.
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Read existing artifacts for context**
+   - `openspec/changes/<name>/proposal.md`
+   - `openspec/changes/<name>/design.md`
+   - `openspec/changes/<name>/tasks.md`
+   - etc.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+   | Insight Type | Where to Capture |
+   |--------------|------------------|
+   | New requirement discovered | `specs/<capability>/spec.md` |
+   | Requirement changed | `specs/<capability>/spec.md` |
+   | Design decision made | `design.md` |
+   | Scope changed | `proposal.md` |
+   | New work identified | `tasks.md` |
+   | Assumption invalidated | Relevant artifact |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When things crystallize, you might offer a summary - but it's optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.claude/commands/opsx/opsx-archive-and-commit.md
+++ b/.claude/commands/opsx/opsx-archive-and-commit.md
@@ -1,0 +1,193 @@
+---
+description: Arquiva uma change aprovada e finalizada, sincroniza a spec e gera commit semântico automaticamente
+argument-hint: <change-name>
+---
+
+# Objetivo
+
+Arquivar uma change já concluída, garantindo que:
+
+- a spec consolidada esteja atualizada
+- a pasta da change seja movida para archive
+- o estado final do repositório seja revisado
+- um commit semântico seja gerado automaticamente com base nas alterações realizadas
+
+# Entrada obrigatória
+
+Receba o nome da change em `$ARGUMENTS`.
+
+Se o nome da change não for informado, interrompa e peça explicitamente o identificador correto da change.
+
+# Regras gerais
+
+- Só executar este fluxo para changes já implementadas e revisadas.
+- Não arquivar se a change ainda tiver lacunas relevantes de implementação, testes ou revisão.
+- Não criar commit vazio.
+- O commit deve refletir apenas o estado final da change arquivada.
+- A mensagem deve seguir o padrão de Conventional Commits.
+- O commit deve resumir corretamente a natureza principal da mudança.
+
+# Fluxo obrigatório
+
+## Etapa 1 — Validar a existência da change
+
+Localize a change informada.
+
+Verifique se existem os artefatos esperados da change, como por exemplo:
+- proposal
+- tasks
+- spec deltas
+- arquivos associados à implementação
+
+Se a change não existir ou estiver inconsistente, interrompa e explique o problema.
+
+---
+
+## Etapa 2 — Verificar se a change está pronta para archive
+
+Antes de arquivar, revisar o estado da mudança.
+
+Confirmar que:
+- a implementação foi concluída
+- os testes necessários foram criados ou ajustados
+- a revisão técnica final foi feita
+- não existem pendências explícitas da própria change
+- não existem alterações sabidamente fora do escopo da change
+
+Se houver indício forte de mudança incompleta, interrompa e explique o motivo.
+
+---
+
+## Etapa 3 — Executar o archive
+
+Executar o fluxo de archive da change.
+
+Objetivo desta etapa:
+- consolidar a spec final
+- mover a change para o local de archive
+- deixar o repositório no estado final pós-change
+
+Após o archive, validar:
+- se a pasta da change saiu do estado ativo
+- se os arquivos de spec ficaram consistentes
+- se o estado final do repositório faz sentido
+
+Se o archive falhar, interrompa e não tente commitar.
+
+---
+
+## Etapa 4 — Inspecionar o diff final
+
+Após o archive, analisar os arquivos alterados no repositório.
+
+Classificar as mudanças em grupos, por exemplo:
+- código de produção
+- testes
+- spec/documentação
+- infraestrutura/automação
+- archive da change
+
+Usar essa leitura para decidir o tipo principal do commit.
+
+---
+
+## Etapa 5 — Determinar o tipo semântico do commit
+
+Escolher o tipo principal do commit com base no impacto predominante da change.
+
+Usar preferencialmente um destes tipos:
+
+- `feat` → quando a change adiciona funcionalidade nova relevante
+- `fix` → quando corrige defeito ou comportamento incorreto
+- `refactor` → quando melhora estrutura interna sem alterar comportamento esperado
+- `test` → quando a principal mudança é cobertura de testes
+- `docs` → quando a principal mudança é documentação/spec
+- `chore` → quando a principal mudança é manutenção técnica sem valor funcional direto
+
+Regras:
+- escolher um único tipo principal
+- priorizar o efeito dominante da mudança
+- não escolher `chore` se houve entrega funcional clara
+- não escolher `docs` se houve implementação real de código relevante
+
+---
+
+## Etapa 6 — Gerar a mensagem do commit
+
+Gerar uma mensagem de commit curta, clara e semântica no padrão:
+
+`tipo: descrição`
+
+Exemplos válidos:
+- `feat: add spec assistant MCP integration`
+- `fix: correct XML serialization for IBS CBS blocks`
+- `refactor: centralize cep and phone normalization`
+- `test: add serializer coverage for conditional XML nodes`
+- `docs: archive spec change for multi agent orchestration`
+
+Regras da mensagem:
+- usar inglês, salvo se o projeto adotar outro padrão explícito
+- ser curta e objetiva
+- descrever o efeito principal da mudança
+- evitar mensagens vagas como `update`, `changes`, `adjustments`
+- evitar múltiplas intenções no mesmo título
+
+Se fizer sentido, pode adicionar corpo explicativo curto no commit, com:
+- resumo das áreas afetadas
+- observação de archive da change
+- contexto resumido da implementação
+
+---
+
+## Etapa 7 — Preparar o commit
+
+Antes de commitar:
+- revisar os arquivos modificados
+- garantir que o estado final está coerente
+- garantir que não existem alterações acidentais e irrelevantes
+- garantir que o commit não está vazio
+
+Se houver arquivos suspeitos, sinalizar isso antes do commit.
+
+---
+
+## Etapa 8 — Executar o commit
+
+Realizar o commit usando a mensagem gerada.
+
+Se houver corpo complementar, incluir no commit.
+
+Não criar mais de um commit nesta etapa.
+
+Se o commit falhar, explicar claramente o erro.
+
+---
+
+# Forma de resposta esperada
+
+Ao final, apresentar um resumo estruturado contendo:
+
+## 1. Change arquivada
+- nome da change
+- confirmação do archive
+
+## 2. Arquivos e áreas impactadas
+- visão resumida do que entrou no estado final
+
+## 3. Tipo semântico escolhido
+- tipo do commit
+- justificativa curta
+
+## 4. Commit gerado
+- mensagem final do commit
+
+## 5. Observações finais
+- riscos, pendências ou ausência delas
+
+# Critério de conclusão
+
+Só considerar concluído quando:
+- a change tiver sido arquivada com sucesso
+- o estado final do repositório tiver sido inspecionado
+- o commit semântico tiver sido gerado
+- o `git commit` tiver sido executado com sucesso

--- a/.claude/commands/opsx/propose.md
+++ b/.claude/commands/opsx/propose.md
@@ -1,0 +1,106 @@
+---
+name: "OPSX: Propose"
+description: Propose a new change - create it and generate all artifacts in one step
+category: Workflow
+tags: [workflow, artifacts, experimental]
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Input**: The argument after `/opsx:propose` is the change name (kebab-case), OR a description of what the user wants to build.
+
+**Steps**
+
+1. **If no input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change at `openspec/changes/<name>/` with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `outputPath`: Where to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` to start implementing."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.claude/lsp/README.md
+++ b/.claude/lsp/README.md
@@ -1,0 +1,33 @@
+# LSP da POC
+
+## Objetivo
+Documentar os LSPs que podem melhorar a qualidade do fluxo da POC.
+
+## Estratégia
+Nesta POC, a pasta `lsp/` começa como documentação e planejamento.
+A ativação prática pode ser feita depois, de forma incremental.
+
+## Prioridades
+1. C#
+2. TypeScript
+
+## Benefícios esperados
+- melhor navegação entre símbolos
+- melhor entendimento de referências
+- melhor leitura de código entre arquivos
+- apoio à implementação
+- apoio à revisão técnica
+- refatorações mais seguras
+- melhor suporte à criação de testes
+
+## Regra da POC
+Não tentar ativar tudo de uma vez.
+Começar pelas linguagens que mais impactam o fluxo real do estudo.
+
+## Ordem sugerida
+1. C#
+2. TypeScript
+
+## Observação
+A pasta `lsp/` organiza intenção, estratégia e contexto.
+A configuração concreta pode ser adicionada depois.

--- a/.claude/lsp/csharp.md
+++ b/.claude/lsp/csharp.md
@@ -1,0 +1,27 @@
+# LSP C#
+
+## Objetivo
+Melhorar a qualidade da navegação e análise de código C# na POC.
+
+## Onde ajuda mais
+- implementação em código de produção
+- revisão técnica
+- criação de testes unitários
+- navegação entre classes, interfaces e referências
+- refatorações com mais segurança
+
+## Casos de uso na POC
+- localizar rapidamente implementações existentes
+- evitar criação de métodos duplicados
+- encontrar pontos centrais de reutilização
+- entender impacto de mudanças em builders, services e testes
+- apoiar o `implementation-agent`
+- apoiar o `review-agent`
+
+## Benefícios esperados
+- menos alteração baseada só em busca textual
+- mais precisão em referências e uso real de símbolos
+- melhor identificação de acoplamento e duplicação
+
+## Prioridade
+Alta

--- a/.claude/lsp/typescript.md
+++ b/.claude/lsp/typescript.md
@@ -1,0 +1,28 @@
+# LSP TypeScript / Angular
+
+## Objetivo
+Melhorar a análise de código front-end em TypeScript e Angular na POC.
+
+## Onde ajuda mais
+- navegação entre componentes, services e models
+- entendimento de referências
+- revisão de mudanças
+- análise de impacto entre arquivos
+- refatorações com mais segurança
+
+## Casos de uso na POC
+- localizar uso de componentes e serviços
+- identificar duplicação de lógica
+- entender dependências entre arquivos
+- apoiar mudanças guiadas por spec no front-end
+
+## Benefícios esperados
+- melhor leitura estrutural do projeto Angular
+- menos alterações cegas por grep
+- mais segurança ao ajustar componentes e serviços
+
+## Prioridade
+Alta
+
+## Observação
+É o segundo LSP prioritário da POC, junto com C#.

--- a/.claude/mcp/README.md
+++ b/.claude/mcp/README.md
@@ -1,0 +1,48 @@
+# MCP da POC
+
+## Objetivo
+Centralizar a documentação dos MCPs usados ou planejados na POC de estudo sobre uso de IA.
+
+## Servidor MCP atual
+- Nome: `spec-assistant`
+
+## Registro
+O servidor MCP é registrado na raiz do projeto em `.mcp.json`.
+
+## Implementação
+O código do servidor MCP atual fica em:
+
+`ia/mcp-spec-server`
+
+## Execução esperada
+O Claude Code deve conseguir iniciar o servidor a partir de:
+
+`node ./ia/mcp-spec-server/dist/index.js`
+
+## Requisitos
+- O diretório `dist/` deve existir.
+- O build do servidor deve estar atualizado.
+- O workspace deve ser aberto na raiz do projeto para que o caminho relativo funcione corretamente.
+
+## Papel na POC
+O MCP atual existe para apoiar o fluxo spec-driven, especialmente em:
+- leitura e interpretação de specs
+- apoio ao entendimento de proposal e tasks
+- apoio ao fluxo de aplicação de change
+- possível enriquecimento do `spec-agent`
+
+## Estratégia da POC
+Nesta POC:
+- `.claude/mcp/` documenta os MCPs
+- `ia/` contém o código real dos servidores MCP
+- `.mcp.json` faz o vínculo entre Claude Code e os servidores
+
+## Próximos MCPs possíveis
+- GitHub
+- Azure DevOps
+- documentação externa
+- observabilidade
+
+## Regra de simplicidade
+Não adicionar MCP novo sem um caso de uso claro no fluxo da POC.
+Priorizar primeiro o MCP de spec já existente.

--- a/.claude/mcp/docs.md
+++ b/.claude/mcp/docs.md
@@ -1,0 +1,23 @@
+# MCP Docs
+
+## Objetivo
+Documentar o possível uso de MCP para integração com documentação externa ao código.
+
+## Casos de uso
+- leitura de specs fora do repositório
+- leitura de documentação funcional
+- leitura de documentos de apoio à proposal
+- apoio ao entendimento de regras de negócio
+
+## Onde ajuda mais
+- `spec-agent`
+- `implementation-agent`
+
+## Prioridade
+Alta, se a documentação principal estiver fora do repositório.
+
+## Quando faz sentido
+Quando a POC depender de documentação externa para guiar a implementação.
+
+## Observação
+É um dos MCPs mais úteis caso a spec não esteja toda dentro do projeto.

--- a/.claude/mcp/github.md
+++ b/.claude/mcp/github.md
@@ -1,0 +1,24 @@
+# MCP GitHub
+
+## Objetivo
+Documentar o possível uso de MCP para integração com GitHub na POC.
+
+## Casos de uso
+- leitura de issues
+- leitura de pull requests
+- entendimento de contexto externo ao código
+- apoio ao fluxo spec-driven
+- correlação entre proposta e implementação
+
+## Onde ajuda mais
+- `spec-agent`
+- `review-agent`
+
+## Prioridade
+Média
+
+## Quando faz sentido
+Quando a POC precisar buscar contexto fora do repositório local.
+
+## Observação
+Não é prioridade inicial se a POC estiver focada no código e no MCP de spec local.

--- a/ia/mcp-spec-server/package.json
+++ b/ia/mcp-spec-server/package.json
@@ -7,6 +7,10 @@
     "build": "tsc -p tsconfig.json",
     "dev": "tsx src/index.ts"
   },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0",
+    "zod": "^3.23.8"
+  },
   "devDependencies": {
     "@types/node": "^22.0.0",
     "tsx": "^4.19.0",

--- a/ia/mcp-spec-server/src/index.ts
+++ b/ia/mcp-spec-server/src/index.ts
@@ -1,119 +1,349 @@
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import path from "node:path";
+import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
 
-type ToolRequest = {
-  tool: string;
-  args?: Record<string, unknown>;
-};
+const server = new McpServer({
+  name: "spec-assistant",
+  version: "1.2.0"
+});
 
-function readSpecFile(fileName: string): string {
-  const specPath = path.join(process.cwd(), "openspec", fileName);
-  return readFileSync(specPath, "utf-8");
+function projectRoot(): string {
+  return process.cwd();
 }
 
-function getSpec(featureId: string) {
-  const spec = readSpecFile("nfse-serializer.spec.md");
-  return { featureId, spec };
+function changeRoot(changeName: string): string {
+  return path.join(projectRoot(), "openspec", "changes", changeName);
 }
 
-function listAcceptanceCriteria(featureId: string) {
-  const criteria = readSpecFile("acceptance-criteria.md");
-  return { featureId, criteria };
+function ensureExists(targetPath: string, label: string): void {
+  if (!existsSync(targetPath)) {
+    throw new Error(`${label} not found: ${targetPath}`);
+  }
 }
 
-function suggestCommitMessage(featureId: string, changesSummary: string) {
+function readUtf8File(targetPath: string): string {
+  ensureExists(targetPath, "File");
+  return readFileSync(targetPath, "utf-8");
+}
+
+function safeReadIfExists(targetPath: string): string | null {
+  if (!existsSync(targetPath)) {
+    return null;
+  }
+
+  return readFileSync(targetPath, "utf-8");
+}
+
+function listFilesRecursively(baseDir: string): string[] {
+  if (!existsSync(baseDir)) {
+    return [];
+  }
+
+  const entries = readdirSync(baseDir);
+  const files: string[] = [];
+
+  for (const entry of entries) {
+    const fullPath = path.join(baseDir, entry);
+    const relativePath = path.relative(projectRoot(), fullPath);
+    const entryStat = statSync(fullPath);
+
+    if (entryStat.isDirectory()) {
+      files.push(...listFilesRecursively(fullPath));
+      continue;
+    }
+
+    files.push(relativePath);
+  }
+
+  return files.sort();
+}
+
+function getChangeArtifacts(changeName: string) {
+  const root = changeRoot(changeName);
+
+  ensureExists(root, "Change directory");
+
   return {
-    featureId,
-    conventionalCommit: `feat(${featureId.toLowerCase()}): ${changesSummary}`
+    root,
+    proposalPath: path.join(root, "proposal.md"),
+    tasksPath: path.join(root, "tasks.md"),
+    specsDir: path.join(root, "specs")
   };
 }
 
-function generateBddTests(featureId: string, targetLanguage: string) {
+function formatTextResult(title: string, payload: unknown) {
   return {
-    featureId,
-    targetLanguage,
-    testingConventions: {
-      framework: "xUnit",
-      assertions: "Shouldly",
-      forbidAssertions: ["Assert.Equal", "Assert.NotNull", "Assert.Null", "Assert.StartsWith", "Assert.Contains"],
-      namingPattern: "Given_<context>_Should_<expected_behavior>",
-      structure: ["Arrange", "Act", "Assert"]
-    },
-    requiredScenarios: [
-      "documento mínimo válido",
-      "documento completo com todos os blocos opcionais",
-      "tomador com CPF",
-      "tomador com CNPJ",
-      "endereço nacional",
-      "endereço estrangeiro",
-      "totais aproximados por valor",
-      "totais aproximados por percentual",
-      "sem totais aproximados"
-    ],
-    examples: [
+    content: [
       {
-        testName: "Given_MinimalValidDocument_Should_GenerateValidDpsStructure"
-      },
-      {
-        testName: "Given_CompleteDocument_Should_ContainAllOptionalBlocks"
+        type: "text" as const,
+        text: `# ${title}\n\n${JSON.stringify(payload, null, 2)}`
       }
     ]
   };
 }
 
-function reviewCodeAgainstSpec(featureId: string, changedFiles: string[]) {
-  return {
-    featureId,
-    changedFiles,
-    checklist: [
-      "Há modelo canônico intermediário?",
-      "Regras de negócio estão separadas da montagem XML?",
-      "O endpoint da API está alinhado à spec?",
-      "Há testes BDD + 3A cobrindo o fluxo mínimo?"
-    ]
-  };
-}
+function toSpecAssistantUri(kind: string, changeName: string, extraPath?: string): string {
+  const encodedChange = encodeURIComponent(changeName);
 
-function handle(request: ToolRequest) {
-  switch (request.tool) {
-    case "get_spec":
-      return getSpec(String(request.args?.featureId ?? "FEATURE-NFSE-SERIALIZER-001"));
-    case "list_acceptance_criteria":
-      return listAcceptanceCriteria(String(request.args?.featureId ?? "FEATURE-NFSE-SERIALIZER-001"));
-    case "suggest_commit_message":
-      return suggestCommitMessage(
-        String(request.args?.featureId ?? "FEATURE-NFSE-SERIALIZER-001"),
-        String(request.args?.changesSummary ?? "evolve nfse poc")
-      );
-    case "generate_bdd_tests":
-      return generateBddTests(
-        String(request.args?.featureId ?? "FEATURE-NFSE-SERIALIZER-001"),
-        String(request.args?.targetLanguage ?? "csharp")
-      );
-    case "review_code_against_spec":
-      return reviewCodeAgainstSpec(
-        String(request.args?.featureId ?? "FEATURE-NFSE-SERIALIZER-001"),
-        Array.isArray(request.args?.changedFiles) ? request.args!.changedFiles as string[] : []
-      );
-    default:
-      return { error: `Unknown tool: ${request.tool}` };
+  if (!extraPath) {
+    return `spec-assistant://${kind}/${encodedChange}`;
   }
+
+  const normalized = extraPath.replace(/\\/g, "/");
+  return `spec-assistant://${kind}/${encodedChange}/${normalized}`;
 }
 
-process.stdin.setEncoding("utf-8");
-let buffer = "";
-process.stdin.on("data", chunk => {
-  buffer += chunk;
-  const lines = buffer.split("\n");
-  buffer = lines.pop() ?? "";
-  for (const line of lines) {
-    if (!line.trim()) continue;
-    try {
-      const request = JSON.parse(line) as ToolRequest;
-      const result = handle(request);
-      process.stdout.write(JSON.stringify(result) + "\n");
-    } catch (error) {
-      process.stdout.write(JSON.stringify({ error: String(error) }) + "\n");
+function firstParam(value: string | string[]): string {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function joinParam(value: string | string[]): string {
+  return Array.isArray(value) ? value.join("/") : value;
+}
+
+/**
+ * Resources
+ */
+
+server.registerResource(
+  "change-proposal",
+  new ResourceTemplate("spec-assistant://proposal/{changeName}", { list: undefined }),
+  {
+    title: "OpenSpec Change Proposal",
+    description: "Conteúdo do proposal.md de uma change do OpenSpec"
+  },
+  async (uri, { changeName }) => {
+    const resolvedChangeName = firstParam(changeName);
+    const { proposalPath } = getChangeArtifacts(resolvedChangeName);
+
+    return {
+      contents: [
+        {
+          uri: uri.href,
+          text: readUtf8File(proposalPath),
+          mimeType: "text/markdown"
+        }
+      ]
+    };
+  }
+);
+
+server.registerResource(
+    "change-tasks",
+    new ResourceTemplate("spec-assistant://tasks/{changeName}", { list: undefined }),
+    {
+      title: "OpenSpec Change Tasks",
+      description: "Conteúdo do tasks.md de uma change do OpenSpec"
+    },
+    async (uri, { changeName }) => {
+      const resolvedChangeName = firstParam(changeName);
+      const { tasksPath } = getChangeArtifacts(resolvedChangeName);
+
+      return {
+        contents: [
+          {
+            uri: uri.href,
+            text: readUtf8File(tasksPath),
+            mimeType: "text/markdown"
+          }
+        ]
+      };
     }
+);
+
+server.registerResource(
+  "change-spec-file",
+  new ResourceTemplate("spec-assistant://spec-file/{changeName}/{filePath*}", { list: undefined }),
+  {
+    title: "OpenSpec Change Spec File",
+    description: "Lê um arquivo específico dentro de openspec/changes/<change>/specs"
+  },
+  async (uri, { changeName, filePath }) => {
+    const resolvedChangeName = firstParam(changeName);
+    const resolvedFilePath = joinParam(filePath);
+    const { specsDir } = getChangeArtifacts(resolvedChangeName);
+    const targetPath = path.join(specsDir, resolvedFilePath);
+
+    return {
+      contents: [
+        {
+          uri: uri.href,
+          text: readUtf8File(targetPath),
+          mimeType: "text/markdown"
+        }
+      ]
+    };
   }
+);
+
+/**
+ * Tools
+ */
+
+server.registerTool(
+    "get_change_summary",
+    {
+      title: "Get Change Summary",
+      description: "Lê proposal, tasks e arquivos de spec de uma change do OpenSpec.",
+      inputSchema: {
+        changeName: z.string().min(1)
+      }
+    },
+    async ({ changeName }) => {
+      const { proposalPath, tasksPath, specsDir } = getChangeArtifacts(changeName);
+
+      const proposal = safeReadIfExists(proposalPath);
+      const tasks = safeReadIfExists(tasksPath);
+      const specFiles = listFilesRecursively(specsDir);
+
+      return formatTextResult("Change Summary", {
+        changeName,
+        proposalResource: toSpecAssistantUri("proposal", changeName),
+        tasksResource: toSpecAssistantUri("tasks", changeName),
+        proposalPath: path.relative(projectRoot(), proposalPath),
+        tasksPath: path.relative(projectRoot(), tasksPath),
+        specFiles,
+        specResources: specFiles.map((relativePath) => {
+          const relativeToSpecs = relativePath
+              .replace(/^openspec[\\/]+changes[\\/]+/, "")
+              .split(/[\\/]/)
+              .slice(3)
+              .join("/");
+
+          return toSpecAssistantUri("spec-file", changeName, relativeToSpecs);
+        }),
+        proposal,
+        tasks
+      });
+    }
+);
+
+server.registerTool(
+    "get_change_proposal",
+    {
+      title: "Get Change Proposal",
+      description: "Lê o proposal.md de uma change.",
+      inputSchema: {
+        changeName: z.string().min(1)
+      }
+    },
+    async ({ changeName }) => {
+      const { proposalPath } = getChangeArtifacts(changeName);
+
+      return formatTextResult("Change Proposal", {
+        changeName,
+        resourceUri: toSpecAssistantUri("proposal", changeName),
+        proposalPath: path.relative(projectRoot(), proposalPath),
+        proposal: readUtf8File(proposalPath)
+      });
+    }
+);
+
+server.registerTool(
+    "get_change_tasks",
+    {
+      title: "Get Change Tasks",
+      description: "Lê o tasks.md de uma change.",
+      inputSchema: {
+        changeName: z.string().min(1)
+      }
+    },
+    async ({ changeName }) => {
+      const { tasksPath } = getChangeArtifacts(changeName);
+
+      return formatTextResult("Change Tasks", {
+        changeName,
+        resourceUri: toSpecAssistantUri("tasks", changeName),
+        tasksPath: path.relative(projectRoot(), tasksPath),
+        tasks: readUtf8File(tasksPath)
+      });
+    }
+);
+
+server.registerTool(
+    "list_change_spec_files",
+    {
+      title: "List Change Spec Files",
+      description: "Lista os arquivos de spec delta dentro de openspec/changes/<change>/specs.",
+      inputSchema: {
+        changeName: z.string().min(1)
+      }
+    },
+    async ({ changeName }) => {
+      const { specsDir } = getChangeArtifacts(changeName);
+      const files = listFilesRecursively(specsDir);
+
+      return formatTextResult("Change Spec Files", {
+        changeName,
+        specsDir: path.relative(projectRoot(), specsDir),
+        files,
+        resources: files.map((relativePath) => {
+          const relativeToSpecs = relativePath
+              .replace(/^openspec[\\/]+changes[\\/]+/, "")
+              .split(/[\\/]/)
+              .slice(3)
+              .join("/");
+
+          return toSpecAssistantUri("spec-file", changeName, relativeToSpecs);
+        })
+      });
+    }
+);
+
+server.registerTool(
+    "suggest_change_commit_message",
+    {
+      title: "Suggest Change Commit Message",
+      description: "Sugere commit semântico com base na change.",
+      inputSchema: {
+        changeName: z.string().min(1),
+        commitType: z.enum(["feat", "fix", "refactor", "test", "docs", "chore"]).default("feat"),
+        summary: z.string().min(1).default("apply approved change")
+      }
+    },
+    async ({ changeName, commitType, summary }) => {
+      return formatTextResult("Suggested Commit Message", {
+        changeName,
+        conventionalCommit: `${commitType}: ${summary} (${changeName})`
+      });
+    }
+);
+
+server.registerTool(
+    "review_change_against_spec",
+    {
+      title: "Review Change Against Spec",
+      description: "Gera checklist de revisão técnica alinhado à change.",
+      inputSchema: {
+        changeName: z.string().min(1),
+        changedFiles: z.array(z.string()).default([])
+      }
+    },
+    async ({ changeName, changedFiles }) => {
+      return formatTextResult("Review Checklist", {
+        changeName,
+        changedFiles,
+        checklist: [
+          "A implementação respeitou o proposal e o tasks.md?",
+          "Os critérios de aceite foram cobertos?",
+          "O escopo permaneceu dentro da change?",
+          "Houve reutilização antes de criar novos métodos auxiliares?",
+          "Foi evitada duplicação de lógica para CEP, telefone, documento, datas e normalizações?",
+          "Os testes unitários cobrem o comportamento alterado?",
+          "Se houve XML, os testes cobrem estrutura, nós condicionais e schema quando aplicável?"
+        ]
+      });
+    }
+);
+
+async function main(): Promise<void> {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+main().catch((error) => {
+  console.error("[spec-assistant] Failed to start MCP server:", error);
+  process.exit(1);
 });


### PR DESCRIPTION
Configure MCP servers and LSP integrations for the project:
- Add MCP docs: spec-assistant, github, firecrawl
- Add LSP docs: csharp-lsp, typescript-lsp
- Expand mcp-spec-server with new tools and capabilities
- Add opsx:archive-and-commit command
- Update agent definitions with MCP/LSP awareness
- Update apply-orchestrate with MCP/LSP integration points