### PR TITLE
feat(engine): prove build-time generation with gissonline schema

### DIFF
--- a/openspec/changes/archive/2026-03-21-prove-build-time-generation-with-gissonline-schema/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-21-prove-build-time-generation-with-gissonline-schema/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-21

--- a/openspec/changes/archive/2026-03-21-prove-build-time-generation-with-gissonline-schema/design.md
+++ b/openspec/changes/archive/2026-03-21-prove-build-time-generation-with-gissonline-schema/design.md
@@ -1,0 +1,39 @@
+# Design: prove-build-time-generation-with-gissonline-schema
+
+## Context
+
+GISSOnline usa namespace `http://www.giss.com.br/enviar-lote-rps-envio-v2_04.xsd` com imports de `tipos-v2_04.xsd` e `xmldsig-core-schema20020212.xsd`. Estrutura: `EnviarLoteRpsEnvio` → `LoteRps` (tipo `tcLoteRps`). É o terceiro provider após nacional e ABRASF.
+
+A engine (`SchemaGenerationRunner`) já demonstrou funcionar com nacional e ABRASF. Esta change é essencialmente um exercício de onboarding: customizar rules, executar runner, validar output.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Base-rules.json mínimo do GISSOnline
+- Runner executa e produz artefatos
+- Testes de geração + validação XML
+- Confirmar padrão de onboarding com 3 providers
+
+**Non-Goals:**
+- Alterar código da engine
+- Gerar serializer funcional completo
+- Resolver regras de negócio profundas do GISSOnline
+
+## Decisions
+
+### D-01 — Reutilizar 100% da infraestrutura existente
+
+**Decisão**: Nenhuma alteração em código de produção. Apenas dados (rules JSON) e testes.
+**Razão**: O ponto da change é provar que o onboarding é dados-only.
+
+## Estrutura
+
+```
+providers/gissonline/
+  xsd/                              ← já existe
+  rules/base-rules.json             ← customizar
+  generated/                        ← gitignored, gerado em build
+
+tests/.../SchemaEngine/
+  GissonlineSchemaGenerationTests.cs
+```

--- a/openspec/changes/archive/2026-03-21-prove-build-time-generation-with-gissonline-schema/proposal.md
+++ b/openspec/changes/archive/2026-03-21-prove-build-time-generation-with-gissonline-schema/proposal.md
@@ -1,0 +1,31 @@
+# Change: prove-build-time-generation-with-gissonline-schema
+
+## Why
+
+A engine já foi validada com nacional e ABRASF. GISSOnline é o terceiro provider e utiliza um namespace e estrutura de schema próprios (`http://www.giss.com.br/enviar-lote-rps-envio-v2_04.xsd`), com imports entre schemas distintos do padrão nacional. Provar que a engine funciona com GISSOnline valida a genericidade e confirma o padrão de onboarding por provider.
+
+Os XSDs do GISSOnline já existem em `providers/gissonline/xsd/` (3 arquivos). O `base-rules.json` é uma cópia do ABRASF e precisa ser customizado.
+
+## What Changes
+
+- Customizar `providers/gissonline/rules/base-rules.json` com dados do GISSOnline (namespace, provider name).
+- Executar `SchemaGenerationRunner` sobre o provider GISSOnline.
+- Validar que a engine produz SchemaModel, records e builder skeleton.
+- Criar testes que executam o runner para GISSOnline e validam saída.
+- Criar testes de validação XML contra os XSDs do GISSOnline (choice, sequence, required).
+
+## Capabilities
+
+### New Capabilities
+
+_(nenhuma)_
+
+### Modified Capabilities
+
+- `nfse-xsd-generation-engine`: Terceiro provider validado (GISSOnline). Confirma que o padrão de onboarding funciona com 3 providers distintos.
+
+## Impact
+
+- **Providers**: `base-rules.json` customizado para GISSOnline. Artefatos gerados em `providers/gissonline/generated/` (gitignored).
+- **Tests**: Testes de geração e validação XML do GISSOnline.
+- **Zero alteração** em código de produção, serializer manual, endpoint ou engine.

--- a/openspec/changes/archive/2026-03-21-prove-build-time-generation-with-gissonline-schema/specs/nfse-xsd-generation-engine/spec.md
+++ b/openspec/changes/archive/2026-03-21-prove-build-time-generation-with-gissonline-schema/specs/nfse-xsd-generation-engine/spec.md
@@ -1,0 +1,15 @@
+# Delta Spec: nfse-xsd-generation-engine
+
+## ADDED Requirements
+
+### Requirement: GISSOnline provider onboarding
+
+O `SchemaGenerationRunner` MUST ser capaz de processar o provider GISSOnline sem alterações no código da engine, confirmando que o onboarding é data-driven.
+
+#### Scenario: Analyze GISSOnline schema
+- **WHEN** o runner é executado para o provider "gissonline"
+- **THEN** produz SchemaDocument com complexTypes do GISSOnline e artefatos em `providers/gissonline/generated/`
+
+#### Scenario: Validate generated XML against GISSOnline XSD
+- **WHEN** XML mínimo é construído de acordo com o schema do GISSOnline
+- **THEN** o XML é válido contra os XSDs do provider

--- a/openspec/changes/archive/2026-03-21-prove-build-time-generation-with-gissonline-schema/tasks.md
+++ b/openspec/changes/archive/2026-03-21-prove-build-time-generation-with-gissonline-schema/tasks.md
@@ -1,0 +1,27 @@
+# Tasks: prove-build-time-generation-with-gissonline-schema
+
+## 1. Customizar base-rules.json do GISSOnline
+
+- [x] 1.1 Reescrever `providers/gissonline/rules/base-rules.json` com provider="gissonline", namespace correto, e apenas complementos que o XSD não expressa
+
+## 2. Executar geração GISSOnline
+
+- [x] 2.1 Executar `SchemaGenerationRunner` para o provider GISSOnline via teste
+- [x] 2.2 Verificar que records foram gerados para os complexTypes do GISSOnline
+- [x] 2.3 Verificar que o builder skeleton foi gerado
+- [x] 2.4 Verificar que o schema-report.md foi gerado
+
+## 3. Testes
+
+- [x] 3.1 Criar `GissonlineSchemaGenerationTests` em `tests/.../SchemaEngine/`
+- [x] 3.2 Teste: Given_GissonlineXsd_Should_ProduceSchemaDocumentWithGissonlineComplexTypes
+- [x] 3.3 Teste: Given_GissonlineProvider_Should_GenerateArtifactsViaRunner
+- [x] 3.4 Teste: Given_GissonlineXsd_Should_ValidateMinimalXmlAgainstSchema
+- [x] 3.5 Teste de regressão: Given_NacionalProvider_Should_StillGenerateCorrectly
+- [x] 3.6 Teste de regressão: Given_AbrasfProvider_Should_StillGenerateCorrectly
+
+## 4. Build e validação
+
+- [x] 4.1 `dotnet build` sem erros
+- [x] 4.2 `dotnet test` com todos os testes passando
+- [x] 4.3 Verificar que `providers/gissonline/generated/` está no `.gitignore` (já coberto por `providers/*/generated/`)

--- a/openspec/specs/nfse-xsd-generation-engine/spec.md
+++ b/openspec/specs/nfse-xsd-generation-engine/spec.md
@@ -127,3 +127,11 @@ O XML produzido a partir da estrutura do schema MUST ser validável contra os XS
 #### Scenario: Choice, sequence, required and restriction validation
 - **WHEN** XML é validado contra o XSD do provider
 - **THEN** choice com múltiplos elementos falha, sequence com ordem errada falha, required ausente falha, valor fora do pattern falha
+
+### Requirement: GISSOnline provider onboarding
+
+O `SchemaGenerationRunner` MUST processar o provider GISSOnline sem alterações no código da engine, confirmando onboarding data-driven. Validação XML contra XSD do GISSOnline deve cobrir minimal valid, required missing e choice groups.
+
+#### Scenario: GISSOnline onboarding
+- **WHEN** o runner é executado para "gissonline" com XSDs e base-rules.json mínimo
+- **THEN** artefatos são gerados e XML mínimo válido passa validação contra os XSDs do GISSOnline

--- a/providers/gissonline/rules/base-rules.json
+++ b/providers/gissonline/rules/base-rules.json
@@ -1,0 +1,17 @@
+{
+  "provider": "gissonline",
+  "version": "2.04",
+  "description": "Regras complementares do GISSOnline — a maioria das regras é inferida do XSD",
+  "constants": {
+    "namespace": "http://www.giss.com.br/enviar-lote-rps-envio-v2_04.xsd",
+    "tiposNamespace": "http://www.giss.com.br/tipos-v2_04.xsd"
+  },
+  "defaults": {
+  },
+  "enums": {
+  },
+  "formatting": {
+  },
+  "conditionals": {
+  }
+}

--- a/providers/gissonline/xsd/enviar-lote-rps-envio-v2_04.xsd
+++ b/providers/gissonline/xsd/enviar-lote-rps-envio-v2_04.xsd
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	targetNamespace="http://www.giss.com.br/enviar-lote-rps-envio-v2_04.xsd"
+	xmlns="http://www.giss.com.br/enviar-lote-rps-envio-v2_04.xsd"
+	xmlns:dsig="http://www.w3.org/2000/09/xmldsig#" xmlns:tipos="http://www.giss.com.br/tipos-v2_04.xsd"
+	attributeFormDefault="unqualified" elementFormDefault="qualified">
+
+	<xsd:import namespace="http://www.w3.org/2000/09/xmldsig#"
+		schemaLocation="xmldsig-core-schema20020212.xsd" />
+
+	<xsd:import namespace="http://www.giss.com.br/tipos-v2_04.xsd"
+		schemaLocation="tipos-v2_04.xsd" />
+
+	<xsd:element name="EnviarLoteRpsEnvio">
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element name="LoteRps" type="tipos:tcLoteRps"
+					minOccurs="1" maxOccurs="1" />
+				<xsd:element ref="dsig:Signature" minOccurs="0"
+					maxOccurs="1" />
+			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
+
+</xsd:schema>
+

--- a/providers/gissonline/xsd/tipos-v2_04.xsd
+++ b/providers/gissonline/xsd/tipos-v2_04.xsd
@@ -1,0 +1,3059 @@
+<?xml version="1.0"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	targetNamespace="http://www.giss.com.br/tipos-v2_04.xsd" xmlns="http://www.giss.com.br/tipos-v2_04.xsd"
+	xmlns:dsig="http://www.w3.org/2000/09/xmldsig#" attributeFormDefault="unqualified"
+	elementFormDefault="qualified">
+
+	<xsd:import namespace="http://www.w3.org/2000/09/xmldsig#"
+		schemaLocation="xmldsig-core-schema20020212.xsd" />
+
+	<xsd:simpleType name="tsNumeroNfse">
+		<xsd:restriction base="xsd:nonNegativeInteger">
+			<xsd:totalDigits value="15" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="tsCodigoVerificacao">
+		<xsd:restriction base="xsd:string">
+			<xsd:maxLength value="9" />
+			<xsd:minLength value="1" />
+			<xsd:whiteSpace value="collapse" />
+			<xsd:pattern value="[a-zA-Z0-9]{1,9}" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="tsNif">
+		<xsd:restriction base="xsd:string">
+			<xsd:maxLength value="40" />
+			<xsd:minLength value="1" />
+			<xsd:whiteSpace value="collapse" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="tsStatusRps">
+		<xsd:annotation>
+			<xsd:documentation>Situacao do RPS (
+				1 - Normal;
+				2 - Cancelado)
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:byte">
+			<xsd:pattern value="1|2" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="tsStatusNfse">
+		<xsd:annotation>
+			<xsd:documentation>Situacao da NFS-e (
+				1 - Normal;
+				2 - Cancelada)
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:byte">
+			<xsd:pattern value="1|2" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="tsExigibilidadeISS">
+		<xsd:annotation>
+			<xsd:documentation>Exigibilidade do ISS da NFS-e (
+				1 - Exigivel;
+				2 - Nao incidencia;
+				3 - Isencao;
+				4 - Exportacao;
+				5 - Imunidade;
+				6 - Exigibilidade Suspensa por Decisao Judicial;
+				7 - Exigibilidade Suspensa por Processo Administrativo)
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:byte">
+			<xsd:pattern value="1|2|3|4|5|6|7" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="tsIdentifNaoExigibilidade">
+		<xsd:restriction base="xsd:string">
+			<xsd:maxLength value="4" />
+			<xsd:minLength value="1" />
+			<xsd:whiteSpace value="collapse" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="tsNumeroProcesso">
+		<xsd:restriction base="xsd:string">
+			<xsd:maxLength value="30" />
+			<xsd:minLength value="1" />
+			<xsd:whiteSpace value="collapse" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="tsRegimeEspecialTributacao">
+		<xsd:annotation>
+			<xsd:documentation>Exigibilidade do ISS da NFS-e (
+				1 - Microempresa Municipal;
+				2 - Estimativa;
+				3 - Sociedade de Profissionais;
+				4 - Cooperativa;
+				5 - Microempresario Individual (MEI);
+				6 - Microempresa ou Empresa de Pequeno Porte (ME EPP))
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:byte">
+			<xsd:pattern value="1|2|3|4|5|6" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="tsSimNao">
+		<xsd:annotation>
+			<xsd:documentation>Sim ou Nao (
+				1 - Sim;
+				2 - Nao)
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:byte">
+			<xsd:pattern value="1|2" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="tsResponsavelRetencao">
+		<xsd:annotation>
+			<xsd:documentation>Responsavel pela retencao do ISSQN (
+				1 - Tomador;
+				2 - Intermediario)
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:byte">
+			<xsd:pattern value="1|2" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="tsPagina">
+		<xsd:restriction base="xsd:nonNegativeInteger">
+			<xsd:minInclusive value="1" />
+			<xsd:maxInclusive value="999999" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="tsNumeroRps">
+		<xsd:restriction base="xsd:nonNegativeInteger">
+			<xsd:totalDigits value="15" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="tsSerieRps">
+		<xsd:restriction base="xsd:string">
+			<xsd:maxLength value="5" />
+			<xsd:minLength value="1" />
+			<xsd:whiteSpace value="collapse" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="tsTipoRps">
+		<xsd:annotation>
+			<xsd:documentation>Tipo do RPS (
+				1 - RPS;
+				2 - RPS Nota Fiscal Conjugada (Mista);
+				3 - Cupom)
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:byte">
+			<xsd:pattern value="1|2|3" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="tsOutrasInformacoes">
+		<xsd:restriction base="xsd:string">
+			<xsd:maxLength value="510" />
+			<xsd:minLength value="1" />
+			<xsd:whiteSpace value="collapse" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="tsValor">
+		<xsd:restriction base="xsd:decimal">
+			<xsd:totalDigits value="15" />
+			<xsd:fractionDigits value="2" fixed="true" />
+			<xsd:minInclusive value="0" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="tsItemListaServico">
+		<xsd:annotation>
+			<xsd:documentation>Subitem do serviço prestado conforme LC 116/2003
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:string">
+			<xsd:whiteSpace value="preserve" />
+			<xsd:enumeration value="01.01" />
+			<xsd:enumeration value="01.02" />
+			<xsd:enumeration value="01.03" />
+			<xsd:enumeration value="01.04" />
+			<xsd:enumeration value="01.05" />
+			<xsd:enumeration value="01.06" />
+			<xsd:enumeration value="01.07" />
+			<xsd:enumeration value="01.08" />
+			<xsd:enumeration value="01.09" />
+			<xsd:enumeration value="02.01" />
+			<xsd:enumeration value="03.02" />
+			<xsd:enumeration value="03.03" />
+			<xsd:enumeration value="03.04" />
+			<xsd:enumeration value="03.05" />
+			<xsd:enumeration value="04.01" />
+			<xsd:enumeration value="04.02" />
+			<xsd:enumeration value="04.03" />
+			<xsd:enumeration value="04.04" />
+			<xsd:enumeration value="04.05" />
+			<xsd:enumeration value="04.06" />
+			<xsd:enumeration value="04.07" />
+			<xsd:enumeration value="04.08" />
+			<xsd:enumeration value="04.09" />
+			<xsd:enumeration value="04.10" />
+			<xsd:enumeration value="04.11" />
+			<xsd:enumeration value="04.12" />
+			<xsd:enumeration value="04.13" />
+			<xsd:enumeration value="04.14" />
+			<xsd:enumeration value="04.15" />
+			<xsd:enumeration value="04.16" />
+			<xsd:enumeration value="04.17" />
+			<xsd:enumeration value="04.18" />
+			<xsd:enumeration value="04.19" />
+			<xsd:enumeration value="04.20" />
+			<xsd:enumeration value="04.21" />
+			<xsd:enumeration value="04.22" />
+			<xsd:enumeration value="04.23" />
+			<xsd:enumeration value="05.01" />
+			<xsd:enumeration value="05.02" />
+			<xsd:enumeration value="05.03" />
+			<xsd:enumeration value="05.04" />
+			<xsd:enumeration value="05.05" />
+			<xsd:enumeration value="05.06" />
+			<xsd:enumeration value="05.07" />
+			<xsd:enumeration value="05.08" />
+			<xsd:enumeration value="05.09" />
+			<xsd:enumeration value="06.01" />
+			<xsd:enumeration value="06.02" />
+			<xsd:enumeration value="06.03" />
+			<xsd:enumeration value="06.04" />
+			<xsd:enumeration value="06.05" />
+			<xsd:enumeration value="06.06" />
+			<xsd:enumeration value="07.01" />
+			<xsd:enumeration value="07.02" />
+			<xsd:enumeration value="07.03" />
+			<xsd:enumeration value="07.04" />
+			<xsd:enumeration value="07.05" />
+			<xsd:enumeration value="07.06" />
+			<xsd:enumeration value="07.07" />
+			<xsd:enumeration value="07.08" />
+			<xsd:enumeration value="07.09" />
+			<xsd:enumeration value="07.10" />
+			<xsd:enumeration value="07.11" />
+			<xsd:enumeration value="07.12" />
+			<xsd:enumeration value="07.13" />
+			<xsd:enumeration value="07.16" />
+			<xsd:enumeration value="07.17" />
+			<xsd:enumeration value="07.18" />
+			<xsd:enumeration value="07.19" />
+			<xsd:enumeration value="07.20" />
+			<xsd:enumeration value="07.21" />
+			<xsd:enumeration value="07.22" />
+			<xsd:enumeration value="08.01" />
+			<xsd:enumeration value="08.02" />
+			<xsd:enumeration value="09.01" />
+			<xsd:enumeration value="09.02" />
+			<xsd:enumeration value="09.03" />
+			<xsd:enumeration value="10.01" />
+			<xsd:enumeration value="10.02" />
+			<xsd:enumeration value="10.03" />
+			<xsd:enumeration value="10.04" />
+			<xsd:enumeration value="10.05" />
+			<xsd:enumeration value="10.06" />
+			<xsd:enumeration value="10.07" />
+			<xsd:enumeration value="10.08" />
+			<xsd:enumeration value="10.09" />
+			<xsd:enumeration value="10.10" />
+			<xsd:enumeration value="11.01" />
+			<xsd:enumeration value="11.02" />
+			<xsd:enumeration value="11.03" />
+			<xsd:enumeration value="11.04" />
+			<xsd:enumeration value="11.05" />
+			<xsd:enumeration value="12.01" />
+			<xsd:enumeration value="12.02" />
+			<xsd:enumeration value="12.03" />
+			<xsd:enumeration value="12.04" />
+			<xsd:enumeration value="12.05" />
+			<xsd:enumeration value="12.06" />
+			<xsd:enumeration value="12.07" />
+			<xsd:enumeration value="12.08" />
+			<xsd:enumeration value="12.09" />
+			<xsd:enumeration value="12.10" />
+			<xsd:enumeration value="12.11" />
+			<xsd:enumeration value="12.12" />
+			<xsd:enumeration value="12.13" />
+			<xsd:enumeration value="12.14" />
+			<xsd:enumeration value="12.15" />
+			<xsd:enumeration value="12.16" />
+			<xsd:enumeration value="12.17" />
+			<xsd:enumeration value="13.02" />
+			<xsd:enumeration value="13.03" />
+			<xsd:enumeration value="13.04" />
+			<xsd:enumeration value="13.05" />
+			<xsd:enumeration value="14.01" />
+			<xsd:enumeration value="14.02" />
+			<xsd:enumeration value="14.03" />
+			<xsd:enumeration value="14.04" />
+			<xsd:enumeration value="14.05" />
+			<xsd:enumeration value="14.06" />
+			<xsd:enumeration value="14.07" />
+			<xsd:enumeration value="14.08" />
+			<xsd:enumeration value="14.09" />
+			<xsd:enumeration value="14.10" />
+			<xsd:enumeration value="14.11" />
+			<xsd:enumeration value="14.12" />
+			<xsd:enumeration value="14.13" />
+			<xsd:enumeration value="14.14" />
+			<xsd:enumeration value="15.01" />
+			<xsd:enumeration value="15.02" />
+			<xsd:enumeration value="15.03" />
+			<xsd:enumeration value="15.04" />
+			<xsd:enumeration value="15.05" />
+			<xsd:enumeration value="15.06" />
+			<xsd:enumeration value="15.07" />
+			<xsd:enumeration value="15.08" />
+			<xsd:enumeration value="15.09" />
+			<xsd:enumeration value="15.10" />
+			<xsd:enumeration value="15.11" />
+			<xsd:enumeration value="15.12" />
+			<xsd:enumeration value="15.13" />
+			<xsd:enumeration value="15.14" />
+			<xsd:enumeration value="15.15" />
+			<xsd:enumeration value="15.16" />
+			<xsd:enumeration value="15.17" />
+			<xsd:enumeration value="15.18" />
+			<xsd:enumeration value="16.01" />
+			<xsd:enumeration value="16.02" />
+			<xsd:enumeration value="17.01" />
+			<xsd:enumeration value="17.02" />
+			<xsd:enumeration value="17.03" />
+			<xsd:enumeration value="17.04" />
+			<xsd:enumeration value="17.05" />
+			<xsd:enumeration value="17.06" />
+			<xsd:enumeration value="17.08" />
+			<xsd:enumeration value="17.09" />
+			<xsd:enumeration value="17.10" />
+			<xsd:enumeration value="17.11" />
+			<xsd:enumeration value="17.12" />
+			<xsd:enumeration value="17.13" />
+			<xsd:enumeration value="17.14" />
+			<xsd:enumeration value="17.15" />
+			<xsd:enumeration value="17.16" />
+			<xsd:enumeration value="17.17" />
+			<xsd:enumeration value="17.18" />
+			<xsd:enumeration value="17.19" />
+			<xsd:enumeration value="17.20" />
+			<xsd:enumeration value="17.21" />
+			<xsd:enumeration value="17.22" />
+			<xsd:enumeration value="17.23" />
+			<xsd:enumeration value="17.24" />
+			<xsd:enumeration value="17.25" />
+			<xsd:enumeration value="18.01" />
+			<xsd:enumeration value="19.01" />
+			<xsd:enumeration value="20.01" />
+			<xsd:enumeration value="20.02" />
+			<xsd:enumeration value="20.03" />
+			<xsd:enumeration value="21.01" />
+			<xsd:enumeration value="22.01" />
+			<xsd:enumeration value="23.01" />
+			<xsd:enumeration value="24.01" />
+			<xsd:enumeration value="25.01" />
+			<xsd:enumeration value="25.02" />
+			<xsd:enumeration value="25.03" />
+			<xsd:enumeration value="25.04" />
+			<xsd:enumeration value="26.01" />
+			<xsd:enumeration value="27.01" />
+			<xsd:enumeration value="28.01" />
+			<xsd:enumeration value="29.01" />
+			<xsd:enumeration value="30.01" />
+			<xsd:enumeration value="31.01" />
+			<xsd:enumeration value="32.01" />
+			<xsd:enumeration value="33.01" />
+			<xsd:enumeration value="34.01" />
+			<xsd:enumeration value="35.01" />
+			<xsd:enumeration value="36.01" />
+			<xsd:enumeration value="37.01" />
+			<xsd:enumeration value="38.01" />
+			<xsd:enumeration value="39.01" />
+			<xsd:enumeration value="40.01" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="tsCodigoCnae">
+		<xsd:restriction base="xsd:int">
+			<xsd:totalDigits value="7" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="tsCodigoTributacao">
+		<xsd:restriction base="xsd:string">
+			<xsd:maxLength value="20" />
+			<xsd:minLength value="1" />
+			<xsd:whiteSpace value="collapse" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="tsDescricaoCodigoTributacaoMunicipio">
+		<xsd:restriction base="xsd:string">
+			<xsd:maxLength value="1000" />
+			<xsd:minLength value="1" />
+			<xsd:whiteSpace value="collapse" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="tsCodigoNbs">
+		<xsd:restriction base="xsd:string">
+			<xsd:maxLength value="9" />
+			<xsd:minLength value="1" />
+			<xsd:whiteSpace value="collapse" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="tsAliquota">
+		<xsd:restriction base="xsd:decimal">
+			<xsd:totalDigits value="5"/>
+			<xsd:fractionDigits value="4"/>
+			<xsd:minInclusive value="0"/>
+			<xsd:whiteSpace value="collapse"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="tsDiscriminacao">
+		<xsd:restriction base="xsd:string">
+			<xsd:maxLength value="2000" />
+			<xsd:minLength value="1" />
+			<xsd:whiteSpace value="collapse" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="tsCodigoMunicipioIbge">
+		<xsd:restriction base="xsd:int">
+			<xsd:totalDigits value="7" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="tsInscricaoMunicipal">
+		<xsd:restriction base="xsd:string">
+			<xsd:maxLength value="15" />
+			<xsd:minLength value="1" />
+			<xsd:whiteSpace value="collapse" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="tsRazaoSocial">
+		<xsd:restriction base="xsd:string">
+			<xsd:maxLength value="150" />
+			<xsd:minLength value="1" />
+			<xsd:whiteSpace value="collapse" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="tsNomeFantasia">
+		<xsd:restriction base="xsd:string">
+			<xsd:maxLength value="60" />
+			<xsd:minLength value="1" />
+			<xsd:whiteSpace value="collapse" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="tsCnpj">
+		<xsd:restriction base="xsd:string">
+			<xsd:length value="14" fixed="true" />
+			<xsd:whiteSpace value="collapse" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="tsEndereco">
+		<xsd:restriction base="xsd:string">
+			<xsd:maxLength value="255" />
+			<xsd:minLength value="1" />
+			<xsd:whiteSpace value="collapse" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="tsNumeroEndereco">
+		<xsd:restriction base="xsd:string">
+			<xsd:maxLength value="60" />
+			<xsd:minLength value="1" />
+			<xsd:whiteSpace value="collapse" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="tsComplementoEndereco">
+		<xsd:restriction base="xsd:string">
+			<xsd:maxLength value="60" />
+			<xsd:minLength value="1" />
+			<xsd:whiteSpace value="collapse" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="tsBairro">
+		<xsd:restriction base="xsd:string">
+			<xsd:maxLength value="60" />
+			<xsd:minLength value="1" />
+			<xsd:whiteSpace value="collapse" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="tsUf">
+		<xsd:annotation>
+			<xsd:documentation>UF (
+				AC - Acre;
+				AL - Alagoas;
+				AM - Amazonas;
+				AP - Amapa;
+				BA - Bahia;
+				CE - Ceara;
+				DF - Distrito Federal;
+				ES - Espirito Santo;
+				GO - Goias;
+				MA - Maranhao;
+				MG - Minas Gerais;
+				MS - Mato Grosso do Sul;
+				MT - Mato Grosso;
+				PA - Para;
+				PB - Paraiba;
+				PE - Pernambuco;
+				PI - Piaui;
+				PR - Parana;
+				RJ - Rio de Janeiro;
+				RN - Rio Grande do Norte;
+				RO - Rondonia;
+				RR - Roraima;
+				RS - Rio Grande do Sul;
+				SC - Santa Catarina;
+				SE - Sergipe;
+				SP - Sao Paulo;
+				TO - Tocantins)
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:string">
+			<xsd:length value="2" fixed="true" />
+			<xsd:whiteSpace value="collapse" />
+			<xsd:enumeration value="AC" />
+			<xsd:enumeration value="AL" />
+			<xsd:enumeration value="AM" />
+			<xsd:enumeration value="AP" />
+			<xsd:enumeration value="BA" />
+			<xsd:enumeration value="CE" />
+			<xsd:enumeration value="DF" />
+			<xsd:enumeration value="ES" />
+			<xsd:enumeration value="GO" />
+			<xsd:enumeration value="MA" />
+			<xsd:enumeration value="MG" />
+			<xsd:enumeration value="MS" />
+			<xsd:enumeration value="MT" />
+			<xsd:enumeration value="PA" />
+			<xsd:enumeration value="PB" />
+			<xsd:enumeration value="PE" />
+			<xsd:enumeration value="PI" />
+			<xsd:enumeration value="PR" />
+			<xsd:enumeration value="RJ" />
+			<xsd:enumeration value="RN" />
+			<xsd:enumeration value="RO" />
+			<xsd:enumeration value="RR" />
+			<xsd:enumeration value="RS" />
+			<xsd:enumeration value="SC" />
+			<xsd:enumeration value="SE" />
+			<xsd:enumeration value="SP" />
+			<xsd:enumeration value="TO" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="tsCodigoPaisIbge">
+		<xsd:restriction base="xsd:string">
+			<xsd:length value="4" />
+			<xsd:whiteSpace value="collapse" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="tsCep">
+		<xsd:restriction base="xsd:string">
+			<xsd:maxLength value="8" />
+			<xsd:whiteSpace value="preserve" />
+			<xsd:pattern value="[0-9]{8}" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="tsEmail">
+		<xsd:restriction base="xsd:string">
+			<xsd:maxLength value="80" />
+			<xsd:minLength value="1" />
+			<xsd:whiteSpace value="collapse" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="tsTelefone">
+		<xsd:restriction base="xsd:string">
+			<xsd:maxLength value="20" />
+			<xsd:minLength value="1" />
+			<xsd:whiteSpace value="collapse" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="tsCpf">
+		<xsd:restriction base="xsd:string">
+			<xsd:length value="11" fixed="true" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="tsCodigoObra">
+		<xsd:restriction base="xsd:string">
+			<xsd:maxLength value="30" />
+			<xsd:minLength value="1" />
+			<xsd:whiteSpace value="collapse" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="tsArt">
+		<xsd:restriction base="xsd:string">
+			<xsd:maxLength value="30" />
+			<xsd:minLength value="1" />
+			<xsd:whiteSpace value="collapse" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="tsIdentificacaoEvento">
+		<xsd:restriction base="xsd:string">
+			<xsd:maxLength value="30" />
+			<xsd:minLength value="1" />
+			<xsd:whiteSpace value="collapse" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="tsDescricaoEvento">
+		<xsd:restriction base="xsd:string">
+			<xsd:maxLength value="255" />
+			<xsd:minLength value="1" />
+			<xsd:whiteSpace value="collapse" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="tsInformacoesComplementares">
+		<xsd:restriction base="xsd:string">
+			<xsd:maxLength value="2000" />
+			<xsd:minLength value="1" />
+			<xsd:whiteSpace value="collapse" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="tsNumeroLote">
+		<xsd:restriction base="xsd:nonNegativeInteger">
+			<xsd:totalDigits value="15" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="tsNumeroProtocolo">
+		<xsd:restriction base="xsd:string">
+			<xsd:maxLength value="50" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="tsSituacaoLoteRps">
+		<xsd:annotation>
+			<xsd:documentation>TSituacao do lote de RPS(
+				1 – Não Recebido;
+				2 – Não Processado;
+				3 – Processado com Erro;
+				4 – Processado com Sucesso)
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:byte">
+			<xsd:pattern value="1|2|3|4" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="tsQuantidadeRps">
+		<xsd:restriction base="xsd:int">
+			<xsd:totalDigits value="4" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="tsCodigoMensagemAlerta">
+		<xsd:restriction base="xsd:string">
+			<xsd:maxLength value="4" />
+			<xsd:minLength value="1" />
+			<xsd:whiteSpace value="collapse" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="tsDescricaoMensagemAlerta">
+		<xsd:restriction base="xsd:string">
+			<xsd:maxLength value="200" />
+			<xsd:minLength value="1" />
+			<xsd:whiteSpace value="collapse" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="tsCodigoCancelamentoNfse">
+		<xsd:annotation>
+			<xsd:documentation>Codigo do Cancelamento da NFS-e (
+				1 - Erro na emissao;
+				2 - Servico nao prestado;
+				3 - Erro de assinatura;
+				4 - Duplicidade da nota;
+				5 - Erro de processamento)
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:byte">
+			<xsd:pattern value="1|2|3|4|5" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="tsIdTag">
+		<xsd:restriction base="xsd:string">
+			<xsd:maxLength value="255" />
+			<xsd:minLength value="1" />
+			<xsd:whiteSpace value="collapse" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="tsVersao">
+		<xsd:restriction base="xsd:token">
+			<xsd:pattern value="[1-9]{1}[0-9]{0,1}\.[0-9]{2}" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="tsTipoDeducao">
+		<xsd:annotation>
+			<xsd:documentation>Codigo de identificação do tipo da deducao (
+				1 – Materiais;
+				2 – Subempreitada de mão de obra;
+				3 – Serviços;
+				4 – Produção externa;
+				5 – Alimentação e bebidas/frigobar;
+				6 – Reembolso de despesas;
+				7 – Repasse consorciado;
+				8 – Repasse plano de saúde;
+				99 – Outras deduções)
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:byte">
+			<xsd:pattern value="1|2|3|4|5|6|7|8|99" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="tsDescricaoDeducao">
+		<xsd:restriction base="xsd:string">
+			<xsd:maxLength value="150" />
+			<xsd:minLength value="1" />
+			<xsd:whiteSpace value="collapse" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="tsNumeroNfe">
+		<xsd:restriction base="xsd:nonNegativeInteger">
+			<xsd:totalDigits value="9" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="tsChaveAcessoNfe">
+		<xsd:restriction base="xsd:nonNegativeInteger">
+			<xsd:totalDigits value="44" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="tsIdentificacaoDocumento">
+		<xsd:restriction base="xsd:string">
+			<xsd:maxLength value="255" />
+			<xsd:minLength value="1" />
+			<xsd:whiteSpace value="collapse" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="tsEnderecoCompletoExterior">
+		<xsd:restriction base="xsd:string">
+			<xsd:maxLength value="255" />
+			<xsd:minLength value="1" />
+			<xsd:whiteSpace value="collapse" />
+		</xsd:restriction>
+		
+	</xsd:simpleType>
+		<xsd:simpleType name="TSCodigoEndPostal">
+		<xsd:annotation>
+			<xsd:documentation>Código de enderaçamento postal</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:string">
+			<xsd:whiteSpace value="preserve"/>
+			<xsd:minLength value="1"/>
+			<xsd:maxLength value="11"/>
+		</xsd:restriction>		
+	</xsd:simpleType>
+	
+		<xsd:simpleType name="TSCidade">
+		<xsd:annotation>
+			<xsd:documentation>Cidade</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:string">
+			<xsd:whiteSpace value="preserve"/>
+			<xsd:minLength value="1"/>
+			<xsd:maxLength value="60"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+		<xsd:simpleType name="TSEstadoProvRegiao">
+		<xsd:annotation>
+			<xsd:documentation>Estado, província ou região</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:string">
+			<xsd:whiteSpace value="preserve"/>
+			<xsd:minLength value="1"/>
+			<xsd:maxLength value="60"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	
+	<xsd:simpleType name="TSDec2V2">
+		<xsd:annotation>
+			<xsd:documentation>Valor decimal com 1 ou 2 dígitos mais 2 casas decimais</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:string">
+			<xsd:whiteSpace value="preserve"/>
+			<xsd:pattern value="0|0\.[0-9]{2}|[1-9]{1}[0-9]{0,1}(\.[0-9]{2})?"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	
+	<xsd:simpleType name="TSDec15V2">
+		<xsd:annotation>
+			<xsd:documentation>Valor decimal com 1 a 15 dígitos mais 2 casas decimais</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:string">
+			<xsd:whiteSpace value="preserve"/>
+			<xsd:pattern value="0|0\.[0-9]{2}|[1-9]{1}[0-9]{0,14}(\.[0-9]{2})?"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	
+	
+	<xsd:simpleType name="TSTipoRetPISCofins">
+		<xsd:annotation>
+			<xsd:documentation>
+        Tipo de retencao do Pis/Cofins:
+        1 - Retido;
+        2 - Não Retido;
+      </xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:string">
+			<xsd:whiteSpace value="preserve"/>
+			<xsd:enumeration value="1"/>
+			<xsd:enumeration value="2"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	
+	<xsd:simpleType name="TSDec3V2">
+		<xsd:annotation>
+			<xsd:documentation>Valor decimal com 1 a 3 dígitos mais 2 casas decimais</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:string">
+			<xsd:whiteSpace value="preserve"/>
+			<xsd:pattern value="0|0\.[0-9]{2}|[1-9]{1}[0-9]{0,2}(\.[0-9]{2})?"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	
+	<xsd:simpleType name="TSTipoCST">
+		<xsd:annotation>
+			<xsd:documentation>
+        Código de Situação Tributária do PIS/COFINS (CST):
+        00 - Nenhum;      
+        01 - Operação Tributável com Alíquota Básica;
+        02 - Operação Tributável com Alíquota Diferenciada;
+        03 - Operação Tributável com Alíquota por Unidade de Medida de Produto;
+        04 - Operação Tributável monofásica - Revenda a Alíquota Zero;
+        05 - Operação Tributável por Substituição Tributária;
+        06 - Operação Tributável a Alíquota Zero;
+        07 - Operação Tributável da Contribuição;
+        08 - Operação sem Incidência da Contribuição;
+        09 - Operação com Suspensão da Contribuição;
+      </xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:string">
+			<xsd:whiteSpace value="preserve"/>
+			<xsd:enumeration value="00"/>
+			<xsd:enumeration value="01"/>
+			<xsd:enumeration value="02"/>
+			<xsd:enumeration value="03"/>
+			<xsd:enumeration value="04"/>
+			<xsd:enumeration value="05"/>
+			<xsd:enumeration value="06"/>
+			<xsd:enumeration value="07"/>
+			<xsd:enumeration value="08"/>
+			<xsd:enumeration value="09"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	
+		<xsd:simpleType name="TSRTCFinNFSe">
+		<xsd:annotation>
+			<xsd:documentation>
+        Indicador da finalidade da emissão de NFS-e:
+        0 - NFS-e regular;
+      </xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:string">
+			<xsd:whiteSpace value="preserve"/>
+			<xsd:enumeration value="0"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="TSRTCIndFinal">
+		<xsd:annotation>
+			<xsd:documentation>
+        Indica operação de uso ou consumo pessoal (art. 57):
+        0 - Não;
+        1 - Sim;
+      </xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:string">
+			<xsd:whiteSpace value="preserve"/>
+			<xsd:enumeration value="0"/>
+			<xsd:enumeration value="1"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="TSRTCCodIndOp">
+		<xsd:annotation>
+			<xsd:documentation>
+        Código indicador da operação de fornecimento, conforme tabela "código indicador de operação"
+      </xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:string">
+			<xsd:whiteSpace value="preserve"/>
+			<xsd:pattern value="[0-9]{6}"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="TSRTCTpOper">
+		<xsd:annotation>
+			<xsd:documentation>
+Tipo de Operação com Entes Governanementais ou outros serviços sobre bens imóveis:
+1 – Fornecimento com pagamento posterior;
+2 –  Recebimento do pagamento com fornecimento já realizado;
+3 – Fornecimento com pagamento já realizado;
+4 – Recebimento do pagamento com fornecimento posterior;
+5 – Fornecimento e recebimento do pagamento concomitantes.
+      </xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:string">
+			<xsd:whiteSpace value="preserve"/>
+			<xsd:enumeration value="1"/>
+			<xsd:enumeration value="2"/>
+			<xsd:enumeration value="3"/>
+			<xsd:enumeration value="4"/>
+			<xsd:enumeration value="5"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="TSDesc50">
+		<xsd:restriction base="TSString">
+			<xsd:minLength value="1"/>
+			<xsd:maxLength value="50"/>
+		</xsd:restriction>
+	</xsd:simpleType>	
+	
+	<xsd:simpleType name="TSRTCTpEnteGov">
+		<xsd:annotation>
+			<xsd:documentation>
+        Tipo de ente governamental
+        Para administração pública direta e suas autarquias e fundações:
+        1 - União;
+        2 - Estado;
+        3 - Distrito Federal;
+        4 - Município;
+        9 - Outro;
+      </xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:string">
+			<xsd:whiteSpace value="preserve"/>
+			<xsd:enumeration value="1"/>
+			<xsd:enumeration value="2"/>
+			<xsd:enumeration value="3"/>
+			<xsd:enumeration value="4"/>
+			<xsd:enumeration value="9"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	
+	<xsd:simpleType name="TSRTCIndDest">
+		<xsd:annotation>
+			<xsd:documentation>
+        A respeito do Destinatário dos serviços:
+        0 – O tomador identificado na NFS-e é o adquirente e o destinatário do fornecimento (tomador = adquirente = destinatário);
+        1 – O tomador e o adquirente são a mesma pessoa, mas o destinatário é uma pessoa física ou jurídica ou equiparada diversa do indicado como tomador/adquirente ou se trata de um estabelecimento do adquirente diferente do indicado no campo “tomador” (tomador = adquirente ≠ destinatário);
+        <!--
+		2 - O adquirente e o destinatário são a mesma pessoa, mas diferente do tomador de serviços; (tomador  ≠ adquirente = destinatário)
+        3 - O tomador e o destinatário são a mesma pessoa, diferente do adquirente; (tomador =  destinatário ≠ adquirente)
+        4 - O tomador, o adquirente e o destinatário são pessoas distintas que devem ser identificadas. (tomador ≠ adquirente ≠ destinatário)
+-->
+      </xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:string">
+			<xsd:whiteSpace value="preserve"/>
+			<xsd:enumeration value="0"/>
+			<xsd:enumeration value="1"/>
+			<xsd:enumeration value="2"/>
+			<xsd:enumeration value="3"/>
+			<xsd:enumeration value="4"/>
+		</xsd:restriction>
+	</xsd:simpleType>	
+	
+	<xsd:simpleType name="TSCodMunIBGE">
+		<xsd:annotation>
+			<xsd:documentation>Tipo Código do Município segundo tabela IBGE</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:string">
+			<xsd:whiteSpace value="preserve"/>
+			<xsd:pattern value="[0-9]{7}"/>
+		</xsd:restriction>
+	</xsd:simpleType>	
+	
+	<xsd:simpleType name="TSRTCCodSitTrib">
+		<xsd:annotation>
+			<xsd:documentation>
+        Código de Situação Tributária
+      </xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:string">
+			<xsd:whiteSpace value="preserve"/>
+			<xsd:pattern value="[0-9]{3}"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="TSRTCCodClassTrib">
+		<xsd:annotation>
+			<xsd:documentation>
+        Código de Classificação Tributária
+      </xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:string">
+			<xsd:whiteSpace value="preserve"/>
+			<xsd:pattern value="[0-9]{6}"/>
+		</xsd:restriction>
+	</xsd:simpleType>	
+	
+		<xsd:simpleType name="TSString">
+		<xsd:annotation>
+			<xsd:documentation>Tipo string genérico</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:string">
+			<xsd:whiteSpace value="preserve"/>
+			<xsd:pattern value="[!-ÿ]{1}[ -ÿ]{0,}[!-ÿ]{1}|[!-ÿ]{1}"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="TSData">
+		<xsd:annotation>
+			<xsd:documentation>Tipo data no formato AAAA-MM-DD</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:string">
+			<xsd:whiteSpace value="preserve"/>
+			<xsd:pattern value="(((20(([02468][048])|([13579][26]))-02-29))|(20[0-9][0-9])-((((0[1-9])|(1[0-2]))-((0[1-9])|(1\d)|(2[0-8])))|((((0[13578])|(1[02]))-31)|(((0[1,3-9])|(1[0-2]))-(29|30)))))"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="TSRTCTpReeRepRes">
+		<xsd:annotation>
+			<xsd:documentation>
+        Tipo de valor incluído neste documento, recebido por motivo de estarem relacionadas a operações de terceiros,
+        objeto de reembolso, repasse ou ressarcimento pelo recebedor, já tributados e aqui referenciados
+        01 - Repasse de remuneração por intermediação de imóveis a demais corretores envolvidos na operação;
+        02 - Repasse de valores a fornecedor relativo a fornecimento intermediado por agência de turismo;
+        03 - Reembolso ou ressarcimento recebido por agência de propaganda e publicidade por valores pagos relativos 
+             a serviços de produção externa por conta e ordem de terceiro;
+        04 - Reembolso ou ressarcimento recebido por agência de propaganda e publicidade por valores pagos relativos 
+             a serviços de mídia por conta e ordem de terceiro;
+        99 - Outros reembolsos ou ressarcimentos recebidos por valores pagos relativos a operações por conta e ordem de terceiro;
+      </xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:string">
+			<xsd:whiteSpace value="preserve"/>
+			<xsd:enumeration value="01"/>
+			<xsd:enumeration value="02"/>
+			<xsd:enumeration value="03"/>
+			<xsd:enumeration value="04"/>
+			<xsd:enumeration value="99"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+
+
+	<xsd:simpleType name="TSDesc150">
+		<xsd:restriction base="TSString">
+			<xsd:minLength value="1"/>
+			<xsd:maxLength value="150"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="TSDesc255">
+		<xsd:restriction base="TSString">
+			<xsd:whiteSpace value="preserve"/>
+			<xsd:minLength value="1"/>
+			<xsd:maxLength value="255"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="TSCNPJ">
+		<xsd:annotation>
+			<xsd:documentation>Tipo Número do CNPJ</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:string">
+			<xsd:whiteSpace value="preserve"/>
+			<xsd:maxLength value="14"/>
+			<xsd:pattern value="[0-9]{14}"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="TSCPF">
+		<xsd:annotation>
+			<xsd:documentation>Tipo Número do CPF</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:string">
+			<xsd:whiteSpace value="preserve"/>
+			<xsd:maxLength value="11"/>
+			<xsd:pattern value="[0-9]{11}"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="TSNIF">
+		<xsd:restriction base="xsd:string">
+			<xsd:whiteSpace value="preserve"/>
+			<xsd:minLength value="1"/>
+			<xsd:maxLength value="40"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="TSCodNaoNIF">
+		<xsd:annotation>
+			<xsd:documentation>
+        Motivo para não informação do NIF:
+        0 - Não informado na nota de origem;
+        1 - Dispensado do NIF;
+        2 - Não exigência do NIF;
+      </xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:string">
+			<xsd:whiteSpace value="preserve"/>
+			<xsd:enumeration value="0"/>
+			<xsd:enumeration value="1"/>
+			<xsd:enumeration value="2"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="TSNum7Dig">
+		<xsd:annotation>
+			<xsd:documentation>Número com 7 dígitos</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:string">
+			<xsd:whiteSpace value="preserve"/>
+			<xsd:maxLength value="7"/>
+			<xsd:pattern value="[0-9]{7}"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="TSRTCTipoChaveDFe">
+		<xsd:annotation>
+			<xsd:documentation>
+        Documento fiscal a que se refere a chaveDfe que seja um dos documentos do Repositório Nacional:
+        1 - NFS-e;
+        2 - NF-e;
+        3 - CT-e;
+        9 - Outro;
+      </xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:string">
+			<xsd:whiteSpace value="preserve"/>
+			<xsd:enumeration value="1"/>
+			<xsd:enumeration value="2"/>
+			<xsd:enumeration value="3"/>
+			<xsd:enumeration value="9"/>
+		</xsd:restriction>
+	</xsd:simpleType>	
+	
+		<xsd:simpleType name="TSRTCChaveDFe">
+		<xsd:annotation>
+			<xsd:documentation>
+        Chave do Documento Fiscal Eletrônico
+      </xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:string">
+			<xsd:whiteSpace value="preserve"/>
+			<xsd:minLength value="1"/>
+			<xsd:maxLength value="50"/>
+		</xsd:restriction>
+	</xsd:simpleType>	
+	
+		<xsd:simpleType name="TSCodMoeda">
+		<xsd:annotation>
+			<xsd:documentation>Tipo com código que identifica a moeda conforme tabela do BACEN</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:string">
+			<xsd:whiteSpace value="preserve"/>
+			<xsd:maxLength value="3"/>
+			<xsd:pattern value="[0-9]{3}"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="TSModoPrestacao">
+		<xsd:annotation>
+			<xsd:documentation>
+        Modo de Prestação:
+        0 - Desconhecido (tipo não informado na nota de origem);
+        1 - Transfronteiriço;
+        2 - Consumo no Brasil;
+        3 - Presença Comercial no Exterior;
+        4 - Movimento Temporário de Pessoas Físicas;
+      </xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:string">
+			<xsd:whiteSpace value="preserve"/>
+			<xsd:enumeration value="0"/>
+			<xsd:enumeration value="1"/>
+			<xsd:enumeration value="2"/>
+			<xsd:enumeration value="3"/>
+			<xsd:enumeration value="4"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="TSVincPrest">
+		<xsd:annotation>
+			<xsd:documentation>
+        Vínculo entre as partes no negócio:
+        0 - Sem vínculo com o Tomador/Prestador
+        1 - Controlada;
+        2 - Controladora;
+        3 - Coligada;
+        4 - Matriz;
+        5 - Filial ou sucursal;
+        6 - Outro vínculo;
+      </xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:string">
+			<xsd:whiteSpace value="preserve"/>
+			<xsd:enumeration value="0"/>
+			<xsd:enumeration value="1"/>
+			<xsd:enumeration value="2"/>
+			<xsd:enumeration value="3"/>
+			<xsd:enumeration value="4"/>
+			<xsd:enumeration value="5"/>
+			<xsd:enumeration value="6"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="TSMecAFComExPrest">
+		<xsd:annotation>
+			<xsd:documentation>
+        Mecanismo de apoio/fomento ao Comércio Exterior utilizado pelo prestador do serviço:
+        00 - Desconhecido (tipo não informado na nota de origem);
+        01 - Nenhum;
+        02 - ACC - Adiantamento sobre Contrato de Câmbio – Redução a Zero do IR e do IOF;
+        03 - ACE – Adiantamento sobre Cambiais Entregues - Redução a Zero do IR e do IOF;
+        04 - BNDES-Exim Pós-Embarque – Serviços;
+        05 - BNDES-Exim Pré-Embarque - Serviços;
+        06 - FGE - Fundo de Garantia à Exportação;
+        07 - PROEX - EQUALIZAÇÃO
+        08 - PROEX - Financiamento;
+      </xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:string">
+			<xsd:whiteSpace value="preserve"/>
+			<xsd:enumeration value="00"/>
+			<xsd:enumeration value="01"/>
+			<xsd:enumeration value="02"/>
+			<xsd:enumeration value="03"/>
+			<xsd:enumeration value="04"/>
+			<xsd:enumeration value="05"/>
+			<xsd:enumeration value="06"/>
+			<xsd:enumeration value="07"/>
+			<xsd:enumeration value="08"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="TSMecAFComExToma">
+		<xsd:annotation>
+			<xsd:documentation>
+        Mecanismo de apoio/fomento ao Comércio Exterior utilizado pelo tomador do serviço:
+        00 - Desconhecido (tipo não informado na nota de origem);
+        01 - Nenhum;
+        02 - Adm. Pública e Repr. Internacional;
+        03 - Alugueis e Arrend. Mercantil de maquinas, equip., embarc. e aeronaves;
+        04 - Arrendamento Mercantil de aeronave para empresa de transporte aéreo público;
+        05 - Comissão a agentes externos na exportação;
+        06 - Despesas de armazenagem, mov. e transporte de carga no exterior;
+        07 - Eventos FIFA (subsidiária);
+        08 - Eventos FIFA;
+        09 - Fretes, arrendamentos de embarcações ou aeronaves e outros;
+        10 - Material Aeronáutico;
+        11 - Promoção de Bens no Exterior;
+        12 - Promoção de Dest. Turísticos Brasileiros;
+        13 - Promoção do Brasil no Exterior;
+        14 - Promoção Serviços no Exterior;
+        15 - RECINE;
+        16 - RECOPA;
+        17 - Registro e Manutenção de marcas, patentes e cultivares;
+        18 - REICOMP;
+        19 - REIDI;
+        20 - REPENEC;
+        21 - REPES;
+        22 - RETAERO; 
+        23 - RETID;
+        24 - Royalties, Assistência Técnica, Científica e Assemelhados;
+        25 - Serviços de avaliação da conformidade vinculados aos Acordos da OMC;
+        26 - ZPE;
+      </xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:string">
+			<xsd:whiteSpace value="preserve"/>
+			<xsd:enumeration value="00"/>
+			<xsd:enumeration value="01"/>
+			<xsd:enumeration value="02"/>
+			<xsd:enumeration value="03"/>
+			<xsd:enumeration value="04"/>
+			<xsd:enumeration value="05"/>
+			<xsd:enumeration value="06"/>
+			<xsd:enumeration value="07"/>
+			<xsd:enumeration value="08"/>
+			<xsd:enumeration value="09"/>
+			<xsd:enumeration value="10"/>
+			<xsd:enumeration value="11"/>
+			<xsd:enumeration value="12"/>
+			<xsd:enumeration value="13"/>
+			<xsd:enumeration value="14"/>
+			<xsd:enumeration value="15"/>
+			<xsd:enumeration value="16"/>
+			<xsd:enumeration value="17"/>
+			<xsd:enumeration value="18"/>
+			<xsd:enumeration value="19"/>
+			<xsd:enumeration value="20"/>
+			<xsd:enumeration value="21"/>
+			<xsd:enumeration value="22"/>
+			<xsd:enumeration value="23"/>
+			<xsd:enumeration value="24"/>
+			<xsd:enumeration value="25"/>
+			<xsd:enumeration value="26"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="TSMovTempBens">
+		<xsd:annotation>
+			<xsd:documentation>
+        Vínculo da Operação à Movimentação Temporária de Bens:
+        0 - Desconhecido (tipo não informado na nota de origem);
+        1 - Não;
+        2 - Vinculada - Declaração de Importação;
+        3 - Vinculada - Declaração de Exportação;
+      </xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:string">
+			<xsd:whiteSpace value="preserve"/>
+			<xsd:enumeration value="0"/>
+			<xsd:enumeration value="1"/>
+			<xsd:enumeration value="2"/>
+			<xsd:enumeration value="3"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	
+	<xsd:simpleType name="TSNumDocImport">
+		<xsd:annotation>
+			<xsd:documentation>Número da Declaração de Importação (DI/DSI/DA/DRI-E) averbado</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="TSString">
+			<xsd:minLength value="1"/>
+			<xsd:maxLength value="12"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="TSNumRegExport">
+		<xsd:annotation>
+			<xsd:documentation>Número do Registro de Exportação (RE) averbado</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="TSString">
+			<xsd:minLength value="1"/>
+			<xsd:maxLength value="12"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="TSEnvMDIC">
+		<xsd:annotation>
+			<xsd:documentation>
+        Compartilhar as informações da NFS-e gerada a partir desta DPS com a Secretaria de Comércio Exterior:
+        0 - Não enviar para o MDIC;
+        1 - Enviar para o MDIC;
+      </xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:string">
+			<xsd:whiteSpace value="preserve"/>
+			<xsd:enumeration value="0"/>
+			<xsd:enumeration value="1"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	
+	<xsd:simpleType name="TSDesc600">
+		<xsd:restriction base="TSString">
+			<xsd:whiteSpace value="preserve"/>
+			<xsd:minLength value="1"/>
+			<xsd:maxLength value="600"/>
+		</xsd:restriction>
+	</xsd:simpleType>	
+	
+  	<xsd:simpleType name="tpChaveNotaNacional">
+    	<xsd:annotation>
+      		<xsd:documentation>definicao da chave de acesso da NFSE no ADN</xsd:documentation>
+    	</xsd:annotation>
+    		<xsd:restriction base="xsd:string">
+      	<xsd:pattern value="[0-9A-Z]{50}" />
+    	</xsd:restriction>
+  </xsd:simpleType>		
+	
+	<!-- definition of complex elements -->
+	<xsd:complexType name="tcCpfCnpj">
+		<xsd:choice>
+			<xsd:element name="Cpf" type="tsCpf" minOccurs="1"
+				maxOccurs="1" />
+			<xsd:element name="Cnpj" type="tsCnpj" minOccurs="1"
+				maxOccurs="1" />
+		</xsd:choice>
+	</xsd:complexType>
+
+	<xsd:complexType name="tcEndereco">
+		<xsd:sequence>
+			<xsd:element name="Endereco" type="tsEndereco" minOccurs="1"
+				maxOccurs="1" />
+			<xsd:element name="Numero" type="tsNumeroEndereco"
+				minOccurs="1" maxOccurs="1" />
+			<xsd:element name="Complemento" type="tsComplementoEndereco"
+				minOccurs="0" maxOccurs="1" />
+			<xsd:element name="Bairro" type="tsBairro" minOccurs="1"
+				maxOccurs="1" />
+			<xsd:element name="CodigoMunicipio" type="tsCodigoMunicipioIbge"
+				minOccurs="1" maxOccurs="1" />
+			<xsd:element name="Uf" type="tsUf" minOccurs="1"
+				maxOccurs="1" />
+			<xsd:element name="Cep" type="tsCep" minOccurs="1"
+				maxOccurs="1" />
+		</xsd:sequence>
+	</xsd:complexType>
+
+	<xsd:complexType name="tcEnderecoExterior">
+		<xsd:sequence>
+			<xsd:element name="CodigoPais" type="tsCodigoPaisIbge"
+				minOccurs="1" maxOccurs="1" />
+			<xsd:element name="EnderecoCompletoExterior" type="tsEnderecoCompletoExterior" 
+				minOccurs="1" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Campo com descricoes adicionais sobre o endereço do exterior.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>	
+			<xsd:element name="cEndPost" type="TSCodigoEndPostal">
+				<xsd:annotation>
+					<xsd:documentation>Código alfanumérico do Endereçamento Postal no exterior do prestador do serviço.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="xCidade" type="TSCidade">
+				<xsd:annotation>
+					<xsd:documentation>Nome da cidade no exterior do prestador do serviço.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="xEstProvReg" type="TSEstadoProvRegiao">
+				<xsd:annotation>
+					<xsd:documentation>Estado, província ou região da cidade no exterior do prestador do serviço.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+
+	<xsd:complexType name="tcContato">
+		<xsd:choice minOccurs="1" maxOccurs="1">
+			<xsd:sequence minOccurs="1" maxOccurs="1">
+				<xsd:element name="Telefone" type="tsTelefone"
+					minOccurs="1" maxOccurs="1" />
+				<xsd:element name="Email" type="tsEmail" minOccurs="0"
+					maxOccurs="1" />
+			</xsd:sequence>
+			<xsd:sequence>
+				<xsd:element name="Email" type="tsEmail" minOccurs="1"
+					maxOccurs="1" />
+			</xsd:sequence>
+		</xsd:choice>
+	</xsd:complexType>
+
+	<xsd:complexType name="tcIdentificacaoOrgaoGerador">
+		<xsd:sequence>
+			<xsd:element name="CodigoMunicipio" type="tsCodigoMunicipioIbge"
+				minOccurs="1" maxOccurs="1" />
+			<xsd:element name="Uf" type="tsUf" minOccurs="1"
+				maxOccurs="1" />
+		</xsd:sequence>
+	</xsd:complexType>
+
+	<xsd:complexType name="tcIdentificacaoRps">
+		<xsd:sequence>
+			<xsd:element name="Numero" type="tsNumeroRps" minOccurs="1"
+				maxOccurs="1" />
+			<xsd:element name="Serie" type="tsSerieRps" minOccurs="1"
+				maxOccurs="1" />
+			<xsd:element name="Tipo" type="tsTipoRps" minOccurs="1"
+				maxOccurs="1" />
+		</xsd:sequence>
+	</xsd:complexType>
+
+	<xsd:complexType name="tcIdentificacaoPessoaEmpresa">
+		<xsd:sequence>
+			<xsd:element name="CpfCnpj" type="tcCpfCnpj" minOccurs="1"
+				maxOccurs="1" />
+			<xsd:element name="InscricaoMunicipal" type="tsInscricaoMunicipal"
+				minOccurs="0" maxOccurs="1" />
+		</xsd:sequence>
+	</xsd:complexType>
+
+	<xsd:complexType name="tcDadosTomador">
+		<xsd:sequence>
+			<xsd:element name="IdentificacaoTomador" type="tcIdentificacaoPessoaEmpresa"
+				minOccurs="0" maxOccurs="1" />
+			<xsd:element name="NifTomador" type="tsNif" minOccurs="0"
+				maxOccurs="1" />
+			<xsd:element name="RazaoSocial" type="tsRazaoSocial"
+				minOccurs="1" maxOccurs="1" />
+			<xsd:choice minOccurs="0">
+				<xsd:element name="Endereco" type="tcEndereco"
+					minOccurs="1" maxOccurs="1" />
+				<xsd:element name="EnderecoExterior" type="tcEnderecoExterior"
+					minOccurs="1" maxOccurs="1" />
+			</xsd:choice>
+			<xsd:element name="Contato" type="tcContato" minOccurs="0"
+				maxOccurs="1" />
+		</xsd:sequence>
+	</xsd:complexType>
+
+	<xsd:complexType name="tcDadosIntermediario">
+		<xsd:sequence>
+			<xsd:element name="IdentificacaoIntermediario" type="tcIdentificacaoPessoaEmpresa"
+				minOccurs="1" maxOccurs="1" />
+			<xsd:element name="RazaoSocial" type="tsRazaoSocial"
+				minOccurs="1" maxOccurs="1" />
+			<xsd:element name="CodigoMunicipio" type="tsCodigoMunicipioIbge"
+				minOccurs="1" maxOccurs="1" />
+		</xsd:sequence>
+	</xsd:complexType>
+	
+	<!--TIPO COMPLEXO PARA INFORMAÇÕES DE TRIBUTOS FEDERAIS E VALOR APROXIMADO DOS TRIBUTOS DA NFSE-->
+	<xsd:complexType name="TCInfoTributacao">
+		<xsd:sequence>
+			<xsd:element name="tribFed" type="TCTribFederal" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>
+            Grupo de informações de outros tributos relacionados ao serviço prestado
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="totTrib" type="TCTribTotal">
+				<xsd:annotation>
+					<xsd:documentation>
+            Grupo de informações para totais aproximados dos tributos relacionados ao serviço prestado
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+
+	<!--TIPO COMPLEXO PARA INFORMAÇÕES DE TRIBUTAÇÃO ESPECÍFICA PARA TOTAL DOS TRIBUTOS-->
+	<xsd:complexType name="TCTribTotalPercent">
+		<xsd:sequence>
+			<xsd:element name="pTotTribFed" type="TSDec3V2">
+				<xsd:annotation>
+					<xsd:documentation>
+            Valor percentual total aproximado dos tributos federais (%).
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="pTotTribEst" type="TSDec3V2">
+				<xsd:annotation>
+					<xsd:documentation>
+            Valor percentual total aproximado dos tributos estaduais (%).
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="pTotTribMun" type="TSDec3V2">
+				<xsd:annotation>
+					<xsd:documentation>
+            Valor percentual total aproximado dos tributos municipais (%).
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+		
+	<!--TIPO COMPLEXO PARA INFORMAÇÕES DE TRIBUTAÇÃO ESPECÍFICA PARA TOTAL DOS TRIBUTOS-->
+	<xsd:complexType name="TCTribTotal">
+		<xsd:sequence>
+			<xsd:choice>
+				<xsd:element name="pTotTrib" type="TCTribTotalPercent">
+					<xsd:annotation>
+						<xsd:documentation>
+              Valor percentual total aproximado dos tributos, em conformidade com o artigo 1o da Lei no 12.741/2012
+            </xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
+				<xsd:element name="pTotTribSN" type="TSDec2V2">
+					<xsd:annotation>
+						<xsd:documentation>
+              Valor percentual aproximado do total dos tributos da alíquota do Simples Nacional (%)
+            </xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
+			</xsd:choice>
+		</xsd:sequence>
+	</xsd:complexType>	
+	
+	<!--TIPO COMPLEXO PARA INFORMAÇÕES DE TRIBUTAÇÃO ESPECÍFICA PARA PIS/COFINS-->
+	<xsd:complexType name="TCTribFederal">
+		<xsd:sequence>
+			<xsd:element name="piscofins" type="TCTribOutrosPisCofins" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>
+            Grupo de informações dos tributos PIS/COFINS
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>	
+
+	<!--TIPO COMPLEXO PARA INFORMAÇÕES DE TRIBUTAÇÃO ESPECÍFICA PARA OUTROS TRIBUTOS DO TIPO PIS/COFINS-->
+	<xsd:complexType name="TCTribOutrosPisCofins">
+		<xsd:sequence>
+			<xsd:element name="CST" type="TSTipoCST">
+				<xsd:annotation>
+					<xsd:documentation>
+            Código de Situação Tributária do PIS/COFINS (CST):
+            00 - Nenhum;      
+            01 - Operação Tributável com Alíquota Básica;
+            02 - Operação Tributável com Alíquota Diferenciada;
+            03 - Operação Tributável com Alíquota por Unidade de Medida de Produto;
+            04 - Operação Tributável monofásica - Revenda a Alíquota Zero;
+            05 - Operação Tributável por Substituição Tributária;
+            06 - Operação Tributável a Alíquota Zero;
+            07 - Operação Tributável da Contribuição;
+            08 - Operação sem Incidência da Contribuição;
+            09 - Operação com Suspensão da Contribuição;
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="vBCPisCofins" type="TSDec15V2" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>
+            Valor da Base de Cálculo do PIS/COFINS (R$).
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="pAliqPis" type="TSDec2V2" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>
+            Valor da Alíquota do PIS (%).
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="pAliqCofins" type="TSDec2V2" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>
+            Valor da Alíquota da COFINS (%).
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="vPis" type="TSDec15V2" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>
+            Valor monetário do PIS (R$).
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="vCofins" type="TSDec15V2" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>
+            Valor monetário do COFINS (R$).
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="tpRetPisCofins" type="TSTipoRetPISCofins" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>
+            Tipo de retencao do Pis/Cofins:
+            1 - Retido;
+            2 - Não Retido;
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+	
+	<!--TIPO COMPLEXO PARA INFORMAÇÕES DECLARADAS REFERENTES A IBS/CBS-->
+	<xsd:complexType name="TCRTCInfoIBSCBS">
+		<xsd:sequence>
+			<xsd:element name="finNFSe" type="TSRTCFinNFSe">
+				<xsd:annotation>
+					<xsd:documentation>Indicador da finalidade da emissão de NFS-e</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="indFinal" type="TSRTCIndFinal">
+				<xsd:annotation>
+					<xsd:documentation>
+            Indica operação de uso ou consumo pessoal (art. 57)
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="cIndOp" type="TSRTCCodIndOp">
+				<xsd:annotation>
+					<xsd:documentation>Código indicador da operação de fornecimento, conforme tabela "código indicador de operação"</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="tpOper" type="TSRTCTpOper" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Código indicador da operação com entes Governamentais, conforme situações previstas na LC 214/2025</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="gRefNFSe" minOccurs="0">
+				<xsd:complexType>
+					<xsd:choice>
+						<xsd:element name="refNFSe" type="TSDesc50" maxOccurs="99"/>
+					</xsd:choice>
+				</xsd:complexType>
+			</xsd:element>
+			<xsd:element name="tpEnteGov" type="TSRTCTpEnteGov" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Tipo de ente governamental</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="indDest" type="TSRTCIndDest">
+				<xsd:annotation>
+					<xsd:documentation>A respeito do Destinatário dos serviços</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="valores" type="TCRTCInfoValoresIBSCBS">
+				<xsd:annotation>
+					<xsd:documentation>Grupo de informações relativas aos valores do serviço prestado para IBS e CBS</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>			
+	
+	
+
+	<!--TIPO COMPLEXO INFORMAÇÕES RELATIVAS AOS VALORES DO SERVIÇO PRESTADO IBSCBS-->
+	<xsd:complexType name="TCRTCInfoValoresIBSCBS">
+		<xsd:sequence>
+			<xsd:element name="gReeRepRes" type="TCRTCInfoReeRepRes" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Grupo de informações relativas a valores incluídos neste documento e recebidos por motivo de estarem relacionadas 
+            a operações de terceiros, objeto de reembolso, repasse ou ressarcimento pelo recebedor, já tributados e aqui referenciados</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="trib" type="TCRTCInfoTributosIBSCBS">
+				<xsd:annotation>
+					<xsd:documentation>Grupo de informações relacionados aos tributos IBS e CBS</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="cLocalidadeIncid" type="TSCodMunIBGE">
+				<xsd:annotation>
+					<xsd:documentation>Código IBGE da localidade de incidência do IBS/CBS (local da operação)</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="pRedutor" type="TSDec2V2">
+				<xsd:annotation>
+					<xsd:documentation>Percentual de redução de aliquota em compra governamental</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="vBC" type="TSDec15V2" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Valor da Base de Cálculo do ISSQN (R$) = Valor do Serviço - Desconto Incondicionado - Deduções/Reduções - Benefício Municipal
+            vBC = vServ - descIncond - (vDR ou vCalcDR + vCalcReeRepRes) - (vRedBCBM ou VCalcBM)</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>	
+	
+	<!--TIPO COMPLEXO INFORMAÇÕES RELACIONADOS AOS TRIBUTOS IBSCBS-->
+	<xsd:complexType name="TCRTCInfoTributosIBSCBS">
+		<xsd:sequence>
+			<xsd:element name="gIBSCBS" type="TCRTCInfoTributosSitClas">
+				<xsd:annotation>
+					<xsd:documentation>Grupo de informações relacionadas ao IBS e à CBS</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>	
+	
+	
+	<!--TIPO COMPLEXO INFORMAÇÕES RELACIONADOS AOS TRIBUTOS SITUACAO E CLASSIFICACAO IBSCBS-->
+	<xsd:complexType name="TCRTCInfoTributosSitClas">
+		<xsd:sequence>
+			<xsd:element name="CST" type="TSRTCCodSitTrib">
+				<xsd:annotation>
+					<xsd:documentation>Código de Situação Tributária do IBS e da CBS</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="cClassTrib" type="TSRTCCodClassTrib">
+				<xsd:annotation>
+					<xsd:documentation>Código de Classificação Tributária do IBS e da CBS</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>	
+
+<!--TIPO COMPLEXO INFORMAÇÕES RELATIVAS AOS DOCUMENTOS REFERENCIADOS NO REEMBOLSO REPASSE OU RESSARCIMENTO IBSCBS-->
+	<xsd:complexType name="TCRTCListaDoc">
+		<xsd:sequence>
+			<xsd:choice>
+				<xsd:element name="dFeNacional" type="TCRTCListaDocDFe">
+					<xsd:annotation>
+						<xsd:documentation>
+              Grupo de informações de documentos fiscais eletrônicos que se encontram no repositório nacional
+            </xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
+				<xsd:element name="docFiscalOutro" type="TCRTCListaDocFiscalOutro">
+					<xsd:annotation>
+						<xsd:documentation>
+              Grupo de informações de documento fiscais, eletrônicos ou não, que não se encontram no repositório nacional
+            </xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
+				<xsd:element name="docOutro" type="TCRTCListaDocOutro">
+					<xsd:annotation>
+						<xsd:documentation>
+              Grupo de informações de documento não fiscal.
+            </xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
+			</xsd:choice>
+			<xsd:element name="fornec" type="TCRTCListaDocFornec" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>
+            Grupo de informações do fornecedor do documento referenciado
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="dtEmiDoc" type="TSData">
+				<xsd:annotation>
+					<xsd:documentation>
+            Data da emissão do documento dedutível
+            Ano, mês e dia (AAAA-MM-DD)
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="dtCompDoc" type="TSData">
+				<xsd:annotation>
+					<xsd:documentation>
+            Data da competência do documento dedutível
+            Ano, mês e dia (AAAA-MM-DD)
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="tpReeRepRes" type="TSRTCTpReeRepRes">
+				<xsd:annotation>
+					<xsd:documentation>
+            Tipo de valor incluído neste documento, recebido por motivo de estarem relacionadas a operações de terceiros, 
+            objeto de reembolso, repasse ou ressarcimento pelo recebedor, já tributados e aqui referenciados
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="xTpReeRepRes" type="TSDesc150" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>
+            Descrição do reembolso ou ressarcimento quando a opção é 
+            "99 – Outros reembolsos ou ressarcimentos recebidos por valores pagos relativos a operações por conta e ordem de terceiro"
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="vlrReeRepRes" type="TSDec15V2">
+				<xsd:annotation>
+					<xsd:documentation>
+            Valor monetário (total ou parcial, conforme documento informado) utilizado para não inclusão na base de cálculo 
+            do ISS e do IBS e da CBS da NFS-e que está sendo emitida (R$)
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>	
+
+	<xsd:complexType name="TCRTCInfoReeRepRes">
+		<xsd:sequence>
+			<xsd:element name="documentos" type="TCRTCListaDoc" maxOccurs="1000">
+				<xsd:annotation>
+					<xsd:documentation>Grupo relativo aos documentos referenciados nos casos de reembolso, repasse e ressarcimento que serão 
+            considerados na base de cálculo do ISSQN, do IBS e da CBS</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+	
+	
+	<!--TIPO COMPLEXO INFORMAÇÕES DO FORNECEDOR DO DOCUMENTO REFERENCIADO-->
+	<xsd:complexType name="TCRTCListaDocFornec">
+		<xsd:sequence>
+			<xsd:choice>
+				<xsd:element name="CNPJ" type="TSCNPJ">
+					<xsd:annotation>
+						<xsd:documentation>
+              Número da inscrição no Cadastro Nacional de Pessoa Jurídica (CNPJ) do Fornecedor do serviço
+            </xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
+				<xsd:element name="CPF" type="TSCPF">
+					<xsd:annotation>
+						<xsd:documentation>
+              Número da inscrição no Cadastro de Pessoa Física (CPF) do Fornecedor do serviço
+            </xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
+				<xsd:element name="NIF" type="TSNIF">
+					<xsd:annotation>
+						<xsd:documentation>
+              Este elemento só deverá ser preenchido para fornecedores não residentes no Brasil
+            </xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
+				<xsd:element name="cNaoNIF" type="TSCodNaoNIF">
+					<xsd:annotation>
+						<xsd:documentation>
+              Motivo para não informação do NIF:
+              0 - Não informado na nota de origem;
+              1 - Dispensado do NIF;
+              2 - Não exigência do NIF;
+            </xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
+			</xsd:choice>
+			<xsd:element name="xNome" type="TSDesc150">
+				<xsd:annotation>
+					<xsd:documentation>
+            Nome / Razão Social do do Fornecedor do serviço
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>	
+	
+	<!--TIPO COMPLEXO INFORMAÇÕES DE DOCUMENTO NÃO FISCAL-->
+	<xsd:complexType name="TCRTCListaDocOutro">
+		<xsd:sequence>
+			<xsd:element name="nDoc" type="TSDesc255">
+				<xsd:annotation>
+					<xsd:documentation>
+            Número do documento não fiscal
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="xDoc" type="TSDesc255">
+				<xsd:annotation>
+					<xsd:documentation>
+            Descrição do documento não fiscal
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+	
+<!--TIPO COMPLEXO INFORMAÇÕES DE DOCUMENTO FISCAIS, ELETRÔNICOS OU NÃO, QUE NÃO SE ENCONTRAM NO REPOSITÓRIO NACIONAL-->
+	<xsd:complexType name="TCRTCListaDocFiscalOutro">
+		<xsd:sequence>
+			<xsd:element name="cMunDocFiscal" type="TSNum7Dig">
+				<xsd:annotation>
+					<xsd:documentation>
+            Código do município emissor do documento fiscal que não se encontra no repositório nacional
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="nDocFiscal" type="TSDesc255">
+				<xsd:annotation>
+					<xsd:documentation>
+            Número do documento fiscal que não se encontra no repositório nacional
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="xDocFiscal" type="TSDesc255">
+				<xsd:annotation>
+					<xsd:documentation>
+            Descrição do documento fiscal
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+	
+	<!--TIPO COMPLEXO INFORMAÇÕES DE DOCUMENTOS FISCAIS ELETRÔNICOS QUE SE ENCONTRAM NO REPOSITÓRIO NACIONAL-->
+	<xsd:complexType name="TCRTCListaDocDFe">
+		<xsd:sequence>
+			<xsd:element name="tipoChaveDFe" type="TSRTCTipoChaveDFe">
+				<xsd:annotation>
+					<xsd:documentation>
+            Documento fiscal a que se refere a chaveDfe que seja um dos documentos do Repositório Nacional
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="xTipoChaveDFe" type="TSDesc255" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>
+            Descrição da DF-e a que se refere a chaveDfe que seja um dos documentos do Repositório Nacional
+            Deve ser preenchido apenas quando "tipoChaveDFe = 9 (Outro)"
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="chaveDFe" type="TSRTCChaveDFe">
+				<xsd:annotation>
+					<xsd:documentation>
+            Chave do Documento Fiscal eletrônico do repositório nacional referenciado para os casos de operações já tributadas
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>	
+	
+		<xsd:complexType name="TCRTCIBSCBS">
+		<xsd:sequence>
+			<xsd:element name="xLocalidadeIncid" type="TSDesc600">
+				<xsd:annotation>
+					<xsd:documentation>
+            Nome da localidade de incidência do IBS/CBS
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="xCClassTrib" type="TSDesc600">
+				<xsd:annotation>
+					<xsd:documentation>
+            Descrição do Código de Classificação Tributária do IBS/CBS
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="valores" type="TCRTCValoresIBSCBS">
+				<xsd:annotation>
+					<xsd:documentation>
+            Grupo de valores brutos referentes ao IBS/CBS
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="totCIBS" type="TCRTCTotalCIBS">
+				<xsd:annotation>
+					<xsd:documentation>
+            Grupo de Totalizadores
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>				
+	
+	<!--TIPO COMPLEXO DOS VALORES BRUTOS IBSCBS-->
+	<xsd:complexType name="TCRTCValoresIBSCBS">
+		<xsd:sequence>
+			<xsd:element name="vCalcReeRepRes" type="TSDec15V2" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>
+            Valor monetário (R$) total relativo ao fornecimento próprio de bens materiais ou relacionados a operações de terceiros, 
+            objeto de reembolso, repasse ou ressarcimento pelo recebedor, já tributados e aqui referenciados e que não integram 
+            da base de cálculo (BC) do ISSQN, do IBS e da CBS.
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="uf" type="TCRTCValoresIBSCBSUF">
+				<xsd:annotation>
+					<xsd:documentation>
+            Grupo de Informações relativas aos valores do IBS Estadual
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="mun" type="TCRTCValoresIBSCBSMun">
+				<xsd:annotation>
+					<xsd:documentation>
+            Grupo de Informações relativas aos valores do IBS Municipal
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="fed" type="TCRTCValoresIBSCBSFed">
+				<xsd:annotation>
+					<xsd:documentation>
+            Grupo de Informações relativas aos valores da CBS
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>	
+	
+	
+	<!--TIPO COMPLEXO IBS ESTADUAL-->
+	<xsd:complexType name="TCRTCValoresIBSCBSUF">
+		<xsd:sequence>
+			<xsd:element name="pIBSUF" type="TSDec2V2">
+				<xsd:annotation>
+					<xsd:documentation>
+            Alíquota da UF para IBS da localidade de incidência parametrizada no sistema
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="pRedAliqUF" type="TSDec3V2" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>
+            Percentual de redução de alíquota estadual
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="pAliqEfetUF" type="TSDec2V2">
+				<xsd:annotation>
+					<xsd:documentation>
+            pAliqEfetUF = pIBSUF x (1 - pRedAliqUF) x (1 - pRedutor)
+            Se pRedAliqUF não for informado na DPS, então pAliqEfetUF é a própria pIBSUF
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>	
+	
+	
+	<!--TIPO COMPLEXO IBS MUNICIPAL-->
+	<xsd:complexType name="TCRTCValoresIBSCBSMun">
+		<xsd:sequence>
+			<xsd:element name="pIBSMun" type="TSDec2V2">
+				<xsd:annotation>
+					<xsd:documentation>
+            Alíquota do Município para IBS da localidade de incidência parametrizada no sistema
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="pRedAliqMun" type="TSDec3V2" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>
+            Percentual de redução de alíquota municipal
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="pAliqEfetMun" type="TSDec2V2">
+				<xsd:annotation>
+					<xsd:documentation>
+            pAliqEfetMun = pIBSMun x (1 - pRedAliqMun) x (1 - pRedutor)
+            Se pRedAliqMun não for informado na DPS, então pAliqEfetMun é a própria pIBSMun
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+
+	<!--TIPO COMPLEXO CBS-->
+	<xsd:complexType name="TCRTCValoresIBSCBSFed">
+		<xsd:sequence>
+			<xsd:element name="pCBS" type="TSDec2V2">
+				<xsd:annotation>
+					<xsd:documentation>
+            Alíquota da União para CBS parametrizada no sistema
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="pRedAliqCBS" type="TSDec3V2" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>
+            Percentual da redução de alíquota da CBS
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="pAliqEfetCBS" type="TSDec2V2">
+				<xsd:annotation>
+					<xsd:documentation>
+            pAliqEfetCBS = pCBS x (1 - pRedAliqCBS) x (1 - pRedutor)
+            Se pRedAliqCBS não for informado na DPS, então pAliqEfetCBS é a própria pCBS
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>	
+	
+	
+	<!--TIPO COMPLEXO DE TOTALIZADORES IBSCBS-->
+	<xsd:complexType name="TCRTCTotalCIBS">
+		<xsd:sequence>
+			<xsd:element name="vTotNF" type="TSDec15V2">
+				<xsd:annotation>
+					<xsd:documentation>
+            Valor Total da NF considerando os impostos por fora: IBS e CBS
+            O IBS e a CBS são por fora, por isso seus valores devem ser adicionados ao valor total da NF
+            vTotNF = vLiq (em 2026)
+            vTotNF = vLiq + vCBS + vIBSTot (a partir de 2027)
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="gIBS" type="TCRTCTotalIBS">
+				<xsd:annotation>
+					<xsd:documentation>
+            Grupo de valores referentes ao IBS
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="gCBS" type="TCRTCTotalCBS">
+				<xsd:annotation>
+					<xsd:documentation>
+            Grupo de valores referentes à CBS
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="gTribRegular" type="TCRTCTotalTribRegular" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>
+            Grupo de informações de tributação regular
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="gTribCompraGov" type="TCRTCTotalTribCompraGov" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>
+            Grupo de informações da composição do valor do IBS e da CBS em compras governamentais
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>	
+	
+	<!--TIPO COMPLEXO DE TOTALIZADORES DOS VALORES IBS-->
+	<xsd:complexType name="TCRTCTotalIBS">
+		<xsd:sequence>
+			<xsd:element name="vIBSTot" type="TSDec15V2">
+				<xsd:annotation>
+					<xsd:documentation>
+            Valor total do IBS.
+            vIBSTot = vIBSUF + vIBSMun
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="gIBSCredPres" type="TCRTCTotalIBSCredPres" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>
+            Grupo de valores referentes ao crédito presumido para IBS
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="gIBSUFTot" type="TCRTCTotalIBSUF">
+				<xsd:annotation>
+					<xsd:documentation>
+            Grupo de valores referentes ao IBS Estadual
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="gIBSMunTot" type="TCRTCTotalIBSMun">
+				<xsd:annotation>
+					<xsd:documentation>
+            Grupo de valores referentes ao IBS Municipal
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>	
+	
+	
+	<!--TIPO COMPLEXO DE TOTALIZADORES DOS VALORES CBS-->
+	<xsd:complexType name="TCRTCTotalCBS">
+		<xsd:sequence>
+			<xsd:element name="gCBSCredPres" type="TCRTCTotalCBSCredPres" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>
+            Grupo de valores referentes ao crédito presumido para CBS
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="vDifCBS" type="TSDec15V2">
+				<xsd:annotation>
+					<xsd:documentation>
+            Total do Diferimento CBS
+            vDifCBS = vCBS x pDifCBS
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="vCBS" type="TSDec15V2">
+				<xsd:annotation>
+					<xsd:documentation>
+            Total valor da CBS da União
+            vCBS = vBC x (pCBS ou pAliqEfetCBS)
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+
+	<!--TIPO COMPLEXO DE TOTALIZADORES DOS VALORES TRIBUTAÇÃO REGULAR-->
+	<xsd:complexType name="TCRTCTotalTribRegular">
+		<xsd:sequence>
+			<xsd:element name="pAliqEfeRegIBSUF" type="TSDec2V2">
+				<xsd:annotation>
+					<xsd:documentation>
+            Alíquota efetiva de tributação regular do IBS estadual
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="vTribRegIBSUF" type="TSDec15V2">
+				<xsd:annotation>
+					<xsd:documentation>
+            Valor da tributação regular do IBS estadual
+            vTribRegIBSUF = vBC x pAliqEfeRegIBSUF
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="pAliqEfeRegIBSMun" type="TSDec2V2">
+				<xsd:annotation>
+					<xsd:documentation>
+            Alíquota efetiva de tributação regular do IBS municipal
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="vTribRegIBSMun" type="TSDec15V2">
+				<xsd:annotation>
+					<xsd:documentation>
+            Valor da tributação regular do IBS municipal
+            vTribRegIBSMun = vBC x pAliqEfeRegIBSMun
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="pAliqEfeRegCBS" type="TSDec2V2">
+				<xsd:annotation>
+					<xsd:documentation>
+            Alíquota efetiva de tributação regular da CBS
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="vTribRegCBS" type="TSDec15V2">
+				<xsd:annotation>
+					<xsd:documentation>
+            Valor da tributação regular da CBS
+            vTribRegCBS = vBC x pAliqEfeRegCBS
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+
+	<!--TIPO COMPLEXO DE TOTALIZADORES DOS VALORES IBSCBS EM COMPRAS GOVERNAMENTAIS-->
+	<xsd:complexType name="TCRTCTotalTribCompraGov">
+		<xsd:sequence>
+			<xsd:element name="pIBSUF" type="TSDec2V2">
+				<xsd:annotation>
+					<xsd:documentation>
+            Alíquota do IBS de competência do Estado
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="vIBSUF" type="TSDec15V2">
+				<xsd:annotation>
+					<xsd:documentation>
+            Valor do Tributo do IBS da UF calculado
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="pIBSMun" type="TSDec2V2">
+				<xsd:annotation>
+					<xsd:documentation>
+            Alíquota do IBS de competência do Município
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="vIBSMun" type="TSDec15V2">
+				<xsd:annotation>
+					<xsd:documentation>
+            Valor do Tributo do IBS do Município calculado
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="pCBS" type="TSDec2V2">
+				<xsd:annotation>
+					<xsd:documentation>
+            Alíquota da CBS
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="vCBS" type="TSDec15V2">
+				<xsd:annotation>
+					<xsd:documentation>
+            Valor do Tributo da CBS calculado
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>	
+	
+	<!--TIPO COMPLEXO DE TOTALIZADORES DOS VALORES CREDITO PRESUMIDO IBS-->
+	<xsd:complexType name="TCRTCTotalIBSCredPres">
+		<xsd:sequence>
+			<xsd:element name="pCredPresIBS" type="TSDec2V2">
+				<xsd:annotation>
+					<xsd:documentation>
+            Alíquota do crédito presumido para o IBS
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="vCredPresIBS" type="TSDec15V2">
+				<xsd:annotation>
+					<xsd:documentation>
+            Valor do Crédito Presumido para o IBS
+            vCredPresIBS = vBC x pCredPresIBS
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+	<!--TIPO COMPLEXO DE TOTALIZADORES DOS VALORES IBS ESTADUAL-->
+	<xsd:complexType name="TCRTCTotalIBSUF">
+		<xsd:sequence>
+			<xsd:element name="vDifUF" type="TSDec15V2">
+				<xsd:annotation>
+					<xsd:documentation>
+            Total do Diferimento do IBS estadual
+            vDifUF = vIBSUF x pDifUF
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="vIBSUF" type="TSDec15V2">
+				<xsd:annotation>
+					<xsd:documentation>
+            Total valor do IBS estadual
+            vIBSUF = vBC x (pIBSUF ou pAliqEfetUF)
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+	<!--TIPO COMPLEXO DE TOTALIZADORES DOS VALORES IBS MUNICIPAL-->
+	<xsd:complexType name="TCRTCTotalIBSMun">
+		<xsd:sequence>
+			<xsd:element name="vDifMun" type="TSDec15V2">
+				<xsd:annotation>
+					<xsd:documentation>
+            Total do Diferimento do IBS municipal
+            vDifMun = vIBSMun x pDifMun
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="vIBSMun" type="TSDec15V2">
+				<xsd:annotation>
+					<xsd:documentation>
+            Total valor do IBS municipal
+            vIBSMun = vBC x (pIBSMun ou pAliqEfetMun)
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+	
+		<!--TIPO COMPLEXO DE TOTALIZADORES DOS VALORES CREDITO PRESUMIDO CBS-->
+	<xsd:complexType name="TCRTCTotalCBSCredPres">
+		<xsd:sequence>
+			<xsd:element name="pCredPresCBS" type="TSDec2V2">
+				<xsd:annotation>
+					<xsd:documentation>
+            Alíquota do crédito presumido para a CBS
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="vCredPresCBS" type="TSDec15V2">
+				<xsd:annotation>
+					<xsd:documentation>
+            Valor do Crédito Presumido da CBS
+            vCredPresCBS = vBC x pCredPresCBS
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>	
+
+	<xsd:complexType name="tcValoresDeclaracaoServico">
+		<xsd:sequence>
+			<xsd:element name="ValorServicos" type="tsValor"
+				minOccurs="1" maxOccurs="1" />
+			<xsd:element name="ValorDeducoes" type="tsValor"
+				minOccurs="0" maxOccurs="1" />
+			<xsd:element name="ValorPis" type="tsValor" minOccurs="0"
+				maxOccurs="1" />
+			<xsd:element name="ValorCofins" type="tsValor" minOccurs="0"
+				maxOccurs="1" />
+			<xsd:element name="ValorInss" type="tsValor" minOccurs="0"
+				maxOccurs="1" />
+			<xsd:element name="ValorIr" type="tsValor" minOccurs="0"
+				maxOccurs="1" />
+			<xsd:element name="ValorCsll" type="tsValor" minOccurs="0"
+				maxOccurs="1" />
+			<xsd:element name="OutrasRetencoes" type="tsValor"
+				minOccurs="0" maxOccurs="1" />
+			<xsd:element name="ValTotTributos" type="tsValor"
+				minOccurs="0" maxOccurs="1" />
+			<xsd:element name="ValorIss" type="tsValor" minOccurs="0"
+				maxOccurs="1" />
+			<xsd:element name="Aliquota" type="tsAliquota" minOccurs="0"
+				maxOccurs="1" />
+			<xsd:element name="DescontoIncondicionado" type="tsValor"
+				minOccurs="0" maxOccurs="1" />
+			<xsd:element name="DescontoCondicionado" type="tsValor"
+				minOccurs="0" maxOccurs="1" />
+			<xsd:element name="trib" type="TCInfoTributacao">
+				<xsd:annotation>
+					<xsd:documentation>
+            Grupo de informações relacionados aos tributos federais e valor aproximado dos tributos referentes ao serviço prestado
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="IBSCBS" type="TCRTCInfoIBSCBS">
+				<xsd:annotation>
+					<xsd:documentation>Grupo de informações declaradas pelo emitente referentes ao IBS e à CBS</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>	
+		</xsd:sequence>
+	</xsd:complexType>
+
+	<xsd:complexType name="tcValoresNfse">
+		<xsd:sequence>
+			<xsd:element name="BaseCalculo" type="tsValor" minOccurs="1"
+				maxOccurs="1" />
+			<xsd:element name="Aliquota" type="tsAliquota" minOccurs="0"
+				maxOccurs="1" />
+			<xsd:element name="ValorIss" type="tsValor" minOccurs="0"
+				maxOccurs="1" />
+			<xsd:element name="ValorLiquidoNfse" type="tsValor"
+				minOccurs="1" maxOccurs="1" />
+		</xsd:sequence>
+	</xsd:complexType>
+	
+		<!--TIPO COMPLEXO PARA INFORMAÇÕES DE COMÉRCIO EXTERIOR-->
+	<xsd:complexType name="TCComExterior">
+		<xsd:sequence>
+			<xsd:element name="mdPrestacao" type="TSModoPrestacao">
+				<xsd:annotation>
+					<xsd:documentation>
+            Modo de Prestação:
+            0 - Desconhecido (tipo não informado na nota de origem);
+            1 - Transfronteiriço;
+            2 - Consumo no Brasil;
+            3 - Movimento Temporário de Pessoas Físicas;
+            4 - Consumo no Exterior;
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="vincPrest" type="TSVincPrest">
+				<xsd:annotation>
+					<xsd:documentation>Vínculo entre as partes no negócio:
+            0 - Sem vínculo com o Tomador/Prestador
+            1 - Controlada;
+            2 - Controladora;
+            3 - Coligada;
+            4 - Matriz;
+            5 - Filial ou sucursal;
+            6 - Outro vínculo;
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="tpMoeda" type="TSCodMoeda">
+				<xsd:annotation>
+					<xsd:documentation>Identifica a moeda da transação comercial</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="vServMoeda" type="TSDec15V2">
+				<xsd:annotation>
+					<xsd:documentation>Valor do serviço prestado expresso em moeda estrangeira especificada em tpmoeda</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="mecAFComexP" type="TSMecAFComExPrest">
+				<xsd:annotation>
+					<xsd:documentation>
+            Mecanismo de apoio/fomento ao Comércio Exterior utilizado pelo prestador do serviço:
+            00 - Desconhecido (tipo não informado na nota de origem);
+            01 - Nenhum;
+            02 - ACC - Adiantamento sobre Contrato de Câmbio – Redução a Zero do IR e do IOF;
+            03 - ACE – Adiantamento sobre Cambiais Entregues - Redução a Zero do IR e do IOF;
+            04 - BNDES-Exim Pós-Embarque – Serviços;
+            05 - BNDES-Exim Pré-Embarque - Serviços;
+            06 - FGE - Fundo de Garantia à Exportação;
+            07 - PROEX - EQUALIZAÇÃO
+            08 - PROEX - Financiamento;
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="mecAFComexT" type="TSMecAFComExToma">
+				<xsd:annotation>
+					<xsd:documentation>
+            Mecanismo de apoio/fomento ao Comércio Exterior utilizado pelo tomador do serviço:
+            00 - Desconhecido (tipo não informado na nota de origem);
+            01 - Nenhum;
+            02 - Adm. Pública e Repr. Internacional;
+            03 - Alugueis e Arrend. Mercantil de maquinas, equip., embarc. e aeronaves;
+            04 - Arrendamento Mercantil de aeronave para empresa de transporte aéreo público;
+            05 - Comissão a agentes externos na exportação;
+            06 - Despesas de armazenagem, mov. e transporte de carga no exterior;
+            07 - Eventos FIFA (subsidiária);
+            08 - Eventos FIFA;
+            09 - Fretes, arrendamentos de embarcações ou aeronaves e outros;
+            10 - Material Aeronáutico;
+            11 - Promoção de Bens no Exterior;
+            12 - Promoção de Dest. Turísticos Brasileiros;
+            13 - Promoção do Brasil no Exterior;
+            14 - Promoção Serviços no Exterior;
+            15 - RECINE;
+            16 - RECOPA;
+            17 - Registro e Manutenção de marcas, patentes e cultivares;
+            18 - REICOMP;
+            19 - REIDI;
+            20 - REPENEC;
+            21 - REPES;
+            22 - RETAERO; 
+            23 - RETID;
+            24 - Royalties, Assistência Técnica, Científica e Assemelhados;
+            25 - Serviços de avaliação da conformidade vinculados aos Acordos da OMC;
+            26 - ZPE;
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="movTempBens" type="TSMovTempBens">
+				<xsd:annotation>
+					<xsd:documentation>
+            Vínculo da Operação à Movimentação Temporária de Bens:
+            0 - Desconhecido (tipo não informado na nota de origem);
+            1 - Não;
+            2 - Vinculada - Declaração de Importação;
+            3 - Vinculada - Declaração de Exportação;
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="nDI" type="TSNumDocImport" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Número da Declaração de Importação (DI/DSI/DA/DRI-E) averbado</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="nRE" type="TSNumRegExport" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Número do Registro de Exportação (RE) averbado</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="mdic" type="TSEnvMDIC">
+				<xsd:annotation>
+					<xsd:documentation>
+            Compartilhar as informações da NFS-e gerada a partir desta DPS com a Secretaria de Comércio Exterior:
+            0 - Não enviar para o MDIC;
+            1 - Enviar para o MDIC;
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>			
+
+	<xsd:complexType name="tcDadosServico">
+		<xsd:sequence>
+			<xsd:element name="Valores" type="tcValoresDeclaracaoServico"
+				minOccurs="1" maxOccurs="1" />
+			<xsd:element name="IssRetido" type="tsSimNao" minOccurs="1"
+				maxOccurs="1" />
+			<xsd:element name="ResponsavelRetencao" type="tsResponsavelRetencao"
+				minOccurs="0" maxOccurs="1" />
+			<xsd:element name="ItemListaServico" type="tsItemListaServico"
+				minOccurs="1" maxOccurs="1" />
+			<xsd:element name="CodigoCnae" type="tsCodigoCnae"
+				minOccurs="0" maxOccurs="1" />
+			<xsd:element name="CodigoTributacaoMunicipio" type="tsCodigoTributacao"
+				minOccurs="0" maxOccurs="1" />
+			<xsd:element name="CodigoNbs" type="tsCodigoNbs"
+				minOccurs="1" maxOccurs="1" />
+			<xsd:element name="Discriminacao" type="tsDiscriminacao"
+				minOccurs="1" maxOccurs="1" />
+			<xsd:element name="CodigoMunicipio" type="tsCodigoMunicipioIbge"
+				minOccurs="1" maxOccurs="1" />
+			<xsd:element name="CodigoPais" type="tsCodigoPaisIbge"
+				minOccurs="0" maxOccurs="1" />
+			<xsd:element name="ExigibilidadeISS" type="tsExigibilidadeISS"
+				minOccurs="1" maxOccurs="1" />
+			<xsd:element name="IdentifNaoExigibilidade" type="tsIdentifNaoExigibilidade"
+				minOccurs="0" maxOccurs="1" />
+			<xsd:element name="MunicipioIncidencia" type="tsCodigoMunicipioIbge"
+				minOccurs="0" maxOccurs="1" />
+			<xsd:element name="NumeroProcesso" type="tsNumeroProcesso"
+				minOccurs="0" maxOccurs="1" />
+			<xsd:element name="comExt" type="TCComExterior" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Grupo de informações relativas à exportação/importação de serviço prestado</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>					
+		</xsd:sequence>
+	</xsd:complexType>
+
+	<xsd:complexType name="tcDadosConstrucaoCivil">
+		<xsd:choice minOccurs="1" maxOccurs="1">
+			<xsd:sequence minOccurs="1" maxOccurs="1">
+				<xsd:element name="CodigoObra" type="tsCodigoObra"
+					minOccurs="1" maxOccurs="1" />
+				<xsd:element name="Art" type="tsArt" minOccurs="0"
+					maxOccurs="1" />
+			</xsd:sequence>
+			<xsd:sequence>
+				<xsd:element name="Art" type="tsArt" minOccurs="1"
+					maxOccurs="1" />
+			</xsd:sequence>
+		</xsd:choice>
+	</xsd:complexType>
+
+	<xsd:complexType name="tcEvento">
+		<xsd:choice minOccurs="1" maxOccurs="1">
+			<xsd:sequence minOccurs="1" maxOccurs="1">
+				<xsd:element name="IdentificacaoEvento" type="tsIdentificacaoEvento"
+					minOccurs="1" maxOccurs="1" />
+				<xsd:element name="DescricaoEvento" type="tsDescricaoEvento"
+					minOccurs="0" maxOccurs="1" />
+			</xsd:sequence>
+			<xsd:sequence>
+				<xsd:element name="DescricaoEvento" type="tsDescricaoEvento"
+					minOccurs="1" maxOccurs="1" />
+			</xsd:sequence>
+		</xsd:choice>
+	</xsd:complexType>
+
+	<xsd:complexType name="tcDadosPrestador">
+		<xsd:sequence>
+			<xsd:element name="RazaoSocial" type="tsRazaoSocial"
+				minOccurs="1" maxOccurs="1" />
+			<xsd:element name="NomeFantasia" type="tsNomeFantasia"
+				minOccurs="0" maxOccurs="1" />
+			<xsd:element name="Endereco" type="tcEndereco" minOccurs="1"
+				maxOccurs="1" />
+			<xsd:element name="Contato" type="tcContato" minOccurs="0"
+				maxOccurs="1" />
+		</xsd:sequence>
+	</xsd:complexType>
+
+	<xsd:complexType name="tcIdentificacaoNfseDeducao">
+		<xsd:sequence>
+			<xsd:element name="CodigoMunicipioGerador" type="tsCodigoMunicipioIbge"
+				minOccurs="1" maxOccurs="1" />
+			<xsd:element name="NumeroNfse" type="tsNumeroNfse"
+				minOccurs="1" maxOccurs="1" />
+			<xsd:element name="CodigoVerificacao" type="tsCodigoVerificacao"
+				minOccurs="0" maxOccurs="1" />
+		</xsd:sequence>
+	</xsd:complexType>
+
+	<xsd:complexType name="tcIdentificacaoNfeDeducao">
+		<xsd:sequence>
+			<xsd:element name="NumeroNfe" type="tsNumeroNfe"
+				minOccurs="1" maxOccurs="1" />
+			<xsd:element name="UfNfe" type="tsUf" minOccurs="1"
+				maxOccurs="1" />
+			<xsd:element name="ChaveAcessoNfe" type="tsChaveAcessoNfe"
+				minOccurs="0" maxOccurs="1" />
+		</xsd:sequence>
+	</xsd:complexType>
+
+	<xsd:complexType name="tcOutroDocumentoDeducao">
+		<xsd:sequence>
+			<xsd:element name="IdentificacaoDocumento" type="tsIdentificacaoDocumento"
+				minOccurs="1" maxOccurs="1" />
+		</xsd:sequence>
+	</xsd:complexType>
+
+	<xsd:complexType name="tcIdentificacaoDocumentoDeducao">
+		<xsd:sequence>
+			<xsd:choice>
+				<xsd:element name="IdentificacaoNfse" type="tcIdentificacaoNfseDeducao"
+					minOccurs="1" maxOccurs="1" />
+				<xsd:element name="IdentificacaoNfe" type="tcIdentificacaoNfeDeducao"
+					minOccurs="1" maxOccurs="1" />
+				<xsd:element name="OutroDocumento" type="tcOutroDocumentoDeducao"
+					minOccurs="1" maxOccurs="1" />
+			</xsd:choice>
+		</xsd:sequence>
+	</xsd:complexType>
+
+	<xsd:complexType name="tcIdentificacaoFornecedor">
+		<xsd:sequence>
+			<xsd:element name="CpfCnpj" type="tcCpfCnpj" minOccurs="1"
+				maxOccurs="1" />
+		</xsd:sequence>
+	</xsd:complexType>
+
+	<xsd:complexType name="tcFornecedorExterior">
+		<xsd:sequence>
+			<xsd:element name="NifFornecedor" type="tsNif" minOccurs="0"
+				maxOccurs="1" />
+			<xsd:element name="CodigoPais" type="tsCodigoPaisIbge"
+				minOccurs="1" maxOccurs="1" />
+		</xsd:sequence>
+	</xsd:complexType>
+
+	<xsd:complexType name="tcDadosFornecedor">
+		<xsd:sequence>
+			<xsd:choice>
+				<xsd:element name="IdentificacaoFornecedor" type="tcIdentificacaoFornecedor"
+					minOccurs="1" maxOccurs="1" />
+				<xsd:element name="FornecedorExterior" type="tcFornecedorExterior"
+					minOccurs="1" maxOccurs="1" />
+			</xsd:choice>
+		</xsd:sequence>
+	</xsd:complexType>
+
+	<xsd:complexType name="tcDadosDeducao">
+		<xsd:sequence>
+			<xsd:element name="TipoDeducao" type="tsTipoDeducao"
+				minOccurs="1" maxOccurs="1" />
+			<xsd:element name="DescricaoDeducao" type="tsDescricaoDeducao"
+				minOccurs="0" maxOccurs="1" />
+			<xsd:element name="IdentificacaoDocumentoDeducao" type="tcIdentificacaoDocumentoDeducao"
+				minOccurs="1" maxOccurs="1" />
+			<xsd:element name="DadosFornecedor" type="tcDadosFornecedor"
+				minOccurs="1" maxOccurs="1" />
+			<xsd:element name="DataEmissao" type="xsd:date"
+				minOccurs="1" maxOccurs="1" />
+			<xsd:element name="ValorDedutivel" type="tsValor"
+				minOccurs="1" maxOccurs="1" />
+			<xsd:element name="ValorUtilizadoDeducao" type="tsValor"
+				minOccurs="1" maxOccurs="1" />
+		</xsd:sequence>
+	</xsd:complexType>
+
+	<xsd:complexType name="tcInfRps">
+		<xsd:sequence>
+			<xsd:element name="IdentificacaoRps" type="tcIdentificacaoRps"
+				minOccurs="0" maxOccurs="1" />
+			<xsd:element name="DataEmissao" type="xsd:date"
+				minOccurs="1" maxOccurs="1" />
+			<xsd:element name="Status" type="tsStatusRps" minOccurs="1"
+				maxOccurs="1" />
+			<xsd:element name="RpsSubstituido" type="tcIdentificacaoRps"
+				minOccurs="0" maxOccurs="1" />
+		</xsd:sequence>
+		<xsd:attribute name="Id" type="tsIdTag" />
+	</xsd:complexType>
+
+	<xsd:complexType name="tcInfDeclaracaoPrestacaoServico">
+		<xsd:sequence>
+			<xsd:element name="Rps" type="tcInfRps" minOccurs="0"
+				maxOccurs="1" />
+			<xsd:element name="Competencia" type="xsd:date"
+				minOccurs="1" maxOccurs="1" />
+			<xsd:element name="Servico" type="tcDadosServico"
+				minOccurs="1" maxOccurs="1" />
+			<xsd:element name="Prestador" type="tcIdentificacaoPessoaEmpresa"
+				minOccurs="1" maxOccurs="1" />
+			<xsd:element name="TomadorServico" type="tcDadosTomador"
+				minOccurs="0" maxOccurs="1" />
+			<xsd:element name="Intermediario" type="tcDadosIntermediario"
+				minOccurs="0" maxOccurs="1" />
+			<xsd:element name="ConstrucaoCivil" type="tcDadosConstrucaoCivil"
+				minOccurs="0" maxOccurs="1" />
+			<xsd:element name="RegimeEspecialTributacao" type="tsRegimeEspecialTributacao"
+				minOccurs="0" maxOccurs="1" />
+			<xsd:element name="OptanteSimplesNacional" type="tsSimNao"
+				minOccurs="1" maxOccurs="1" />
+			<xsd:element name="IncentivoFiscal" type="tsSimNao"
+				minOccurs="1" maxOccurs="1" />
+			<xsd:element name="Evento" type="tcEvento" minOccurs="0"
+				maxOccurs="1" />
+			<xsd:element name="InformacoesComplementares" type="tsInformacoesComplementares"
+				minOccurs="0" maxOccurs="1" />
+			<xsd:element name="Deducao" type="tcDadosDeducao"
+				minOccurs="0" maxOccurs="unbounded" />
+		</xsd:sequence>
+		<xsd:attribute name="Id" type="tsIdTag" />
+	</xsd:complexType>
+
+	<xsd:complexType name="tcDeclaracaoPrestacaoServico">
+		<xsd:sequence>
+			<xsd:element name="InfDeclaracaoPrestacaoServico" type="tcInfDeclaracaoPrestacaoServico"
+				minOccurs="1" maxOccurs="1" />
+			<xsd:element ref="dsig:Signature" minOccurs="0"
+				maxOccurs="1" />
+		</xsd:sequence>
+	</xsd:complexType>
+
+	<xsd:complexType name="tcIdentificacaoNfse">
+		<xsd:sequence>
+			<xsd:element name="Numero" type="tsNumeroNfse" minOccurs="1"
+				maxOccurs="1" />
+			<xsd:element name="CpfCnpj" type="tcCpfCnpj" minOccurs="1"
+				maxOccurs="1" />
+			<xsd:element name="InscricaoMunicipal" type="tsInscricaoMunicipal"
+				minOccurs="0" maxOccurs="1" />
+			<xsd:element name="CodigoMunicipio" type="tsCodigoMunicipioIbge"
+				minOccurs="1" maxOccurs="1" />
+		</xsd:sequence>
+	</xsd:complexType>
+
+	<xsd:complexType name="tcInfNfse">
+		<xsd:sequence>
+			<xsd:element name="Numero" type="tsNumeroNfse" minOccurs="1"
+				maxOccurs="1" />
+			<xsd:element name="CodigoVerificacao" type="tsCodigoVerificacao"
+				minOccurs="1" maxOccurs="1" />
+			<xsd:element name="DataEmissao" type="xsd:dateTime"
+				minOccurs="1" maxOccurs="1" />
+			<xsd:element name="NfseSubstituida" type="tsNumeroNfse"
+				minOccurs="0" maxOccurs="1" />
+			<xsd:element name="OutrasInformacoes" type="tsOutrasInformacoes"
+				minOccurs="0" maxOccurs="1" />
+			<xsd:element name="ValoresNfse" type="tcValoresNfse"
+				minOccurs="1" maxOccurs="1" />
+			<xsd:element name="DescricaoCodigoTributacaoMunicipio"
+				type="tsDescricaoCodigoTributacaoMunicipio" minOccurs="0" maxOccurs="1" />
+			<xsd:element name="ValorCredito" type="tsValor"
+				minOccurs="0" maxOccurs="1" />
+			<xsd:element name="PrestadorServico" type="tcDadosPrestador"
+				minOccurs="1" maxOccurs="1" />
+			<xsd:element name="OrgaoGerador" type="tcIdentificacaoOrgaoGerador"
+				minOccurs="1" maxOccurs="1" />
+			<xsd:element name="DeclaracaoPrestacaoServico" type="tcDeclaracaoPrestacaoServico"
+				minOccurs="1" maxOccurs="1" />
+		</xsd:sequence>
+		<xsd:attribute name="Id" type="tsIdTag" />
+	</xsd:complexType>
+
+	<xsd:complexType name="tcNfse">
+		<xsd:sequence>
+			<xsd:element name="InfNfse" type="tcInfNfse" minOccurs="1"
+				maxOccurs="1" />
+			<xsd:element ref="dsig:Signature" minOccurs="0"
+				maxOccurs="1" />
+		</xsd:sequence>
+		<xsd:attribute name="versao" type="tsVersao" use="required" />
+	</xsd:complexType>
+
+	<xsd:complexType name="tcInfPedidoCancelamento">
+		<xsd:sequence>
+			<xsd:element name="IdentificacaoNfse" type="tcIdentificacaoNfse"
+				minOccurs="1" maxOccurs="1" />
+			<xsd:element name="CodigoCancelamento" type="tsCodigoCancelamentoNfse"
+				minOccurs="1" maxOccurs="1" />
+		</xsd:sequence>
+		<xsd:attribute name="Id" type="tsIdTag" />
+	</xsd:complexType>
+
+	<xsd:complexType name="tcPedidoCancelamento">
+		<xsd:sequence>
+			<xsd:element name="InfPedidoCancelamento" type="tcInfPedidoCancelamento"
+				minOccurs="1" maxOccurs="1" />
+			<xsd:element ref="dsig:Signature" minOccurs="0"
+				maxOccurs="1" />
+		</xsd:sequence>
+	</xsd:complexType>
+
+	<xsd:complexType name="tcConfirmacaoCancelamento">
+		<xsd:sequence>
+			<xsd:element name="Pedido" type="tcPedidoCancelamento"
+				minOccurs="1" maxOccurs="1" />
+			<xsd:element name="DataHora" type="xsd:dateTime"
+				minOccurs="1" maxOccurs="1" />
+		</xsd:sequence>
+		<xsd:attribute name="Id" type="tsIdTag" />
+	</xsd:complexType>
+
+	<xsd:complexType name="tcCancelamentoNfse">
+		<xsd:sequence>
+			<xsd:element name="Confirmacao" type="tcConfirmacaoCancelamento"
+				minOccurs="1" maxOccurs="1" />
+			<xsd:element ref="dsig:Signature" minOccurs="0"
+				maxOccurs="1" />
+		</xsd:sequence>
+		<xsd:attribute name="versao" type="tsVersao" use="required" />
+	</xsd:complexType>
+
+	<xsd:complexType name="tcRetCancelamento">
+		<xsd:sequence>
+			<xsd:element name="NfseCancelamento" type="tcCancelamentoNfse"
+				minOccurs="1" maxOccurs="1" />
+		</xsd:sequence>
+	</xsd:complexType>
+
+	<xsd:complexType name="tcInfSubstituicaoNfse">
+		<xsd:sequence>
+			<xsd:element name="NfseSubstituidora" type="tsNumeroNfse"
+				minOccurs="1" maxOccurs="1" />
+		</xsd:sequence>
+		<xsd:attribute name="Id" type="tsIdTag" />
+	</xsd:complexType>
+
+	<xsd:complexType name="tcSubstituicaoNfse">
+		<xsd:sequence>
+			<xsd:element name="SubstituicaoNfse" type="tcInfSubstituicaoNfse"
+				minOccurs="1" maxOccurs="1" />
+			<xsd:element ref="dsig:Signature" minOccurs="0"
+				maxOccurs="2" />
+		</xsd:sequence>
+		<xsd:attribute name="versao" type="tsVersao" use="required" />
+	</xsd:complexType>
+
+	<xsd:complexType name="tcCompNfse">
+		<xsd:sequence>
+			<xsd:element name="Nfse" type="tcNfse" minOccurs="1"
+				maxOccurs="1" />
+			<xsd:element name="NfseCancelamento" type="tcCancelamentoNfse"
+				minOccurs="0" maxOccurs="1" />
+			<xsd:element name="NfseSubstituicao" type="tcSubstituicaoNfse"
+				minOccurs="0" maxOccurs="1" />
+			<xsd:element name="IBSCBSTotal" type="TCRTCIBSCBS" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Grupo de informações geradas pelo sistema GISS referentes ao IBS e à CBS automaticamente na conversao em nfse</xsd:documentation>
+					<!--As Informações desse grupo nao devem ser recebidas no RPS, as mesmas serao geradas automaticamente na conversao em nfse-->
+				</xsd:annotation>
+				</xsd:element>						
+     		<xsd:element name="ChaveNotaNacional" type="tpChaveNotaNacional" minOccurs ="0" maxOccurs ="1">
+        		<xsd:annotation>
+          			<xsd:documentation>chave de acesso da NFSE no ADN</xsd:documentation>
+        		</xsd:annotation>
+      		</xsd:element>						
+		</xsd:sequence>
+	</xsd:complexType>
+
+	<xsd:complexType name="tcMensagemRetorno">
+		<xsd:sequence>
+			<xsd:element name="Codigo" type="tsCodigoMensagemAlerta"
+				minOccurs="1" maxOccurs="1" />
+			<xsd:element name="Mensagem" type="tsDescricaoMensagemAlerta"
+				minOccurs="1" maxOccurs="1" />
+			<xsd:element name="Correcao" type="tsDescricaoMensagemAlerta"
+				minOccurs="0" maxOccurs="1" />
+		</xsd:sequence>
+	</xsd:complexType>
+
+	<xsd:complexType name="tcMensagemRetornoLote">
+		<xsd:sequence>
+			<xsd:element name="IdentificacaoRps" type="tcIdentificacaoRps"
+				minOccurs="1" maxOccurs="1" />
+			<xsd:element name="Codigo" type="tsCodigoMensagemAlerta"
+				minOccurs="1" maxOccurs="1" />
+			<xsd:element name="Mensagem" type="tsDescricaoMensagemAlerta"
+				minOccurs="1" maxOccurs="1" />
+		</xsd:sequence>
+	</xsd:complexType>
+
+	<xsd:complexType name="tcLoteRps">
+		<xsd:sequence>
+			<xsd:element name="NumeroLote" type="tsNumeroLote"
+				minOccurs="1" maxOccurs="1" />
+			<xsd:element name="Prestador" type="tcIdentificacaoPessoaEmpresa"
+				minOccurs="1" maxOccurs="1" />
+			<xsd:element name="QuantidadeRps" type="tsQuantidadeRps"
+				minOccurs="1" maxOccurs="1" />
+			<xsd:element name="ListaRps" minOccurs="1" maxOccurs="1">
+				<xsd:complexType>
+					<xsd:sequence>
+						<xsd:element name="Rps" type="tcDeclaracaoPrestacaoServico"
+							minOccurs="1" maxOccurs="unbounded">
+						</xsd:element>
+					</xsd:sequence>
+				</xsd:complexType>
+			</xsd:element>
+		</xsd:sequence>
+		<xsd:attribute name="Id" type="tsIdTag" />
+		<xsd:attribute name="versao" type="tsVersao" use="required" />
+	</xsd:complexType>
+
+	<xsd:element name="ListaMensagemRetornoLote">
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element name="MensagemRetorno" type="tcMensagemRetornoLote"
+					minOccurs="1" maxOccurs="unbounded" />
+			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="ListaMensagemRetorno">
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element name="MensagemRetorno" type="tcMensagemRetorno"
+					minOccurs="1" maxOccurs="unbounded" />
+			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="ListaMensagemAlertaRetorno">
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element name="MensagemRetorno" type="tcMensagemRetorno"
+					minOccurs="1" maxOccurs="unbounded" />
+			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="CompNfse" type="tcCompNfse" />
+
+</xsd:schema>
+

--- a/providers/gissonline/xsd/xmldsig-core-schema20020212.xsd
+++ b/providers/gissonline/xsd/xmldsig-core-schema20020212.xsd
@@ -1,0 +1,316 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Schema for XML Signatures
+    http://www.w3.org/2000/09/xmldsig#
+    $Revision: 1.7 $ on $Date: 2007/09/20 19:06:50 $ by $Author: p052373 $
+
+    Copyright 2001 The Internet Society and W3C (Massachusetts Institute
+    of Technology, Institut National de Recherche en Informatique et en
+    Automatique, Keio University). All Rights Reserved.
+    http://www.w3.org/Consortium/Legal/
+
+    This document is governed by the W3C Software License [1] as described
+    in the FAQ [2].
+
+    [1] http://www.w3.org/Consortium/Legal/copyright-software-19980720
+    [2] http://www.w3.org/Consortium/Legal/IPR-FAQ-20000620.html#DTD
+-->
+
+<!--
+
+Download em 23/02/2007
+Link: 
+	http://www.w3.org/TR/xmldsig-core/#sec-Schema
+	http://www.w3.org/TR/xmldsig-core/xmldsig-core-schema.xsd
+
+-->
+
+<schema xmlns="http://www.w3.org/2001/XMLSchema"
+        xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+        targetNamespace="http://www.w3.org/2000/09/xmldsig#"
+        version="0.1" elementFormDefault="qualified"> 
+
+<!-- Basic Types Defined for Signatures -->
+
+<simpleType name="CryptoBinary">
+  <restriction base="base64Binary">
+  </restriction>
+</simpleType>
+
+<!-- Start Signature -->
+
+<element name="Signature" type="ds:SignatureType"/>
+<complexType name="SignatureType">
+  <sequence> 
+    <element ref="ds:SignedInfo"/> 
+    <element ref="ds:SignatureValue"/> 
+    <element ref="ds:KeyInfo" minOccurs="0"/> 
+    <element ref="ds:Object" minOccurs="0" maxOccurs="unbounded"/> 
+  </sequence>  
+  <attribute name="Id" type="ID" use="optional"/>
+</complexType>
+
+  <element name="SignatureValue" type="ds:SignatureValueType"/> 
+  <complexType name="SignatureValueType">
+    <simpleContent>
+      <extension base="base64Binary">
+        <attribute name="Id" type="ID" use="optional"/>
+      </extension>
+    </simpleContent>
+  </complexType>
+
+<!-- Start SignedInfo -->
+
+<element name="SignedInfo" type="ds:SignedInfoType"/>
+<complexType name="SignedInfoType">
+  <sequence> 
+    <element ref="ds:CanonicalizationMethod"/> 
+    <element ref="ds:SignatureMethod"/> 
+    <element ref="ds:Reference" maxOccurs="unbounded"/> 
+  </sequence>  
+  <attribute name="Id" type="ID" use="optional"/> 
+</complexType>
+
+  <element name="CanonicalizationMethod" type="ds:CanonicalizationMethodType"/> 
+  <complexType name="CanonicalizationMethodType" mixed="true">
+    <sequence>
+      <any namespace="##any" minOccurs="0" maxOccurs="unbounded"/>
+      <!-- (0,unbounded) elements from (1,1) namespace -->
+    </sequence>
+    <attribute name="Algorithm" type="anyURI" use="required"/> 
+  </complexType>
+
+  <element name="SignatureMethod" type="ds:SignatureMethodType"/>
+  <complexType name="SignatureMethodType" mixed="true">
+    <sequence>
+      <element name="HMACOutputLength" minOccurs="0" type="ds:HMACOutputLengthType"/>
+      <any namespace="##other" minOccurs="0" maxOccurs="unbounded"/>
+      <!-- (0,unbounded) elements from (1,1) external namespace -->
+    </sequence>
+    <attribute name="Algorithm" type="anyURI" use="required"/> 
+  </complexType>
+
+<!-- Start Reference -->
+
+<element name="Reference" type="ds:ReferenceType"/>
+<complexType name="ReferenceType">
+  <sequence> 
+    <element ref="ds:Transforms" minOccurs="0"/> 
+    <element ref="ds:DigestMethod"/> 
+    <element ref="ds:DigestValue"/> 
+  </sequence>
+  <attribute name="Id" type="ID" use="optional"/> 
+  <attribute name="URI" type="anyURI" use="optional"/> 
+  <attribute name="Type" type="anyURI" use="optional"/> 
+</complexType>
+
+  <element name="Transforms" type="ds:TransformsType"/>
+  <complexType name="TransformsType">
+    <sequence>
+      <element ref="ds:Transform" maxOccurs="unbounded"/>  
+    </sequence>
+  </complexType>
+
+  <element name="Transform" type="ds:TransformType"/>
+  <complexType name="TransformType" mixed="true">
+    <choice minOccurs="0" maxOccurs="unbounded"> 
+      <any namespace="##other" processContents="lax"/>
+      <!-- (1,1) elements from (0,unbounded) namespaces -->
+      <element name="XPath" type="string"/> 
+    </choice>
+    <attribute name="Algorithm" type="anyURI" use="required"/> 
+  </complexType>
+
+<!-- End Reference -->
+
+<element name="DigestMethod" type="ds:DigestMethodType"/>
+<complexType name="DigestMethodType" mixed="true"> 
+  <sequence>
+    <any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+  </sequence>    
+  <attribute name="Algorithm" type="anyURI" use="required"/> 
+</complexType>
+
+<element name="DigestValue" type="ds:DigestValueType"/>
+<simpleType name="DigestValueType">
+  <restriction base="base64Binary"/>
+</simpleType>
+
+<!-- End SignedInfo -->
+
+<!-- Start KeyInfo -->
+
+<element name="KeyInfo" type="ds:KeyInfoType"/> 
+<complexType name="KeyInfoType" mixed="true">
+  <choice maxOccurs="unbounded">     
+    <element ref="ds:KeyName"/> 
+    <element ref="ds:KeyValue"/> 
+    <element ref="ds:RetrievalMethod"/> 
+    <element ref="ds:X509Data"/> 
+    <element ref="ds:PGPData"/> 
+    <element ref="ds:SPKIData"/>
+    <element ref="ds:MgmtData"/>
+    <any processContents="lax" namespace="##other"/>
+    <!-- (1,1) elements from (0,unbounded) namespaces -->
+  </choice>
+  <attribute name="Id" type="ID" use="optional"/> 
+</complexType>
+
+  <element name="KeyName" type="string"/>
+  <element name="MgmtData" type="string"/>
+
+  <element name="KeyValue" type="ds:KeyValueType"/> 
+  <complexType name="KeyValueType" mixed="true">
+   <choice>
+     <element ref="ds:DSAKeyValue"/>
+     <element ref="ds:RSAKeyValue"/>
+     <any namespace="##other" processContents="lax"/>
+   </choice>
+  </complexType>
+
+  <element name="RetrievalMethod" type="ds:RetrievalMethodType"/> 
+  <complexType name="RetrievalMethodType">
+    <sequence>
+      <element ref="ds:Transforms" minOccurs="0"/> 
+    </sequence>  
+    <attribute name="URI" type="anyURI"/>
+    <attribute name="Type" type="anyURI" use="optional"/>
+  </complexType>
+
+<!-- Start X509Data -->
+
+<element name="X509Data" type="ds:X509DataType"/> 
+<complexType name="X509DataType">
+  <sequence maxOccurs="unbounded">
+    <choice>
+      <element name="X509IssuerSerial" type="ds:X509IssuerSerialType"/>
+      <element name="X509SKI" type="base64Binary"/>
+      <element name="X509SubjectName" type="string"/>
+      <element name="X509Certificate" type="base64Binary"/>
+      <element name="X509CRL" type="base64Binary"/>
+      <any namespace="##other" processContents="lax"/>
+    </choice>
+  </sequence>
+</complexType>
+
+<complexType name="X509IssuerSerialType"> 
+  <sequence> 
+    <element name="X509IssuerName" type="string"/> 
+    <element name="X509SerialNumber" type="integer"/> 
+  </sequence>
+</complexType>
+
+<!-- End X509Data -->
+
+<!-- Begin PGPData -->
+
+<element name="PGPData" type="ds:PGPDataType"/> 
+<complexType name="PGPDataType"> 
+  <choice>
+    <sequence>
+      <element name="PGPKeyID" type="base64Binary"/> 
+      <element name="PGPKeyPacket" type="base64Binary" minOccurs="0"/> 
+      <any namespace="##other" processContents="lax" minOccurs="0"
+       maxOccurs="unbounded"/>
+    </sequence>
+    <sequence>
+      <element name="PGPKeyPacket" type="base64Binary"/> 
+      <any namespace="##other" processContents="lax" minOccurs="0"
+       maxOccurs="unbounded"/>
+    </sequence>
+  </choice>
+</complexType>
+
+<!-- End PGPData -->
+
+<!-- Begin SPKIData -->
+
+<element name="SPKIData" type="ds:SPKIDataType"/> 
+<complexType name="SPKIDataType">
+  <sequence maxOccurs="unbounded">
+    <element name="SPKISexp" type="base64Binary"/>
+    <any namespace="##other" processContents="lax" minOccurs="0"/>
+  </sequence>
+</complexType> 
+
+<!-- End SPKIData -->
+
+<!-- End KeyInfo -->
+
+<!-- Start Object (Manifest, SignatureProperty) -->
+
+<element name="Object" type="ds:ObjectType"/> 
+<complexType name="ObjectType" mixed="true">
+  <sequence minOccurs="0" maxOccurs="unbounded">
+    <any namespace="##any" processContents="lax"/>
+  </sequence>
+  <attribute name="Id" type="ID" use="optional"/> 
+  <attribute name="MimeType" type="string" use="optional"/> <!-- add a grep facet -->
+  <attribute name="Encoding" type="anyURI" use="optional"/> 
+</complexType>
+
+<element name="Manifest" type="ds:ManifestType"/> 
+<complexType name="ManifestType">
+  <sequence>
+    <element ref="ds:Reference" maxOccurs="unbounded"/> 
+  </sequence>
+  <attribute name="Id" type="ID" use="optional"/> 
+</complexType>
+
+<element name="SignatureProperties" type="ds:SignaturePropertiesType"/> 
+<complexType name="SignaturePropertiesType">
+  <sequence>
+    <element ref="ds:SignatureProperty" maxOccurs="unbounded"/> 
+  </sequence>
+  <attribute name="Id" type="ID" use="optional"/> 
+</complexType>
+
+   <element name="SignatureProperty" type="ds:SignaturePropertyType"/> 
+   <complexType name="SignaturePropertyType" mixed="true">
+     <choice maxOccurs="unbounded">
+       <any namespace="##other" processContents="lax"/>
+       <!-- (1,1) elements from (1,unbounded) namespaces -->
+     </choice>
+     <attribute name="Target" type="anyURI" use="required"/> 
+     <attribute name="Id" type="ID" use="optional"/> 
+   </complexType>
+
+<!-- End Object (Manifest, SignatureProperty) -->
+
+<!-- Start Algorithm Parameters -->
+
+<simpleType name="HMACOutputLengthType">
+  <restriction base="integer"/>
+</simpleType>
+
+<!-- Start KeyValue Element-types -->
+
+<element name="DSAKeyValue" type="ds:DSAKeyValueType"/>
+<complexType name="DSAKeyValueType">
+  <sequence>
+    <sequence minOccurs="0">
+      <element name="P" type="ds:CryptoBinary"/>
+      <element name="Q" type="ds:CryptoBinary"/>
+    </sequence>
+    <element name="G" type="ds:CryptoBinary" minOccurs="0"/>
+    <element name="Y" type="ds:CryptoBinary"/>
+    <element name="J" type="ds:CryptoBinary" minOccurs="0"/>
+    <sequence minOccurs="0">
+      <element name="Seed" type="ds:CryptoBinary"/>
+      <element name="PgenCounter" type="ds:CryptoBinary"/>
+    </sequence>
+  </sequence>
+</complexType>
+
+<element name="RSAKeyValue" type="ds:RSAKeyValueType"/>
+<complexType name="RSAKeyValueType">
+  <sequence>
+    <element name="Modulus" type="ds:CryptoBinary"/> 
+    <element name="Exponent" type="ds:CryptoBinary"/> 
+  </sequence>
+</complexType> 
+
+<!-- End KeyValue Element-types -->
+
+<!-- End Signature -->
+
+</schema>

--- a/tests/SemanaIA.ServiceInvoice.UnitTests/SchemaEngine/AbrasfXsdValidationTests.cs
+++ b/tests/SemanaIA.ServiceInvoice.UnitTests/SchemaEngine/AbrasfXsdValidationTests.cs
@@ -1,0 +1,175 @@
+using System.Xml;
+using System.Xml.Schema;
+using Shouldly;
+
+namespace SemanaIA.ServiceInvoice.UnitTests.SchemaEngine;
+
+public class AbrasfXsdValidationTests
+{
+    [Fact]
+    public void Given_AbrasfMinimalXml_Should_ValidateAgainstXsd()
+    {
+        // Arrange
+        var xml = BuildAbrasfMinimalXml();
+
+        // Act
+        var errors = ValidateAgainstAbrasfXsd(xml);
+
+        // Assert
+        errors.ShouldBeEmpty($"Minimal ABRASF XML should pass XSD:\n{string.Join("\n", errors)}");
+    }
+
+    [Fact]
+    public void Given_AbrasfXmlMissingRequired_Should_FailValidation()
+    {
+        // Arrange — missing Competencia
+        var xml = BuildAbrasfMinimalXml().Replace("<Competencia>2026-01-20</Competencia>", "");
+
+        // Act
+        var errors = ValidateAgainstAbrasfXsd(xml);
+
+        // Assert
+        errors.Count.ShouldBeGreaterThan(0, "Missing required element should fail");
+    }
+
+    [Fact]
+    public void Given_AbrasfChoiceCpfCnpj_WithOnlyOneBranch_Should_Pass()
+    {
+        // Arrange — CpfCnpj with only Cnpj (valid choice)
+        var xml = BuildAbrasfMinimalXml();
+
+        // Act
+        var errors = ValidateAgainstAbrasfXsd(xml);
+
+        // Assert
+        errors.ShouldBeEmpty("Single choice element should pass");
+    }
+
+    [Fact]
+    public void Given_AbrasfChoiceCpfCnpj_WithBothBranches_Should_Fail()
+    {
+        // Arrange — CpfCnpj with both Cpf and Cnpj (violates choice)
+        var xml = BuildAbrasfMinimalXml()
+            .Replace("<Cnpj>00000000000000</Cnpj>", "<Cpf>12345678901</Cpf><Cnpj>00000000000000</Cnpj>");
+
+        // Act
+        var errors = ValidateAgainstAbrasfXsd(xml);
+
+        // Assert
+        errors.Count.ShouldBeGreaterThan(0, "Both choice elements should fail");
+    }
+
+    [Fact]
+    public void Given_AbrasfWrongSequenceOrder_Should_FailValidation()
+    {
+        // Arrange — swap Servico and Competencia (wrong order)
+        var ns = "http://www.abrasf.org.br/nfse.xsd";
+        var xml = $@"<?xml version=""1.0"" encoding=""utf-8""?>
+<EnviarLoteRpsEnvio xmlns=""{ns}"">
+  <LoteRps Id=""lote1"" versao=""2.04"">
+    <NumeroLote>1</NumeroLote>
+    <Prestador><CpfCnpj><Cnpj>00000000000000</Cnpj></CpfCnpj></Prestador>
+    <QuantidadeRps>1</QuantidadeRps>
+    <ListaRps>
+      <Rps>
+        <InfDeclaracaoPrestacaoServico>
+          <Servico>
+            <Valores><ValorServicos>1000.00</ValorServicos></Valores>
+            <IssRetido>2</IssRetido>
+            <ItemListaServico>01.01</ItemListaServico>
+            <Discriminacao>Teste</Discriminacao>
+            <CodigoMunicipio>3550308</CodigoMunicipio>
+            <ExigibilidadeISS>1</ExigibilidadeISS>
+          </Servico>
+          <Competencia>2026-01-20</Competencia>
+          <Prestador><CpfCnpj><Cnpj>00000000000000</Cnpj></CpfCnpj></Prestador>
+          <OptanteSimplesNacional>2</OptanteSimplesNacional>
+          <IncentivoFiscal>2</IncentivoFiscal>
+        </InfDeclaracaoPrestacaoServico>
+      </Rps>
+    </ListaRps>
+  </LoteRps>
+</EnviarLoteRpsEnvio>";
+
+        // Act
+        var errors = ValidateAgainstAbrasfXsd(xml);
+
+        // Assert
+        errors.Count.ShouldBeGreaterThan(0, "Wrong sequence order should fail");
+    }
+
+    // ==========================================================
+    // Helpers privados (final da classe)
+    // ==========================================================
+
+    private static string BuildAbrasfMinimalXml()
+    {
+        var ns = "http://www.abrasf.org.br/nfse.xsd";
+        return $@"<?xml version=""1.0"" encoding=""utf-8""?>
+<EnviarLoteRpsEnvio xmlns=""{ns}"">
+  <LoteRps Id=""lote1"" versao=""2.04"">
+    <NumeroLote>1</NumeroLote>
+    <Prestador><CpfCnpj><Cnpj>00000000000000</Cnpj></CpfCnpj></Prestador>
+    <QuantidadeRps>1</QuantidadeRps>
+    <ListaRps>
+      <Rps>
+        <InfDeclaracaoPrestacaoServico>
+          <Competencia>2026-01-20</Competencia>
+          <Servico>
+            <Valores><ValorServicos>1000.00</ValorServicos></Valores>
+            <IssRetido>2</IssRetido>
+            <ItemListaServico>01.01</ItemListaServico>
+            <Discriminacao>Servico de teste ABRASF</Discriminacao>
+            <CodigoMunicipio>3550308</CodigoMunicipio>
+            <ExigibilidadeISS>1</ExigibilidadeISS>
+          </Servico>
+          <Prestador><CpfCnpj><Cnpj>00000000000000</Cnpj></CpfCnpj></Prestador>
+          <OptanteSimplesNacional>2</OptanteSimplesNacional>
+          <IncentivoFiscal>2</IncentivoFiscal>
+        </InfDeclaracaoPrestacaoServico>
+      </Rps>
+    </ListaRps>
+  </LoteRps>
+</EnviarLoteRpsEnvio>";
+    }
+
+    private static List<string> ValidateAgainstAbrasfXsd(string xml)
+    {
+        var errors = new List<string>();
+        var xsdDir = FindXsdDir("abrasf");
+
+        var schemaSet = new XmlSchemaSet();
+        var corePath = Path.Combine(xsdDir, "wne_model_xsd_nota_fiscal_abrasf_core.xsd");
+        var coreSettings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Parse };
+        using (var coreReader = XmlReader.Create(corePath, coreSettings))
+            schemaSet.Add("http://www.w3.org/2000/09/xmldsig#", coreReader);
+
+        schemaSet.Add("http://www.abrasf.org.br/nfse.xsd",
+            Path.Combine(xsdDir, "wne_model_xsd_nota_fiscal_abrasf.xsd"));
+        schemaSet.Compile();
+
+        var settings = new XmlReaderSettings
+        {
+            Schemas = schemaSet,
+            ValidationType = ValidationType.Schema
+        };
+        settings.ValidationEventHandler += (_, e) => errors.Add($"[{e.Severity}] {e.Message}");
+
+        using var reader = XmlReader.Create(new StringReader(xml), settings);
+        while (reader.Read()) { }
+
+        return errors;
+    }
+
+    private static string FindXsdDir(string provider)
+    {
+        var dir = AppContext.BaseDirectory;
+        while (dir is not null)
+        {
+            var candidate = Path.Combine(dir, "providers", provider, "xsd");
+            if (Directory.Exists(candidate)) return candidate;
+            dir = Directory.GetParent(dir)?.FullName;
+        }
+        throw new DirectoryNotFoundException($"XSD dir not found: {provider}");
+    }
+}

--- a/tests/SemanaIA.ServiceInvoice.UnitTests/SchemaEngine/GissonlineSchemaGenerationTests.cs
+++ b/tests/SemanaIA.ServiceInvoice.UnitTests/SchemaEngine/GissonlineSchemaGenerationTests.cs
@@ -1,0 +1,328 @@
+using System.Xml;
+using System.Xml.Schema;
+using SemanaIA.ServiceInvoice.XmlGeneration.SchemaEngine;
+using Shouldly;
+
+namespace SemanaIA.ServiceInvoice.UnitTests.SchemaEngine;
+
+public class GissonlineSchemaGenerationTests
+{
+    private static readonly XsdSchemaAnalyzer Analyzer = new();
+
+    // ==========================================================
+    // Schema analysis
+    // ==========================================================
+
+    [Fact]
+    public void Given_GissonlineXsd_Should_ProduceSchemaDocumentWithGissonlineComplexTypes()
+    {
+        // Arrange
+        var xsdPath = FindXsdPath("gissonline", "enviar-lote-rps-envio-v2_04.xsd");
+
+        // Act
+        var schema = Analyzer.Analyze(xsdPath);
+
+        // Assert
+        schema.ShouldNotBeNull();
+        schema.ComplexTypes.Count.ShouldBeGreaterThan(0);
+        schema.RootElementName.ShouldNotBeNullOrWhiteSpace();
+    }
+
+    // ==========================================================
+    // Runner
+    // ==========================================================
+
+    [Fact]
+    public void Given_GissonlineProvider_Should_GenerateArtifactsViaRunner()
+    {
+        // Arrange
+        var providersDir = FindProvidersDir();
+        var runner = new SchemaGenerationRunner();
+
+        // Act
+        var schema = runner.RunForProvider("gissonline", providersDir);
+
+        // Assert
+        schema.ShouldNotBeNull();
+        var generatedDir = Path.Combine(providersDir, "gissonline", "generated");
+        Directory.GetFiles(Path.Combine(generatedDir, "Records"), "*.cs").Length.ShouldBeGreaterThan(0);
+        File.Exists(Path.Combine(generatedDir, "schema-report.md")).ShouldBeTrue();
+    }
+
+    // ==========================================================
+    // XML validation against GISSOnline XSD
+    // ==========================================================
+
+    [Fact]
+    public void Given_GissonlineXsd_Should_LoadAndCompileWithoutErrors()
+    {
+        // Arrange & Act
+        var xsdDir = FindXsdDir("gissonline");
+        var schemaSet = new XmlSchemaSet();
+        var dsigPath = Path.Combine(xsdDir, "xmldsig-core-schema20020212.xsd");
+        using (var dsigReader = XmlReader.Create(dsigPath, new XmlReaderSettings { DtdProcessing = DtdProcessing.Parse }))
+            schemaSet.Add("http://www.w3.org/2000/09/xmldsig#", dsigReader);
+        schemaSet.Add("http://www.giss.com.br/tipos-v2_04.xsd", Path.Combine(xsdDir, "tipos-v2_04.xsd"));
+        schemaSet.Add("http://www.giss.com.br/enviar-lote-rps-envio-v2_04.xsd", Path.Combine(xsdDir, "enviar-lote-rps-envio-v2_04.xsd"));
+        schemaSet.Compile();
+
+        // Assert
+        schemaSet.Count.ShouldBeGreaterThan(0);
+        schemaSet.IsCompiled.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Given_GissonlineSchema_Should_ContainLoteRpsComplexType()
+    {
+        // Arrange
+        var xsdPath = FindXsdPath("gissonline", "enviar-lote-rps-envio-v2_04.xsd");
+
+        // Act
+        var schema = Analyzer.Analyze(xsdPath);
+
+        // Assert
+        var typeNames = schema.ComplexTypes.Select(ct => ct.Name).ToList();
+        typeNames.ShouldContain("tcLoteRps");
+    }
+
+    [Fact]
+    public void Given_GissonlineMinimalXml_Should_ValidateAgainstXsd()
+    {
+        // Arrange
+        var ns = "http://www.giss.com.br/enviar-lote-rps-envio-v2_04.xsd";
+        var t = "http://www.giss.com.br/tipos-v2_04.xsd";
+
+        var xml = $@"<?xml version=""1.0"" encoding=""utf-8""?>
+<EnviarLoteRpsEnvio xmlns=""{ns}"">
+  <LoteRps xmlns:t=""{t}"" Id=""lote1"" versao=""2.04"">
+    <t:NumeroLote>1</t:NumeroLote>
+    <t:Prestador>
+      <t:CpfCnpj><t:Cnpj>00000000000000</t:Cnpj></t:CpfCnpj>
+      <t:InscricaoMunicipal>12345</t:InscricaoMunicipal>
+    </t:Prestador>
+    <t:QuantidadeRps>1</t:QuantidadeRps>
+    <t:ListaRps>
+      <t:Rps>
+        <t:InfDeclaracaoPrestacaoServico>
+          <t:Competencia>2026-01-20</t:Competencia>
+          <t:Servico>
+            <t:Valores>
+              <t:ValorServicos>1000.00</t:ValorServicos>
+              <t:trib><t:totTrib><t:pTotTribSN>0.00</t:pTotTribSN></t:totTrib></t:trib>
+              <t:IBSCBS>
+                <t:finNFSe>0</t:finNFSe>
+                <t:indFinal>0</t:indFinal>
+                <t:cIndOp>100501</t:cIndOp>
+                <t:indDest>0</t:indDest>
+                <t:valores>
+                  <t:trib><t:gIBSCBS><t:CST>000</t:CST><t:cClassTrib>000001</t:cClassTrib></t:gIBSCBS></t:trib>
+                  <t:cLocalidadeIncid>3550308</t:cLocalidadeIncid>
+                  <t:pRedutor>0.00</t:pRedutor>
+                </t:valores>
+              </t:IBSCBS>
+            </t:Valores>
+            <t:IssRetido>2</t:IssRetido>
+            <t:ItemListaServico>01.01</t:ItemListaServico>
+            <t:CodigoNbs>101010100</t:CodigoNbs>
+            <t:Discriminacao>Servico de teste</t:Discriminacao>
+            <t:CodigoMunicipio>3550308</t:CodigoMunicipio>
+            <t:ExigibilidadeISS>1</t:ExigibilidadeISS>
+          </t:Servico>
+          <t:Prestador>
+            <t:CpfCnpj><t:Cnpj>00000000000000</t:Cnpj></t:CpfCnpj>
+          </t:Prestador>
+          <t:OptanteSimplesNacional>2</t:OptanteSimplesNacional>
+          <t:IncentivoFiscal>2</t:IncentivoFiscal>
+        </t:InfDeclaracaoPrestacaoServico>
+      </t:Rps>
+    </t:ListaRps>
+  </LoteRps>
+</EnviarLoteRpsEnvio>";
+
+        // Act
+        var errors = ValidateAgainstGissonlineXsd(xml);
+
+        // Assert
+        errors.ShouldBeEmpty($"Minimal GISSOnline XML should pass XSD validation:\n{string.Join("\n", errors)}");
+    }
+
+    [Fact]
+    public void Given_GissonlineXmlMissingRequired_Should_FailXsdValidation()
+    {
+        // Arrange — missing Competencia (required)
+        var ns = "http://www.giss.com.br/enviar-lote-rps-envio-v2_04.xsd";
+        var t = "http://www.giss.com.br/tipos-v2_04.xsd";
+
+        var xml = $@"<?xml version=""1.0"" encoding=""utf-8""?>
+<EnviarLoteRpsEnvio xmlns=""{ns}"">
+  <LoteRps xmlns:t=""{t}"" Id=""lote1"" versao=""2.04"">
+    <t:NumeroLote>1</t:NumeroLote>
+    <t:Prestador>
+      <t:CpfCnpj><t:Cnpj>00000000000000</t:Cnpj></t:CpfCnpj>
+    </t:Prestador>
+    <t:QuantidadeRps>1</t:QuantidadeRps>
+    <t:ListaRps>
+      <t:Rps>
+        <t:InfDeclaracaoPrestacaoServico>
+          <t:Servico>
+            <t:Valores><t:ValorServicos>1000.00</t:ValorServicos><t:trib><t:totTrib><t:pTotTribSN>0.00</t:pTotTribSN></t:totTrib></t:trib></t:Valores>
+            <t:IssRetido>2</t:IssRetido>
+            <t:ItemListaServico>01.01</t:ItemListaServico>
+            <t:CodigoNbs>101010100</t:CodigoNbs>
+            <t:Discriminacao>Servico</t:Discriminacao>
+            <t:CodigoMunicipio>3550308</t:CodigoMunicipio>
+            <t:ExigibilidadeISS>1</t:ExigibilidadeISS>
+          </t:Servico>
+          <t:Prestador>
+            <t:CpfCnpj><t:Cnpj>00000000000000</t:Cnpj></t:CpfCnpj>
+          </t:Prestador>
+          <t:OptanteSimplesNacional>2</t:OptanteSimplesNacional>
+          <t:IncentivoFiscal>2</t:IncentivoFiscal>
+        </t:InfDeclaracaoPrestacaoServico>
+      </t:Rps>
+    </t:ListaRps>
+  </LoteRps>
+</EnviarLoteRpsEnvio>";
+
+        // Act
+        var errors = ValidateAgainstGissonlineXsd(xml);
+
+        // Assert
+        errors.Count.ShouldBeGreaterThan(0, "Missing required element should fail XSD validation");
+    }
+
+    [Fact]
+    public void Given_GissonlineChoiceCpfCnpj_WithBothBranches_Should_FailXsdValidation()
+    {
+        // Arrange — CpfCnpj with both Cpf and Cnpj (violates choice)
+        var ns = "http://www.giss.com.br/enviar-lote-rps-envio-v2_04.xsd";
+        var t = "http://www.giss.com.br/tipos-v2_04.xsd";
+
+        var xml = $@"<?xml version=""1.0"" encoding=""utf-8""?>
+<EnviarLoteRpsEnvio xmlns=""{ns}"">
+  <LoteRps xmlns:t=""{t}"" Id=""lote1"" versao=""2.04"">
+    <t:NumeroLote>1</t:NumeroLote>
+    <t:Prestador>
+      <t:CpfCnpj><t:Cpf>12345678901</t:Cpf><t:Cnpj>00000000000000</t:Cnpj></t:CpfCnpj>
+    </t:Prestador>
+    <t:QuantidadeRps>0</t:QuantidadeRps>
+    <t:ListaRps><t:Rps><t:InfDeclaracaoPrestacaoServico>
+      <t:Competencia>2026-01-20</t:Competencia>
+      <t:Servico>
+        <t:Valores><t:ValorServicos>1000.00</t:ValorServicos><t:trib><t:totTrib><t:pTotTribSN>0.00</t:pTotTribSN></t:totTrib></t:trib><t:IBSCBS><t:finNFSe>0</t:finNFSe><t:indFinal>0</t:indFinal><t:cIndOp>100501</t:cIndOp><t:indDest>0</t:indDest><t:valores><t:trib><t:gIBSCBS><t:CST>000</t:CST><t:cClassTrib>000001</t:cClassTrib></t:gIBSCBS></t:trib><t:cLocalidadeIncid>3550308</t:cLocalidadeIncid><t:pRedutor>0.00</t:pRedutor></t:valores></t:IBSCBS></t:Valores>
+        <t:IssRetido>2</t:IssRetido><t:ItemListaServico>01.01</t:ItemListaServico><t:CodigoNbs>101010100</t:CodigoNbs><t:Discriminacao>Teste</t:Discriminacao><t:CodigoMunicipio>3550308</t:CodigoMunicipio><t:ExigibilidadeISS>1</t:ExigibilidadeISS>
+      </t:Servico>
+      <t:Prestador><t:CpfCnpj><t:Cnpj>00000000000000</t:Cnpj></t:CpfCnpj></t:Prestador>
+      <t:OptanteSimplesNacional>2</t:OptanteSimplesNacional><t:IncentivoFiscal>2</t:IncentivoFiscal>
+    </t:InfDeclaracaoPrestacaoServico></t:Rps></t:ListaRps>
+  </LoteRps>
+</EnviarLoteRpsEnvio>";
+
+        // Act
+        var errors = ValidateAgainstGissonlineXsd(xml);
+
+        // Assert
+        errors.Count.ShouldBeGreaterThan(0, "Both choice elements (Cpf + Cnpj) should fail XSD validation");
+    }
+
+    // ==========================================================
+    // Regression — other providers still work
+    // ==========================================================
+
+    [Fact]
+    public void Given_NacionalProvider_Should_StillGenerateCorrectly()
+    {
+        // Arrange
+        var providersDir = FindProvidersDir();
+        var runner = new SchemaGenerationRunner();
+
+        // Act
+        var schema = runner.RunForProvider("nacional", providersDir);
+
+        // Assert
+        schema.TargetNamespace.ShouldBe("http://www.sped.fazenda.gov.br/nfse");
+        schema.ComplexTypes.Count.ShouldBeGreaterThan(10);
+    }
+
+    [Fact]
+    public void Given_AbrasfProvider_Should_StillGenerateCorrectly()
+    {
+        // Arrange
+        var providersDir = FindProvidersDir();
+        var runner = new SchemaGenerationRunner();
+
+        // Act
+        var schema = runner.RunForProvider("abrasf", providersDir);
+
+        // Assert
+        schema.TargetNamespace.ShouldBe("http://www.abrasf.org.br/nfse.xsd");
+        schema.ComplexTypes.Count.ShouldBeGreaterThan(5);
+    }
+
+    // ==========================================================
+    // Helpers privados (final da classe)
+    // ==========================================================
+
+    private static List<string> ValidateAgainstGissonlineXsd(string xml)
+    {
+        var errors = new List<string>();
+        var xsdDir = FindXsdDir("gissonline");
+
+        var schemaSet = new XmlSchemaSet();
+        var dsigPath = Path.Combine(xsdDir, "xmldsig-core-schema20020212.xsd");
+        using (var dsigReader = XmlReader.Create(dsigPath, new XmlReaderSettings { DtdProcessing = DtdProcessing.Parse }))
+            schemaSet.Add("http://www.w3.org/2000/09/xmldsig#", dsigReader);
+
+        schemaSet.Add("http://www.giss.com.br/tipos-v2_04.xsd", Path.Combine(xsdDir, "tipos-v2_04.xsd"));
+        schemaSet.Add("http://www.giss.com.br/enviar-lote-rps-envio-v2_04.xsd", Path.Combine(xsdDir, "enviar-lote-rps-envio-v2_04.xsd"));
+        schemaSet.Compile();
+
+        var settings = new XmlReaderSettings
+        {
+            Schemas = schemaSet,
+            ValidationType = ValidationType.Schema
+        };
+        settings.ValidationEventHandler += (_, e) => errors.Add($"[{e.Severity}] {e.Message}");
+
+        using var reader = XmlReader.Create(new StringReader(xml), settings);
+        while (reader.Read()) { }
+
+        return errors;
+    }
+
+    private static string FindXsdPath(string provider, string fileName)
+    {
+        var dir = AppContext.BaseDirectory;
+        while (dir is not null)
+        {
+            var candidate = Path.Combine(dir, "providers", provider, "xsd", fileName);
+            if (File.Exists(candidate)) return candidate;
+            dir = Directory.GetParent(dir)?.FullName;
+        }
+        throw new FileNotFoundException($"XSD not found: {provider}/{fileName}");
+    }
+
+    private static string FindXsdDir(string provider)
+    {
+        var dir = AppContext.BaseDirectory;
+        while (dir is not null)
+        {
+            var candidate = Path.Combine(dir, "providers", provider, "xsd");
+            if (Directory.Exists(candidate)) return candidate;
+            dir = Directory.GetParent(dir)?.FullName;
+        }
+        throw new DirectoryNotFoundException($"XSD dir not found: {provider}");
+    }
+
+    private static string FindProvidersDir()
+    {
+        var dir = AppContext.BaseDirectory;
+        while (dir is not null)
+        {
+            var candidate = Path.Combine(dir, "providers");
+            if (Directory.Exists(candidate)) return candidate;
+            dir = Directory.GetParent(dir)?.FullName;
+        }
+        throw new DirectoryNotFoundException("providers/ not found");
+    }
+}


### PR DESCRIPTION
Third provider (GISSOnline) validates data-driven onboarding:

- Add GISSOnline provider: XSDs + minimal base-rules.json
- Add ABRASF XSD validation tests: valid XML, missing required, choice (Cpf/Cnpj), wrong sequence order
- Add GISSOnline XSD validation tests: valid XML with IBSCBS, missing required, choice violation
- All 3 providers now have full XSD validation coverage
- Zero production code changes — onboarding is data-only
- Sync spec nfse-xsd-generation-engine (GISSOnline requirement)
- 111/111 tests passing
- Archive change prove-build-time-generation-with-gissonline-schema