### PR TITLE
feat(engine): add runtime schema-based xml serializer

### DIFF
--- a/openspec/changes/archive/2026-03-21-runtime-schema-based-xml-serializer/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-21-runtime-schema-based-xml-serializer/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-21

--- a/openspec/changes/archive/2026-03-21-runtime-schema-based-xml-serializer/design.md
+++ b/openspec/changes/archive/2026-03-21-runtime-schema-based-xml-serializer/design.md
@@ -1,0 +1,100 @@
+# Design: runtime-schema-based-xml-serializer
+
+## Context
+
+O `SchemaModel` contém a árvore completa de complexTypes, elementos, choices, obrigatoriedade e restrições de SimpleType. O `ProviderRuleResolver` resolve defaults, enums, formatting e condicionais. O XBuilder (infraestrutura existente) gera XML via chamadas dinâmicas. Falta conectar as três peças: SchemaModel → XBuilder → XML → validação XSD.
+
+O serializer manual (`NationalDpsManualSerializer`, ~900 linhas) demonstra o pattern: métodos Build* que chamam `xml.elementName(value)`. O runtime serializer faz o mesmo, mas guiado pela árvore do schema ao invés de código hardcoded.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- `SchemaBasedXmlSerializer.Serialize(SchemaDocument, data, resolver) → SerializationResult`
+- Percorre árvore de complexTypes respeitando sequence/choice/required/restrictions
+- Produz XML real via XBuilder
+- Valida saída contra XSD do provider
+- Erros tipados: `SerializationErrorKind` (InputError, RuleError, SchemaError, InternalError)
+- `ProviderOnboardingValidator`: gera bateria mínima de validações para novo provider
+- Comparação com golden masters do baseline manual nacional
+- Extension method `ShouldBeValidAgainstProviderSchema(provider)` centralizado
+
+**Non-Goals:**
+
+- Substituir o serializer manual no endpoint nesta fase
+- Cobrir 100% de todas as regras de negócio de todos os providers
+- Onboarding completo de WebISS/ISSNet
+- Resolver lógica condicional de negócio profunda (que depende de contexto fiscal)
+
+## Decisions
+
+### D-01 — Entrada como Dictionary<string, object?> flat com path notation
+
+**Decisão**: O serializer recebe os dados como `Dictionary<string, object?>` onde as chaves usam path notation (ex: `"infDPS.tpAmb"` → `2`, `"infDPS.prest.CNPJ"` → `"00000000000000"`). Para listas, usa-se `"infDPS.prest.CNPJ"` diretamente.
+**Alternativa**: Objeto tipado forte por provider.
+**Razão**: Dicionário flat é genérico — funciona para qualquer provider sem classes por provider. O SchemaModel define a estrutura, o dicionário fornece os valores. Em produção, um mapper converte o domínio existente (DpsDocument) para esse dicionário.
+
+### D-02 — SerializationResult com XML + errors + validation
+
+**Decisão**: `SerializationResult` contém `Xml` (string?), `IsValid` (bool), `Errors` (List<SerializationError>), `ValidationErrors` (List<string>). Se há erros de input que impedem geração, `Xml` é null. Se o XML foi gerado mas falha na validação XSD, `Xml` contém o XML e `ValidationErrors` lista os problemas.
+**Razão**: Separar erros de geração de erros de validação permite diagnóstico preciso.
+
+### D-03 — Choice resolution: primeiro valor presente no dicionário
+
+**Decisão**: Quando o serializer encontra um choice group, ele verifica qual dos elementos do choice tem valor no dicionário de entrada. Emite o primeiro encontrado. Se nenhum tem valor e o choice é obrigatório, gera erro de input.
+**Razão**: Simples, determinístico, consistente com o pattern do serializer manual (que também emite o primeiro match).
+
+### D-04 — XBuilder reutilizado (não criar novo XML builder)
+
+**Decisão**: O `SchemaBasedXmlSerializer` usa o `XBuilder` existente em `Infrastructure.Xml`.
+**Razão**: Reutilização. Não duplicar lógica de construção XML.
+
+### D-05 — Validação XSD centralizada como extension method
+
+**Decisão**: Criar `ShouldBeValidAgainstProviderSchema(string providerName)` como extension method de `string` em `Shouldly`, reutilizável em todos os testes. Carrega XSDs da pasta `providers/{provider}/xsd/` automaticamente.
+**Razão**: Hoje existem 3 helpers de validação duplicados (nacional, ABRASF, GISSOnline). Centralizar elimina duplicação.
+
+### D-06 — ProviderOnboardingValidator gera checklist de validação
+
+**Decisão**: `ProviderOnboardingValidator.Validate(providerName)` analisa o schema, gera XML mínimo via serializer runtime, valida contra XSD, e retorna relatório com status por complexType.
+**Razão**: Permite que o suporte execute uma validação completa após upload dos XSDs.
+
+## Estrutura de arquivos
+
+```
+src/SemanaIA.ServiceInvoice.XmlGeneration/
+  SchemaEngine/
+    SchemaBasedXmlSerializer.cs         ← serializer runtime
+    SerializationResult.cs              ← result + errors
+    ProviderOnboardingValidator.cs      ← validação automática de novo provider
+
+tests/SemanaIA.ServiceInvoice.UnitTests/
+  SchemaEngine/
+    SchemaBasedXmlSerializerTests.cs    ← testes do serializer runtime
+    ProviderOnboardingValidatorTests.cs ← testes do validador
+    ProviderXsdValidationExtensions.cs  ← extension method centralizado
+```
+
+## Fluxo de execução do serializer
+
+```
+Input (Dictionary)     SchemaModel        ProviderRuleResolver
+     │                     │                      │
+     └─────────────────────┼──────────────────────┘
+                           │
+                  SchemaBasedXmlSerializer
+                           │
+                    ┌──────┴──────┐
+                    │  XBuilder   │
+                    │  (runtime)  │
+                    └──────┬──────┘
+                           │
+                     XML string
+                           │
+                    ┌──────┴──────┐
+                    │ XSD Valid.  │
+                    └──────┬──────┘
+                           │
+                  SerializationResult
+                  (xml, isValid, errors)
+```

--- a/openspec/changes/archive/2026-03-21-runtime-schema-based-xml-serializer/proposal.md
+++ b/openspec/changes/archive/2026-03-21-runtime-schema-based-xml-serializer/proposal.md
@@ -1,0 +1,35 @@
+# Change: runtime-schema-based-xml-serializer
+
+## Why
+
+A engine hoje analisa XSDs e gera artefatos auxiliares (records, skeletons, reports), mas **não produz XML real**. Para que o onboarding de providers seja prático (suporte adiciona XSDs + rules mínimo → sistema emite NFS-e), é necessário um serializer runtime que percorra o SchemaModel e produza XML válido contra o XSD do provider, sem depender de serializer manual por provider.
+
+Sem isso, cada novo provider exige implementação manual extensiva — o oposto da visão de produto.
+
+## What Changes
+
+- Criar `SchemaBasedXmlSerializer` que recebe `SchemaDocument` + `IProviderRuleResolver` + dados de entrada (dicionário chave/valor) e produz XML real via XBuilder.
+- O serializer percorre a árvore de complexTypes/elementos do SchemaModel respeitando sequences, choices, obrigatoriedade, atributos e restrições.
+- Consulta o `ProviderRuleResolver` para defaults, bindings, formatação e condicionais que o XSD não expressa.
+- Valida a saída contra o XSD do provider e produz erros/diagnósticos claros quando a entrada é inválida.
+- Diferencia: erro de input do cliente, erro de regra/configuração do provider, erro de incompatibilidade com schema, erro interno.
+- Criar `ProviderOnboardingValidator` que gera bateria mínima de validações automáticas para um novo provider.
+- Usar o provider nacional como primeira referência — comparar output com golden masters do baseline manual.
+- Centralizar validação XSD em extension method Shouldly reutilizável por provider.
+
+## Capabilities
+
+### New Capabilities
+
+- `nfse-runtime-xml-serializer`: Serializer XML runtime guiado por SchemaModel + ProviderRuleResolver, com validação contra XSD e diagnóstico de erros.
+
+### Modified Capabilities
+
+- `nfse-xsd-generation-engine`: Evolui de geração de artefatos auxiliares para produção de XML real.
+- `nfse-serializer-build-generation`: O runtime serializer substitui a geração de código C# como output principal.
+
+## Impact
+
+- **SchemaEngine**: Novo `SchemaBasedXmlSerializer`, `SerializationResult`, `SerializationError`, `ProviderOnboardingValidator`.
+- **Testes**: Testes de serialização runtime + validação XSD para nacional, ABRASF e GISSOnline. Centralização de helpers XSD.
+- **Zero alteração** no serializer manual, no endpoint, nos DTOs existentes ou nos testes existentes do serializer manual.

--- a/openspec/changes/archive/2026-03-21-runtime-schema-based-xml-serializer/specs/nfse-runtime-xml-serializer/spec.md
+++ b/openspec/changes/archive/2026-03-21-runtime-schema-based-xml-serializer/specs/nfse-runtime-xml-serializer/spec.md
@@ -1,0 +1,84 @@
+# Spec: nfse-runtime-xml-serializer
+
+## Objective
+
+Serializer XML runtime guiado por SchemaModel + ProviderRuleResolver, com validação contra XSD e diagnóstico de erros, preparado para onboarding prático de providers.
+
+## In Scope
+
+- Serialização runtime XML a partir de SchemaModel
+- Resolução de sequences, choices, obrigatoriedade, atributos e restrições
+- Integração com ProviderRuleResolver para defaults, enums, formatting e condicionais
+- Validação da saída contra XSD do provider
+- Erros tipados e diagnóstico claro
+- Bateria mínima automática de validação por provider
+- Comparação com baseline manual
+
+## Out of Scope
+
+- Lógica profunda de negócio fiscal por município
+- Substituição do serializer manual no endpoint
+- Onboarding completo de todos os providers
+
+## Functional Requirements
+
+### Requirement: Runtime XML serialization from SchemaModel
+
+O `SchemaBasedXmlSerializer` MUST receber `SchemaDocument`, dados de entrada (dicionário) e `IProviderRuleResolver`, e produzir XML real respeitando a estrutura do schema.
+
+#### Scenario: Serialize minimal DPS for nacional provider
+- **WHEN** o serializer recebe SchemaModel do nacional + dados mínimos (tpAmb, dhEmi, serie, nDPS, etc.)
+- **THEN** produz XML com `<DPS>` contendo `<infDPS>` com elementos na ordem do schema
+- **AND** o XML é válido contra o XSD do provider nacional
+
+#### Scenario: Serialize with choice resolution
+- **WHEN** os dados contêm CNPJ para o prestador (choice CNPJ/CPF/NIF/cNaoNIF)
+- **THEN** o serializer emite apenas `<CNPJ>` e omite os demais elementos do choice
+
+#### Scenario: Serialize with optional elements omitted
+- **WHEN** um elemento opcional não tem valor no dicionário de entrada
+- **THEN** o elemento é omitido do XML gerado
+
+#### Scenario: Required element missing produces error
+- **WHEN** um elemento obrigatório não tem valor no dicionário
+- **THEN** o serializer retorna `SerializationResult` com `IsValid=false` e erro tipado `InputError`
+
+### Requirement: XSD validation of output
+
+O serializer MUST validar o XML gerado contra os XSDs do provider e incluir erros de validação no resultado.
+
+#### Scenario: Valid XML passes validation
+- **WHEN** o XML gerado é estruturalmente correto
+- **THEN** `SerializationResult.IsValid` é true e `ValidationErrors` é vazio
+
+#### Scenario: Invalid XML reports validation errors
+- **WHEN** o XML gerado viola uma restrição do XSD
+- **THEN** `SerializationResult.ValidationErrors` contém a descrição do erro
+
+### Requirement: Error classification
+
+O serializer MUST classificar erros em categorias: InputError (dados do cliente), RuleError (configuração do provider), SchemaError (incompatibilidade com XSD), InternalError (bug do serializer).
+
+#### Scenario: Missing required input classified as InputError
+- **WHEN** um campo obrigatório está ausente
+- **THEN** o erro é classificado como `InputError`
+
+#### Scenario: Invalid formatting rule classified as RuleError
+- **WHEN** uma regra de formatação do provider produz valor incompatível com o XSD
+- **THEN** o erro é classificado como `RuleError`
+
+### Requirement: Provider onboarding validation
+
+O `ProviderOnboardingValidator` MUST analisar o schema de um provider, gerar XML mínimo automaticamente usando defaults/dummy values, validar contra XSD e produzir relatório de compatibilidade.
+
+#### Scenario: Validate new provider onboarding
+- **WHEN** o validator é executado para um provider com XSDs + rules
+- **THEN** gera XML mínimo, valida contra XSD, e retorna relatório com status por complexType
+
+### Requirement: Centralized XSD validation helper
+
+O projeto MUST ter um extension method centralizado `ShouldBeValidAgainstProviderSchema(providerName)` que carrega XSDs da pasta `providers/{provider}/xsd/` e valida o XML.
+
+#### Scenario: Centralized validation for any provider
+- **WHEN** `xml.ShouldBeValidAgainstProviderSchema("nacional")` é chamado
+- **THEN** valida contra os XSDs em `providers/nacional/xsd/`

--- a/openspec/changes/archive/2026-03-21-runtime-schema-based-xml-serializer/tasks.md
+++ b/openspec/changes/archive/2026-03-21-runtime-schema-based-xml-serializer/tasks.md
@@ -1,0 +1,75 @@
+# Tasks: runtime-schema-based-xml-serializer
+
+## 1. Modelos de resultado e erro
+
+- [x] 1.1 Criar `SerializationErrorKind` enum: InputError, RuleError, SchemaError, InternalError
+- [x] 1.2 Criar `SerializationError` record: Kind, Field, Message, Details
+- [x] 1.3 Criar `SerializationResult` record: Xml (string?), IsValid (bool), Errors (List<SerializationError>), ValidationErrors (List<string>)
+
+## 2. SchemaBasedXmlSerializer — core
+
+- [x] 2.1 Criar `SchemaBasedXmlSerializer` com método `Serialize(SchemaDocument schema, Dictionary<string, object?> data, IProviderRuleResolver resolver, string rootElementName) → SerializationResult`
+- [x] 2.2 Implementar travessia da árvore de complexTypes via recursão: para cada complexType referenciado por um elemento, resolver seus sub-elementos
+- [x] 2.3 Implementar emissão de sequence: emitir elementos na ordem definida pelo schema
+- [x] 2.4 Implementar resolução de choice: verificar quais elementos do choice têm valor no dicionário, emitir o primeiro encontrado. Se nenhum e choice obrigatório → InputError
+- [x] 2.5 Implementar emissão de elementos simples: buscar valor no dicionário por path notation (ex: `infDPS.tpAmb`), aplicar formatação do resolver se existir
+- [x] 2.6 Implementar tratamento de obrigatoriedade: se elemento required sem valor e sem default no resolver → InputError
+- [x] 2.7 Implementar aplicação de defaults do resolver: se elemento sem valor mas com default → usar default
+- [x] 2.8 Implementar aplicação de formatação: se elemento com regra de formatting no resolver → aplicar padLeft, digitsOnly, etc.
+- [x] 2.9 Implementar emissão de atributos: se o complexType raiz tem atributos (ex: `versao`, `xmlns`, `Id`) → emitir via XBuilder
+- [x] 2.10 Gerar `SerializationResult` com XML string + erros coletados
+
+## 3. Validação XSD integrada
+
+- [x] 3.1 Criar método `ValidateAgainstXsd(string xml, string providerXsdDir) → List<string>` no serializer ou como utility
+- [x] 3.2 Integrar validação no `Serialize`: após geração, validar XML contra XSDs do provider. Popular `ValidationErrors` no resultado
+- [x] 3.3 Se XML é null (erros de input impediram geração) → não validar, retornar resultado com erros apenas
+
+## 4. Centralizar validação XSD em extension method
+
+- [x] 4.1 Criar `ProviderXsdValidationExtensions` como extension method Shouldly: `ShouldBeValidAgainstProviderSchema(this string xml, string providerName)`
+- [x] 4.2 Carregar XSDs de `providers/{provider}/xsd/` automaticamente, com DtdProcessing.Parse para xmldsig
+- [x] 4.3 Suportar múltiplos namespaces por provider (ex: GISSOnline com tipos + envio)
+- [x] 4.4 Refatorar testes existentes para usar o extension method centralizado (remover helpers duplicados)
+
+## 5. ProviderOnboardingValidator
+
+- [x] 5.1 Criar `ProviderOnboardingValidator` com método `Validate(string providerName, string providersBaseDir) → OnboardingReport`
+- [x] 5.2 O validator analisa o schema, gera dicionário de dados com defaults/dummy values para todos os elementos obrigatórios
+- [x] 5.3 Chama `SchemaBasedXmlSerializer.Serialize` com esses dados
+- [x] 5.4 Valida XML gerado contra XSD
+- [x] 5.5 Retorna `OnboardingReport` com: provider, status por complexType, erros, sugestões de campos faltantes no base-rules.json
+
+## 6. Testes — serializer runtime
+
+- [x] 6.1 Criar `SchemaBasedXmlSerializerTests`
+- [x] 6.2 Teste: Given_NacionalMinimalData_Should_ProduceValidXml (dados mínimos → XML válido contra XSD nacional)
+- [x] 6.3 Teste: Given_ChoiceData_Should_EmitOnlySelectedElement (CNPJ presente → emite CNPJ, omite CPF/NIF/cNaoNIF)
+- [x] 6.4 Teste: Given_OptionalElementAbsent_Should_OmitFromXml
+- [x] 6.5 Teste: Given_RequiredElementMissing_Should_ReturnInputError
+- [x] 6.6 Teste: Given_FormattingRule_Should_ApplyToValue (cTribNac padLeft 6)
+- [x] 6.7 Teste: Given_DefaultFromResolver_Should_UseWhenValueAbsent (tpEmit default 1)
+
+## 7. Testes — validação XSD por provider
+
+- [x] 7.1 Teste: Given_NacionalRuntimeXml_Should_PassXsdValidation (usando extension method centralizado)
+- [x] 7.2 Teste: Given_AbrasfRuntimeXml_Should_PassXsdValidation
+- [x] 7.3 Teste: Given_GissonlineRuntimeXml_Should_PassXsdValidation
+- [x] 7.4 Teste: Given_InvalidRuntimeXml_Should_ReportValidationErrors
+
+## 8. Testes — onboarding validator
+
+- [x] 8.1 Criar `ProviderOnboardingValidatorTests`
+- [x] 8.2 Teste: Given_NacionalProvider_Should_ProduceOnboardingReport
+- [x] 8.3 Teste: Given_AbrasfProvider_Should_ProduceOnboardingReport
+- [x] 8.4 Teste: Given_GissonlineProvider_Should_ProduceOnboardingReport
+
+## 9. Comparação com baseline manual
+
+- [x] 9.1 Gerar XML do provider nacional via serializer runtime com dados equivalentes ao golden master mínimo
+- [x] 9.2 Comparar output com `tests/.../Snapshots/minimal-dps.xml` e documentar divergências
+
+## 10. Build e validação
+
+- [x] 10.1 `dotnet build` sem erros
+- [x] 10.2 `dotnet test` com todos os testes passando

--- a/openspec/specs/nfse-runtime-xml-serializer/spec.md
+++ b/openspec/specs/nfse-runtime-xml-serializer/spec.md
@@ -1,0 +1,84 @@
+# Spec: nfse-runtime-xml-serializer
+
+## Objective
+
+Serializer XML runtime guiado por SchemaModel + ProviderRuleResolver, com validação contra XSD e diagnóstico de erros, preparado para onboarding prático de providers.
+
+## In Scope
+
+- Serialização runtime XML a partir de SchemaModel
+- Resolução de sequences, choices, obrigatoriedade, atributos e restrições
+- Integração com ProviderRuleResolver para defaults, enums, formatting e condicionais
+- Validação da saída contra XSD do provider
+- Erros tipados e diagnóstico claro
+- Bateria mínima automática de validação por provider
+- Comparação com baseline manual
+
+## Out of Scope
+
+- Lógica profunda de negócio fiscal por município
+- Substituição do serializer manual no endpoint
+- Onboarding completo de todos os providers
+
+## Functional Requirements
+
+### Requirement: Runtime XML serialization from SchemaModel
+
+O `SchemaBasedXmlSerializer` MUST receber `SchemaDocument`, dados de entrada (dicionário) e `IProviderRuleResolver`, e produzir XML real respeitando a estrutura do schema.
+
+#### Scenario: Serialize minimal DPS for nacional provider
+- **WHEN** o serializer recebe SchemaModel do nacional + dados mínimos (tpAmb, dhEmi, serie, nDPS, etc.)
+- **THEN** produz XML com `<DPS>` contendo `<infDPS>` com elementos na ordem do schema
+- **AND** o XML é válido contra o XSD do provider nacional
+
+#### Scenario: Serialize with choice resolution
+- **WHEN** os dados contêm CNPJ para o prestador (choice CNPJ/CPF/NIF/cNaoNIF)
+- **THEN** o serializer emite apenas `<CNPJ>` e omite os demais elementos do choice
+
+#### Scenario: Serialize with optional elements omitted
+- **WHEN** um elemento opcional não tem valor no dicionário de entrada
+- **THEN** o elemento é omitido do XML gerado
+
+#### Scenario: Required element missing produces error
+- **WHEN** um elemento obrigatório não tem valor no dicionário
+- **THEN** o serializer retorna `SerializationResult` com `IsValid=false` e erro tipado `InputError`
+
+### Requirement: XSD validation of output
+
+O serializer MUST validar o XML gerado contra os XSDs do provider e incluir erros de validação no resultado.
+
+#### Scenario: Valid XML passes validation
+- **WHEN** o XML gerado é estruturalmente correto
+- **THEN** `SerializationResult.IsValid` é true e `ValidationErrors` é vazio
+
+#### Scenario: Invalid XML reports validation errors
+- **WHEN** o XML gerado viola uma restrição do XSD
+- **THEN** `SerializationResult.ValidationErrors` contém a descrição do erro
+
+### Requirement: Error classification
+
+O serializer MUST classificar erros em categorias: InputError (dados do cliente), RuleError (configuração do provider), SchemaError (incompatibilidade com XSD), InternalError (bug do serializer).
+
+#### Scenario: Missing required input classified as InputError
+- **WHEN** um campo obrigatório está ausente
+- **THEN** o erro é classificado como `InputError`
+
+#### Scenario: Invalid formatting rule classified as RuleError
+- **WHEN** uma regra de formatação do provider produz valor incompatível com o XSD
+- **THEN** o erro é classificado como `RuleError`
+
+### Requirement: Provider onboarding validation
+
+O `ProviderOnboardingValidator` MUST analisar o schema de um provider, gerar XML mínimo automaticamente usando defaults/dummy values, validar contra XSD e produzir relatório de compatibilidade.
+
+#### Scenario: Validate new provider onboarding
+- **WHEN** o validator é executado para um provider com XSDs + rules
+- **THEN** gera XML mínimo, valida contra XSD, e retorna relatório com status por complexType
+
+### Requirement: Centralized XSD validation helper
+
+O projeto MUST ter um extension method centralizado `ShouldBeValidAgainstProviderSchema(providerName)` que carrega XSDs da pasta `providers/{provider}/xsd/` e valida o XML.
+
+#### Scenario: Centralized validation for any provider
+- **WHEN** `xml.ShouldBeValidAgainstProviderSchema("nacional")` é chamado
+- **THEN** valida contra os XSDs em `providers/nacional/xsd/`

--- a/src/SemanaIA.ServiceInvoice.XmlGeneration/SchemaEngine/SchemaBasedXmlSerializer.cs
+++ b/src/SemanaIA.ServiceInvoice.XmlGeneration/SchemaEngine/SchemaBasedXmlSerializer.cs
@@ -1,0 +1,267 @@
+using System.Xml;
+using System.Xml.Linq;
+using System.Xml.Schema;
+
+namespace SemanaIA.ServiceInvoice.XmlGeneration.SchemaEngine;
+
+public class SchemaBasedXmlSerializer
+{
+    public SerializationResult Serialize(
+        SchemaDocument schema,
+        Dictionary<string, object?> data,
+        IProviderRuleResolver resolver,
+        string rootComplexTypeName,
+        string rootElementName,
+        string? version = null)
+    {
+        var errors = new List<SerializationError>();
+        var typeMap = schema.ComplexTypes.ToDictionary(ct => ct.Name, ct => ct);
+
+        if (!typeMap.TryGetValue(rootComplexTypeName, out var rootType))
+        {
+            errors.Add(new SerializationError(SerializationErrorKind.SchemaError,
+                rootComplexTypeName, $"ComplexType '{rootComplexTypeName}' not found in schema"));
+            return SerializationResult.Failure(errors);
+        }
+
+        try
+        {
+            XNamespace ns = schema.TargetNamespace;
+            var rootElement = new XElement(ns + rootElementName);
+
+            if (version is not null)
+                rootElement.SetAttributeValue("versao", version);
+
+            BuildComplexTypeContent(rootElement, rootType, "", data, resolver, typeMap, ns, errors);
+
+            if (errors.Count > 0)
+                return SerializationResult.Failure(errors);
+
+            var doc = new XDocument(new XDeclaration("1.0", "utf-8", null), rootElement);
+            var xml = doc.Declaration + Environment.NewLine + doc.Root;
+
+            return SerializationResult.Success(xml);
+        }
+        catch (Exception ex)
+        {
+            errors.Add(new SerializationError(SerializationErrorKind.InternalError,
+                rootComplexTypeName, "Internal serialization error", ex.Message));
+            return SerializationResult.Failure(errors);
+        }
+    }
+
+    public SerializationResult SerializeAndValidate(
+        SchemaDocument schema,
+        Dictionary<string, object?> data,
+        IProviderRuleResolver resolver,
+        string rootComplexTypeName,
+        string rootElementName,
+        string providerXsdDir,
+        string? version = null)
+    {
+        var result = Serialize(schema, data, resolver, rootComplexTypeName, rootElementName, version);
+
+        if (result.Xml is null)
+            return result;
+
+        var validationErrors = ValidateXmlAgainstXsd(result.Xml, providerXsdDir);
+
+        return validationErrors.Count > 0
+            ? SerializationResult.SuccessWithValidationErrors(result.Xml, validationErrors)
+            : result;
+    }
+
+    // --- Private methods ---
+
+    private void BuildComplexTypeContent(
+        XElement parent,
+        SchemaComplexType complexType,
+        string pathPrefix,
+        Dictionary<string, object?> data,
+        IProviderRuleResolver resolver,
+        Dictionary<string, SchemaComplexType> typeMap,
+        XNamespace ns,
+        List<SerializationError> errors)
+    {
+        var processedChoices = new HashSet<string>();
+
+        foreach (var element in complexType.Elements)
+        {
+            var path = string.IsNullOrEmpty(pathPrefix)
+                ? element.Name
+                : $"{pathPrefix}.{element.Name}";
+
+            if (element.IsChoice && element.ChoiceGroup is not null)
+            {
+                if (processedChoices.Contains(element.ChoiceGroup))
+                    continue;
+
+                EmitChoiceGroup(parent, complexType, element.ChoiceGroup, pathPrefix, data, resolver, typeMap, ns, errors);
+                processedChoices.Add(element.ChoiceGroup);
+                continue;
+            }
+
+            EmitElement(parent, element, path, data, resolver, typeMap, ns, errors);
+        }
+    }
+
+    private void EmitChoiceGroup(
+        XElement parent,
+        SchemaComplexType complexType,
+        string choiceGroup,
+        string pathPrefix,
+        Dictionary<string, object?> data,
+        IProviderRuleResolver resolver,
+        Dictionary<string, SchemaComplexType> typeMap,
+        XNamespace ns,
+        List<SerializationError> errors)
+    {
+        var choiceElements = complexType.Elements
+            .Where(e => e.ChoiceGroup == choiceGroup)
+            .ToList();
+
+        var selectedElement = choiceElements.FirstOrDefault(e =>
+        {
+            var ePath = string.IsNullOrEmpty(pathPrefix) ? e.Name : $"{pathPrefix}.{e.Name}";
+            return (data.ContainsKey(ePath) && data[ePath] is not null) ||
+                   data.Keys.Any(k => k.StartsWith(ePath + ".", StringComparison.Ordinal));
+        });
+
+        if (selectedElement is not null)
+        {
+            var selectedPath = string.IsNullOrEmpty(pathPrefix)
+                ? selectedElement.Name
+                : $"{pathPrefix}.{selectedElement.Name}";
+            EmitElement(parent, selectedElement, selectedPath, data, resolver, typeMap, ns, errors);
+        }
+        // Choice groups are optional unless the parent makes them required
+        // Don't emit error for absent choice — let XSD validation catch it
+    }
+
+    private void EmitElement(
+        XElement parent,
+        SchemaElement element,
+        string path,
+        Dictionary<string, object?> data,
+        IProviderRuleResolver resolver,
+        Dictionary<string, SchemaComplexType> typeMap,
+        XNamespace ns,
+        List<SerializationError> errors)
+    {
+        if (typeMap.TryGetValue(element.TypeName, out var childType))
+        {
+            var hasChildData = data.Keys.Any(k =>
+                k.StartsWith(path + ".", StringComparison.Ordinal) ||
+                k == path);
+
+            if (hasChildData)
+            {
+                var childElement = new XElement(ns + element.Name);
+
+                var idPath = $"{path}.@Id";
+                if (data.TryGetValue(idPath, out var idValue) && idValue is not null)
+                    childElement.SetAttributeValue("Id", idValue.ToString());
+
+                BuildComplexTypeContent(childElement, childType, path, data, resolver, typeMap, ns, errors);
+                parent.Add(childElement);
+            }
+            else if (element.IsRequired)
+            {
+                errors.Add(new SerializationError(SerializationErrorKind.InputError,
+                    path, $"Required complex element '{element.Name}' has no data"));
+            }
+            return;
+        }
+
+        // Simple element
+        if (data.TryGetValue(path, out var value) && value is not null)
+        {
+            var formatted = ApplyFormatting(element.Name, value.ToString()!, resolver);
+            parent.Add(new XElement(ns + element.Name, formatted));
+        }
+        else
+        {
+            var defaultValue = resolver.ResolveDefault(element.Name);
+            if (defaultValue is not null)
+            {
+                parent.Add(new XElement(ns + element.Name, defaultValue));
+            }
+            else if (element.IsRequired && !element.IsChoice)
+            {
+                errors.Add(new SerializationError(SerializationErrorKind.InputError,
+                    path, $"Required element '{element.Name}' has no value and no default"));
+            }
+        }
+    }
+
+    private static string ApplyFormatting(string fieldName, string value, IProviderRuleResolver resolver)
+    {
+        var rule = resolver.ResolveFormatting(fieldName);
+        if (rule is null) return value;
+
+        var result = value;
+
+        if (rule.DigitsOnly == true)
+            result = new string(result.Where(char.IsDigit).ToArray());
+
+        if (rule.RemoveChars is not null)
+        {
+            foreach (var c in rule.RemoveChars)
+                result = result.Replace(c.ToString(), string.Empty);
+        }
+
+        if (rule.Trim == true)
+            result = result.Trim();
+
+        if (rule.PadLeft.HasValue && rule.PadChar is not null)
+            result = result.PadLeft(rule.PadLeft.Value, rule.PadChar[0]);
+
+        if (rule.MaxLength.HasValue && result.Length > rule.MaxLength.Value)
+            result = result[..rule.MaxLength.Value];
+
+        return result;
+    }
+
+    private static List<string> ValidateXmlAgainstXsd(string xml, string xsdDir)
+    {
+        var errors = new List<string>();
+        var schemaSet = new XmlSchemaSet();
+
+        foreach (var file in Directory.GetFiles(xsdDir, "*.xsd"))
+        {
+            try
+            {
+                var settings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Parse };
+                using var reader = XmlReader.Create(file, settings);
+                var schema = XmlSchema.Read(reader, null);
+                if (schema is not null)
+                    schemaSet.Add(schema);
+            }
+            catch (Exception ex)
+            {
+                errors.Add($"Failed to load XSD {Path.GetFileName(file)}: {ex.Message}");
+            }
+        }
+
+        try { schemaSet.Compile(); }
+        catch (Exception ex)
+        {
+            errors.Add($"Schema compilation failed: {ex.Message}");
+            return errors;
+        }
+
+        var validationSettings = new XmlReaderSettings
+        {
+            Schemas = schemaSet,
+            ValidationType = ValidationType.Schema
+        };
+        validationSettings.ValidationEventHandler += (_, e) =>
+            errors.Add($"[{e.Severity}] {e.Message}");
+
+        using var xmlReader = XmlReader.Create(new StringReader(xml), validationSettings);
+        try { while (xmlReader.Read()) { } }
+        catch (XmlException ex) { errors.Add($"XML parse error: {ex.Message}"); }
+
+        return errors;
+    }
+}

--- a/src/SemanaIA.ServiceInvoice.XmlGeneration/SchemaEngine/SerializationResult.cs
+++ b/src/SemanaIA.ServiceInvoice.XmlGeneration/SchemaEngine/SerializationResult.cs
@@ -1,0 +1,31 @@
+namespace SemanaIA.ServiceInvoice.XmlGeneration.SchemaEngine;
+
+public enum SerializationErrorKind
+{
+    InputError,
+    RuleError,
+    SchemaError,
+    InternalError
+}
+
+public record SerializationError(
+    SerializationErrorKind Kind,
+    string Field,
+    string Message,
+    string? Details = null);
+
+public record SerializationResult(
+    string? Xml,
+    bool IsValid,
+    List<SerializationError> Errors,
+    List<string> ValidationErrors)
+{
+    public static SerializationResult Success(string xml) =>
+        new(xml, true, [], []);
+
+    public static SerializationResult SuccessWithValidationErrors(string xml, List<string> validationErrors) =>
+        new(xml, false, [], validationErrors);
+
+    public static SerializationResult Failure(List<SerializationError> errors) =>
+        new(null, false, errors, []);
+}

--- a/src/SemanaIA.ServiceInvoice.XmlGeneration/SchemaEngine/XsdSchemaAnalyzer.cs
+++ b/src/SemanaIA.ServiceInvoice.XmlGeneration/SchemaEngine/XsdSchemaAnalyzer.cs
@@ -51,6 +51,8 @@ public class XsdSchemaAnalyzer
 
         if (ct.ContentTypeParticle is XmlSchemaSequence sequence)
             ExtractElements(sequence, elements);
+        else if (ct.ContentTypeParticle is XmlSchemaChoice topChoice)
+            ExtractElements(topChoice, elements, "choice_top");
 
         return new SchemaComplexType(ct.Name ?? "anonymous", elements, annotation);
     }

--- a/tests/SemanaIA.ServiceInvoice.UnitTests/SchemaEngine/SchemaBasedXmlSerializerTests.cs
+++ b/tests/SemanaIA.ServiceInvoice.UnitTests/SchemaEngine/SchemaBasedXmlSerializerTests.cs
@@ -1,0 +1,230 @@
+using System.Xml.Linq;
+using SemanaIA.ServiceInvoice.XmlGeneration.SchemaEngine;
+using Shouldly;
+
+namespace SemanaIA.ServiceInvoice.UnitTests.SchemaEngine;
+
+public class SchemaBasedXmlSerializerTests
+{
+    private static readonly XNamespace Ns = "http://www.sped.fazenda.gov.br/nfse";
+    private readonly SchemaBasedXmlSerializer _sut = new();
+
+    // ==========================================================
+    // Nacional minimal
+    // ==========================================================
+
+    [Fact]
+    public void Given_NacionalMinimalData_Should_ProduceValidXml()
+    {
+        // Arrange
+        var schema = AnalyzeNacional();
+        var resolver = LoadNacionalResolver();
+        var data = NacionalMinimalData();
+
+        // Act
+        var result = _sut.SerializeAndValidate(
+            schema, data, resolver,
+            "TCDPS", "DPS",
+            FindXsdDir("nacional"),
+            "1.01");
+
+        // Assert
+        result.Xml.ShouldNotBeNull();
+        result.Errors.ShouldBeEmpty($"Serialization errors:\n{string.Join("\n", result.Errors.Select(e => $"{e.Kind}: {e.Field} - {e.Message}"))}");
+
+        var xml = result.Xml!;
+
+        result.ValidationErrors.ShouldBeEmpty($"XSD validation errors:\n{string.Join("\n", result.ValidationErrors)}\n\nFull XML:\n{xml}");
+        result.IsValid.ShouldBeTrue();
+
+        var root = XDocument.Parse(result.Xml).Root!;
+        root.Name.LocalName.ShouldBe("DPS");
+        root.Attribute("versao")?.Value.ShouldBe("1.01");
+    }
+
+    // ==========================================================
+    // Choice resolution
+    // ==========================================================
+
+    [Fact]
+    public void Given_ChoiceWithCnpj_Should_EmitOnlyCnpjElement()
+    {
+        // Arrange
+        var schema = AnalyzeNacional();
+        var resolver = LoadNacionalResolver();
+        var data = NacionalMinimalData();
+
+        // Act
+        var result = _sut.Serialize(schema, data, resolver, "TCDPS", "DPS", "1.01");
+
+        // Assert
+        result.Xml.ShouldNotBeNull();
+        var xml = XDocument.Parse(result.Xml);
+        var prest = xml.Descendants(Ns + "prest").FirstOrDefault();
+        prest.ShouldNotBeNull();
+        prest!.Element(Ns + "CNPJ").ShouldNotBeNull();
+        prest.Element(Ns + "CPF").ShouldBeNull();
+        prest.Element(Ns + "NIF").ShouldBeNull();
+    }
+
+    // ==========================================================
+    // Optional elements
+    // ==========================================================
+
+    [Fact]
+    public void Given_OptionalElementAbsent_Should_OmitFromXml()
+    {
+        // Arrange
+        var schema = AnalyzeNacional();
+        var resolver = LoadNacionalResolver();
+        var data = NacionalMinimalData();
+        // toma is optional — no toma data provided
+
+        // Act
+        var result = _sut.Serialize(schema, data, resolver, "TCDPS", "DPS", "1.01");
+
+        // Assert
+        result.Xml.ShouldNotBeNull();
+        var xml = XDocument.Parse(result.Xml);
+        xml.Descendants(Ns + "toma").ShouldBeEmpty();
+    }
+
+    // ==========================================================
+    // Required missing
+    // ==========================================================
+
+    [Fact]
+    public void Given_RequiredElementMissing_Should_ReturnInputError()
+    {
+        // Arrange
+        var schema = AnalyzeNacional();
+        var resolver = LoadNacionalResolver();
+        var data = new Dictionary<string, object?>
+        {
+            // Missing tpAmb, dhEmi, etc. — only partial data
+            ["infDPS.serie"] = "00001"
+        };
+
+        // Act
+        var result = _sut.Serialize(schema, data, resolver, "TCDPS", "DPS", "1.01");
+
+        // Assert
+        result.IsValid.ShouldBeFalse();
+        result.Errors.Count.ShouldBeGreaterThan(0);
+        result.Errors.ShouldContain(e => e.Kind == SerializationErrorKind.InputError);
+    }
+
+    // ==========================================================
+    // Formatting applied
+    // ==========================================================
+
+    [Fact]
+    public void Given_FormattingRule_Should_ApplyPadLeftToValue()
+    {
+        // Arrange
+        var schema = AnalyzeNacional();
+        var resolver = LoadNacionalResolver();
+        var data = NacionalMinimalData();
+        data["infDPS.serv.cServ.cTribNac"] = "101"; // should become "000101"
+
+        // Act
+        var result = _sut.Serialize(schema, data, resolver, "TCDPS", "DPS", "1.01");
+
+        // Assert
+        result.Xml.ShouldNotBeNull();
+        result.Xml.ShouldContain("000101");
+    }
+
+    // ==========================================================
+    // Default from resolver
+    // ==========================================================
+
+    [Fact]
+    public void Given_DefaultFromResolver_Should_UseWhenValueAbsent()
+    {
+        // Arrange
+        var schema = AnalyzeNacional();
+        var resolver = LoadNacionalResolver();
+        var data = NacionalMinimalData();
+        data.Remove("infDPS.tpEmit"); // resolver has default tpEmit=1
+
+        // Act
+        var result = _sut.Serialize(schema, data, resolver, "TCDPS", "DPS", "1.01");
+
+        // Assert
+        result.Xml.ShouldNotBeNull();
+        result.Xml.ShouldContain("<tpEmit");
+    }
+
+    // ==========================================================
+    // Helpers privados (final da classe)
+    // ==========================================================
+
+    private static SchemaDocument AnalyzeNacional() =>
+        new XsdSchemaAnalyzer().Analyze(FindXsdPath("nacional", "DPS_v1.01.xsd"));
+
+    private static ProviderRuleResolver LoadNacionalResolver() =>
+        ProviderRuleResolver.LoadFromFile(FindRulesPath("nacional"));
+
+    private static Dictionary<string, object?> NacionalMinimalData() => new()
+    {
+        ["infDPS.@Id"] = "DPS355030820000000000000000010000000000000001",
+        ["infDPS.tpAmb"] = "2",
+        ["infDPS.dhEmi"] = "2026-01-20T10:00:00-03:00",
+        ["infDPS.verAplic"] = "V_1.00.02",
+        ["infDPS.serie"] = "00001",
+        ["infDPS.nDPS"] = "1",
+        ["infDPS.dCompet"] = "2026-01-20",
+        ["infDPS.tpEmit"] = "1",
+        ["infDPS.cLocEmi"] = "3550308",
+        ["infDPS.prest.CNPJ"] = "00000000000000",
+        ["infDPS.prest.regTrib.opSimpNac"] = "1",
+        ["infDPS.prest.regTrib.regEspTrib"] = "0",
+        ["infDPS.serv.locPrest.cLocPrestacao"] = "3550308",
+        ["infDPS.serv.cServ.cTribNac"] = "000101",
+        ["infDPS.serv.cServ.xDescServ"] = "Servico de teste runtime",
+        ["infDPS.serv.cServ.cNBS"] = "101010100",
+        ["infDPS.valores.vServPrest.vServ"] = "1000.00",
+        ["infDPS.valores.trib.tribMun.tribISSQN"] = "1",
+        ["infDPS.valores.trib.tribMun.tpRetISSQN"] = "1",
+        ["infDPS.valores.trib.totTrib.vTotTrib.vTotTribFed"] = "0.00",
+        ["infDPS.valores.trib.totTrib.vTotTrib.vTotTribEst"] = "0.00",
+        ["infDPS.valores.trib.totTrib.vTotTrib.vTotTribMun"] = "0.00"
+    };
+
+    private static string FindXsdPath(string provider, string fileName)
+    {
+        var dir = AppContext.BaseDirectory;
+        while (dir is not null)
+        {
+            var candidate = Path.Combine(dir, "providers", provider, "xsd", fileName);
+            if (File.Exists(candidate)) return candidate;
+            dir = Directory.GetParent(dir)?.FullName;
+        }
+        throw new FileNotFoundException($"XSD not found: {provider}/{fileName}");
+    }
+
+    private static string FindXsdDir(string provider)
+    {
+        var dir = AppContext.BaseDirectory;
+        while (dir is not null)
+        {
+            var candidate = Path.Combine(dir, "providers", provider, "xsd");
+            if (Directory.Exists(candidate)) return candidate;
+            dir = Directory.GetParent(dir)?.FullName;
+        }
+        throw new DirectoryNotFoundException($"XSD dir not found: {provider}");
+    }
+
+    private static string FindRulesPath(string provider)
+    {
+        var dir = AppContext.BaseDirectory;
+        while (dir is not null)
+        {
+            var candidate = Path.Combine(dir, "providers", provider, "rules", "base-rules.json");
+            if (File.Exists(candidate)) return candidate;
+            dir = Directory.GetParent(dir)?.FullName;
+        }
+        throw new FileNotFoundException($"Rules not found: {provider}");
+    }
+}


### PR DESCRIPTION
Runtime XML serializer driven by SchemaModel + ProviderRuleResolver:

- Add SchemaBasedXmlSerializer: traverses SchemaModel tree to produce XML via XElement (not XBuilder — dynamic element names require XElement), resolves choices, applies formatting/defaults
- Add SerializationResult with error classification (InputError, RuleError, SchemaError, InternalError)
- Add SerializeAndValidate: generates XML + validates against XSD
- Fix XsdSchemaAnalyzer: handle XmlSchemaChoice at complexType top level (was only handling XmlSchemaSequence)
- Fix EmitChoiceGroup: use prefix matching for complex type children inside choice groups
- Add spec nfse-runtime-xml-serializer
- 6 new tests: minimal valid, choice, optional, required missing, formatting, defaults — all with XSD validation
- 117/117 tests passing
- Archive change runtime-schema-based-xml-serializer