### PR TITLE
feat(engine): add multi-level path binding support to runtime binder

### DIFF
--- a/openspec/changes/archive/2026-03-22-add-multi-level-path-binding-support-to-runtime-binder/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-22-add-multi-level-path-binding-support-to-runtime-binder/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-22

--- a/openspec/changes/archive/2026-03-22-add-multi-level-path-binding-support-to-runtime-binder/design.md
+++ b/openspec/changes/archive/2026-03-22-add-multi-level-path-binding-support-to-runtime-binder/design.md
@@ -1,0 +1,82 @@
+## Context
+
+O `ServiceInvoiceSchemaDataBinder` converte `DpsDocument` em `Dictionary<string, object?>` usando bindings do `ProviderProfile`. O Nacional usa paths diretos como `infDPS.tpAmb` → `Environment`. O serializer consome esse dicionário e navega pelo schema emitindo elementos.
+
+ISSNet usa o mesmo schema nacional (`sped.fazenda.gov.br/nfse`) mas envelopa em:
+```
+EnviarLoteDpsEnvio (root, inline type)
+  └── LoteDps (tcLoteDps)
+       ├── NumeroLote (obrigatório)
+       ├── Prestador (tcIdentificacaoPrestadorDps, obrigatório)
+       │    └── CNPJ/CPF (choice)
+       ├── QuantidadeDps (obrigatório)
+       └── ListaDps (inline type)
+            └── DPS (TCDPS, unbounded)
+                 └── infDPS (TCInfDPS)
+```
+
+O serializer espera encontrar `LoteDps.NumeroLote`, `LoteDps.Prestador.CNPJ`, etc. no dicionário. Mas o binder só gera paths como `infDPS.tpAmb`, sem os wrappers.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Permitir que o binder gere dados para wrapper elements intermediários via configuração JSON
+- Suportar path prefix para remap de bindings do domínio para paths mais profundos
+- ISSNet avançar de FAIL para PASS ou ter gap reduzido e diagnosticado
+- Nacional, ABRASF e GISSOnline continuarem PASS (zero regressão)
+
+**Non-Goals:**
+- Gerar wrappers automaticamente a partir do schema (sem inferência — usa configuração explícita)
+- Suportar lotes com múltiplos DPS (apenas 1 DPS por lote nesta fase)
+- Onboarding completo de Paulistana e Simpliss
+
+## Decisions
+
+### 1. Wrapper bindings como seção no base-rules.json
+
+**Decisão:** Adicionar seção `wrapperBindings` no `base-rules.json` que define valores estáticos e mapeamentos para wrapper elements.
+
+**Formato:**
+```json
+{
+  "wrapperBindings": {
+    "LoteDps.NumeroLote": "1",
+    "LoteDps.Prestador.CNPJ": "Provider.Cnpj | padLeft:14:0",
+    "LoteDps.QuantidadeDps": "1"
+  }
+}
+```
+
+**Alternativa considerada:** Configuração de wrapper hierárquico com `rootWrapper.children`. Rejeitada por ser mais complexa e não reutilizar o formato de binding já existente.
+
+**Racional:** Reutiliza exatamente o mesmo formato de binding já usado na seção `bindings` (path → expression com pipes). O binder processa `wrapperBindings` antes de `bindings`, gerando dados para os níveis intermediários.
+
+### 2. Path prefix para rebasing de bindings
+
+**Decisão:** Adicionar campo `bindingPathPrefix` no `base-rules.json`. Quando presente, todos os paths de `bindings` são prefixados automaticamente.
+
+**Exemplo:** Se `bindingPathPrefix = "LoteDps.ListaDps.DPS"`, o binding `infDPS.tpAmb` se torna `LoteDps.ListaDps.DPS.infDPS.tpAmb`.
+
+**Alternativa considerada:** Duplicar todos os bindings do Nacional com o prefixo completo na seção `bindings` do ISSNet. Rejeitada por violar DRY — os bindings internos do DPS são idênticos ao Nacional.
+
+**Racional:** O Nacional e o ISSNet compartilham a mesma estrutura de DPS/infDPS. A diferença é apenas o envelope. O prefixo permite reutilizar exatamente os mesmos bindings do Nacional dentro do ISSNet.
+
+### 3. Processamento de wrapperBindings no binder
+
+**Decisão:** O `ServiceInvoiceSchemaDataBinder.Bind()` processa `wrapperBindings` primeiro, depois aplica `bindingPathPrefix` a cada path de `bindings`, e finalmente processa os bindings normais.
+
+**Racional:** Garante que os dados de wrapper já existem no dicionário quando o serializer começa a navegar pelo schema. A ordem é: wrappers → dados internos.
+
+### 4. Sem mudanças no serializer
+
+**Decisão:** Nenhuma mudança no `SchemaBasedXmlSerializer`. O serializer já navega corretamente por qualquer profundidade de schema — o problema é apenas que o dicionário de dados não tinha os paths intermediários.
+
+**Racional:** A mudança é 100% na camada de binding/input, não na camada de serialização.
+
+## Risks / Trade-offs
+
+- **[Risco] Regressão em Nacional/ABRASF/GISSOnline** → Mitigation: `bindingPathPrefix` e `wrapperBindings` são opcionais. Quando ausentes, o comportamento é idêntico ao atual.
+
+- **[Risco] ISSNet schema pode ter requisitos adicionais** → Mitigation: O schema ISSNet é baseado no Nacional (`sped.fazenda.gov.br/nfse`). A estrutura interna de DPS é idêntica. Os wrappers são a única diferença estrutural.
+
+- **[Trade-off] Configuração explícita vs inferência** → Preferimos configuração explícita por ser previsível e debuggable, embora exija manutenção manual do `base-rules.json` por provider.

--- a/openspec/changes/archive/2026-03-22-add-multi-level-path-binding-support-to-runtime-binder/proposal.md
+++ b/openspec/changes/archive/2026-03-22-add-multi-level-path-binding-support-to-runtime-binder/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+Providers como ISSNet encapsulam o DPS em wrappers multi-nível (`EnviarLoteDpsEnvio → LoteDps → ListaDps → DPS → infDPS`), enquanto o binder atual assume paths partindo diretamente do primeiro filho do root. Isso impede que o runtime serializer preencha os wrappers intermediários (`LoteDps`, `NumeroLote`, `Prestador`, `QuantidadeDps`, `ListaDps`), gerando erro "Required complex element 'LoteDps' has no data". Com multi-namespace e anonymous inline types já resolvidos, multi-level path binding é o último bloqueio estrutural para ISSNet.
+
+## What Changes
+
+- Estender `ProviderProfile` para suportar configuração de wrapper elements (`wrapperBindings`) no `base-rules.json`, definindo dados estáticos e mapeamentos para elementos wrapper intermediários
+- Ajustar `ServiceInvoiceSchemaDataBinder` para gerar dados de wrapper elements a partir da configuração do provider antes de aplicar os bindings regulares
+- Ajustar `ServiceInvoiceSchemaDataBinder` para suportar path prefix configurável, permitindo que bindings do domínio sejam remapeados para paths mais profundos do schema
+- Configurar `providers/issnet/rules/base-rules.json` com bindings completos incluindo wrappers
+- Expandir testes de validação XSD para ISSNet com dados mínimos completos
+- Atualizar relatório sumarizado por provider
+
+## Capabilities
+
+### New Capabilities
+
+_Nenhuma capability nova — a mudança estende capabilities existentes._
+
+### Modified Capabilities
+
+- `nfse-runtime-xml-serializer`: Ajustar o binder para suportar wrapper element binding e path prefix, permitindo gerar dados de entrada corretos para schemas com múltiplos níveis de encapsulamento
+
+## Impact
+
+- **ProviderProfile.cs**: Nova seção `WrapperBindings` para configuração de elementos wrapper
+- **ServiceInvoiceSchemaDataBinder.cs**: Lógica de geração de wrapper data + suporte a path prefix
+- **providers/issnet/rules/base-rules.json**: Configuração completa de bindings com wrappers
+- **AllProvidersXsdValidationSummaryTests.cs**: Atualização de expectativas para ISSNet
+- **runtime-xsd-validation-summary.md**: Atualização do relatório
+- **Providers estáveis**: Nacional, ABRASF e GISSOnline devem continuar PASS (regressão zero)

--- a/openspec/changes/archive/2026-03-22-add-multi-level-path-binding-support-to-runtime-binder/specs/nfse-runtime-xml-serializer/spec.md
+++ b/openspec/changes/archive/2026-03-22-add-multi-level-path-binding-support-to-runtime-binder/specs/nfse-runtime-xml-serializer/spec.md
@@ -1,0 +1,51 @@
+## MODIFIED Requirements
+
+### Requirement: Domain-to-schema data binding
+
+O `ServiceInvoiceSchemaDataBinder` MUST converter `DpsDocument` em `Dictionary<string, object?>` compatível com o serializer runtime, usando bindings configuráveis por provider (seção `bindings` no `base-rules.json`). O `SchemaSerializationPipeline` MUST orquestrar binding → serialização → validação XSD a partir de `DpsDocument` + providerName.
+
+O binder MUST suportar `wrapperBindings` para gerar dados de wrapper elements intermediários antes dos bindings regulares. O binder MUST suportar `bindingPathPrefix` para prefixar automaticamente os paths de `bindings` quando o schema exigir nesting mais profundo.
+
+#### Scenario: End-to-end pipeline with DpsDocument
+- **WHEN** um DpsDocument válido é processado pelo pipeline para o provider nacional
+- **THEN** o resultado contém XML válido contra o XSD
+
+#### Scenario: Pipeline with production-like data
+- **WHEN** dados equivalentes a um documento real de produção (com provider, borrower, IbsCbs) são processados
+- **THEN** o XML gerado passa validação XSD e contém os CNPJs esperados
+
+#### Scenario: Pipeline with wrapper bindings for ISSNet
+- **WHEN** um DpsDocument é processado pelo pipeline para o provider ISSNet
+- **THEN** o binder gera dados de wrapper (`LoteDps.NumeroLote`, `LoteDps.Prestador`, `LoteDps.QuantidadeDps`) a partir de `wrapperBindings`
+- **AND** os bindings regulares são prefixados com `bindingPathPrefix` gerando paths como `LoteDps.ListaDps.DPS.infDPS.tpAmb`
+- **AND** o XML resultante é válido contra o XSD do ISSNet
+
+#### Scenario: Wrapper bindings absent preserves current behavior
+- **WHEN** um provider sem `wrapperBindings` e sem `bindingPathPrefix` é processado
+- **THEN** o comportamento é idêntico ao anterior (Nacional, ABRASF, GISSOnline continuam PASS)
+
+## ADDED Requirements
+
+### Requirement: Wrapper element binding support
+
+O `ProviderProfile` MUST suportar seção `wrapperBindings` (Dictionary<string, string>) no `base-rules.json`. Cada entrada mapeia um path de wrapper element a uma expressão de binding (valor estático ou expressão com pipes). O `ServiceInvoiceSchemaDataBinder` MUST processar `wrapperBindings` antes de `bindings`.
+
+#### Scenario: Static wrapper value
+- **WHEN** `wrapperBindings` contém `"LoteDps.NumeroLote": "1"`
+- **THEN** o binder adiciona `data["LoteDps.NumeroLote"] = "1"` ao dicionário
+
+#### Scenario: Dynamic wrapper value with pipe
+- **WHEN** `wrapperBindings` contém `"LoteDps.Prestador.CNPJ": "Provider.Cnpj | padLeft:14:0"`
+- **THEN** o binder resolve `Provider.Cnpj` do `DpsDocument`, aplica pipe `padLeft:14:0`, e adiciona ao dicionário
+
+### Requirement: Binding path prefix support
+
+O `ProviderProfile` MUST suportar campo `bindingPathPrefix` (string?) no `base-rules.json`. Quando presente, todos os paths da seção `bindings` MUST ser prefixados automaticamente com esse valor antes de serem adicionados ao dicionário.
+
+#### Scenario: Path prefix applied to bindings
+- **WHEN** `bindingPathPrefix` é `"LoteDps.ListaDps.DPS"` e `bindings` contém `"infDPS.tpAmb": "Environment"`
+- **THEN** o binder adiciona `data["LoteDps.ListaDps.DPS.infDPS.tpAmb"]` ao dicionário
+
+#### Scenario: No prefix preserves current paths
+- **WHEN** `bindingPathPrefix` é null ou ausente
+- **THEN** os paths de `bindings` são usados sem alteração (comportamento atual)

--- a/openspec/changes/archive/2026-03-22-add-multi-level-path-binding-support-to-runtime-binder/tasks.md
+++ b/openspec/changes/archive/2026-03-22-add-multi-level-path-binding-support-to-runtime-binder/tasks.md
@@ -1,0 +1,31 @@
+## 1. Modelo de configuração — ProviderProfile
+
+- [x] 1.1 Adicionar propriedade `WrapperBindings` (Dictionary<string, string>?) ao `ProviderProfile` com suporte a deserialização JSON
+- [x] 1.2 Adicionar propriedade `BindingPathPrefix` (string?) ao `ProviderProfile` com suporte a deserialização JSON
+
+## 2. Binder — suporte a wrapper bindings e path prefix
+
+- [x] 2.1 Ajustar `ServiceInvoiceSchemaDataBinder.Bind()` para processar `wrapperBindings` antes de `bindings`, gerando dados de wrapper elements no dicionário
+- [x] 2.2 Ajustar `ServiceInvoiceSchemaDataBinder.Bind()` para prefixar paths de `bindings` com `bindingPathPrefix` quando presente
+- [x] 2.3 Garantir que `wrapperBindings` suporta expressões de binding existentes (valor estático, property path, pipes como padLeft, format, enum)
+- [x] 2.4 Garantir que providers sem `wrapperBindings` e sem `bindingPathPrefix` mantêm comportamento idêntico ao atual (zero regressão)
+
+## 3. Configuração do provider ISSNet
+
+- [x] 3.1 Configurar `providers/issnet/rules/base-rules.json` com `wrapperBindings` para `LoteDps.NumeroLote`, `LoteDps.Prestador`, `LoteDps.QuantidadeDps`
+- [x] 3.2 Configurar `bindingPathPrefix` como `"LoteDps.ListaDps.DPS"` no `base-rules.json` do ISSNet
+- [x] 3.3 Configurar `bindings` do ISSNet reutilizando os mesmos bindings internos do Nacional (infDPS.*)
+- [x] 3.4 Configurar `rootComplexTypeName` e `rootElementName` corretos para ISSNet no pipeline
+
+## 4. Testes unitários e validação
+
+- [x] 4.1 Criar testes unitários para wrapper bindings no binder (valor estático + expressão com pipe)
+- [x] 4.2 Criar testes unitários para path prefix no binder
+- [x] 4.3 Criar/ajustar testes de runtime XML para ISSNet com dados mínimos e validação contra XSD
+- [x] 4.4 Garantir que testes existentes de Nacional, ABRASF e GISSOnline continuam passando (zero regressão)
+
+## 5. Relatório e validação por provider
+
+- [x] 5.1 Atualizar `AllProvidersXsdValidationSummaryTests` para incluir teste runtime de ISSNet com dados do binder
+- [x] 5.2 Atualizar `runtime-xsd-validation-summary.md` com status atualizado de todos os providers
+- [x] 5.3 Documentar gaps remanescentes por provider com motivo técnico explícito

--- a/openspec/specs/nfse-runtime-xml-serializer/spec.md
+++ b/openspec/specs/nfse-runtime-xml-serializer/spec.md
@@ -94,6 +94,8 @@ O projeto MUST ter um extension method centralizado `ShouldBeValidAgainstProvide
 
 O `ServiceInvoiceSchemaDataBinder` MUST converter `DpsDocument` em `Dictionary<string, object?>` compatível com o serializer runtime, usando bindings configuráveis por provider (seção `bindings` no `base-rules.json`). O `SchemaSerializationPipeline` MUST orquestrar binding → serialização → validação XSD a partir de `DpsDocument` + providerName.
 
+O binder MUST suportar `wrapperBindings` para gerar dados de wrapper elements intermediários antes dos bindings regulares. O binder MUST suportar `bindingPathPrefix` para prefixar automaticamente os paths de `bindings` quando o schema exigir nesting mais profundo.
+
 #### Scenario: End-to-end pipeline with DpsDocument
 - **WHEN** um DpsDocument válido é processado pelo pipeline para o provider nacional
 - **THEN** o resultado contém XML válido contra o XSD
@@ -101,6 +103,40 @@ O `ServiceInvoiceSchemaDataBinder` MUST converter `DpsDocument` em `Dictionary<s
 #### Scenario: Pipeline with production-like data
 - **WHEN** dados equivalentes a um documento real de produção (com provider, borrower, IbsCbs) são processados
 - **THEN** o XML gerado passa validação XSD e contém os CNPJs esperados
+
+#### Scenario: Pipeline with wrapper bindings for ISSNet
+- **WHEN** um DpsDocument é processado pelo pipeline para o provider ISSNet
+- **THEN** o binder gera dados de wrapper (`LoteDps.NumeroLote`, `LoteDps.Prestador`, `LoteDps.QuantidadeDps`) a partir de `wrapperBindings`
+- **AND** os bindings regulares são prefixados com `bindingPathPrefix` gerando paths como `LoteDps.ListaDps.DPS.infDPS.tpAmb`
+- **AND** o XML resultante é válido contra o XSD do ISSNet
+
+#### Scenario: Wrapper bindings absent preserves current behavior
+- **WHEN** um provider sem `wrapperBindings` e sem `bindingPathPrefix` é processado
+- **THEN** o comportamento é idêntico ao anterior (Nacional, ABRASF, GISSOnline continuam PASS)
+
+### Requirement: Wrapper element binding support
+
+O `ProviderProfile` MUST suportar seção `wrapperBindings` (Dictionary<string, string>) no `base-rules.json`. Cada entrada mapeia um path de wrapper element a uma expressão de binding (valor estático ou expressão com pipes). O `ServiceInvoiceSchemaDataBinder` MUST processar `wrapperBindings` antes de `bindings`.
+
+#### Scenario: Static wrapper value
+- **WHEN** `wrapperBindings` contém `"LoteDps.NumeroLote": "const:1"`
+- **THEN** o binder adiciona `data["LoteDps.NumeroLote"] = "1"` ao dicionário
+
+#### Scenario: Dynamic wrapper value with pipe
+- **WHEN** `wrapperBindings` contém `"LoteDps.Prestador.CNPJ": "Provider.Cnpj | padLeft:14:0"`
+- **THEN** o binder resolve `Provider.Cnpj` do `DpsDocument`, aplica pipe `padLeft:14:0`, e adiciona ao dicionário
+
+### Requirement: Binding path prefix support
+
+O `ProviderProfile` MUST suportar campo `bindingPathPrefix` (string?) no `base-rules.json`. Quando presente, todos os paths da seção `bindings` MUST ser prefixados automaticamente com esse valor antes de serem adicionados ao dicionário.
+
+#### Scenario: Path prefix applied to bindings
+- **WHEN** `bindingPathPrefix` é `"LoteDps.ListaDps.DPS"` e `bindings` contém `"infDPS.tpAmb": "Environment"`
+- **THEN** o binder adiciona `data["LoteDps.ListaDps.DPS.infDPS.tpAmb"]` ao dicionário
+
+#### Scenario: No prefix preserves current paths
+- **WHEN** `bindingPathPrefix` é null ou ausente
+- **THEN** os paths de `bindings` são usados sem alteração (comportamento atual)
 
 ### Requirement: All-provider validation summary
 

--- a/providers/issnet/rules/base-rules.json
+++ b/providers/issnet/rules/base-rules.json
@@ -1,12 +1,158 @@
 {
   "provider": "issnet",
   "version": "1.01",
-  "description": "Regras complementares do ISSNet — usa schema DPS nacional",
+  "description": "Regras complementares do ISSNet — usa schema DPS nacional com envelope LoteDps",
   "constants": {
     "namespace": "http://www.sped.fazenda.gov.br/nfse"
   },
-  "defaults": {},
-  "enums": {},
-  "formatting": {},
-  "conditionals": {}
+  "rootComplexTypeName": "_anon_EnviarLoteDpsEnvio",
+  "rootElementName": "EnviarLoteDpsEnvio",
+  "bindingPathPrefix": "LoteDps.ListaDps.DPS",
+  "wrapperBindings": {
+    "LoteDps.@versao": "const:1.01",
+    "LoteDps.NumeroLote": "const:1",
+    "LoteDps.Prestador.CNPJ": "Provider.Cnpj | padLeft:14:0",
+    "LoteDps.Prestador.IM": "Provider.MunicipalTaxNumber",
+    "LoteDps.QuantidadeDps": "const:1",
+    "LoteDps.ListaDps.DPS.@versao": "const:1.01"
+  },
+  "defaults": {
+    "tpAmb": 2,
+    "tpEmit": 1,
+    "opSimpNac": 1,
+    "regEspTrib": 0,
+    "tpRetISSQN": 1,
+    "finNFSe": "0",
+    "indFinal": "0",
+    "indDest": "0",
+    "indTotTrib": "0"
+  },
+  "enums": {
+    "tribISSQN": {
+      "WithinCity": "1",
+      "OutsideCity": "1",
+      "Immune": "2",
+      "Export": "3",
+      "Free": "4",
+      "_default": "1"
+    },
+    "tpRetISSQN": {
+      "NotWithheld": "1",
+      "WithheldByBuyer": "2",
+      "WithheldByIntermediary": "3"
+    },
+    "tpImunidade": {
+      "NotInformed": "0",
+      "Heritage": "1",
+      "Temple": "2",
+      "PoliticalParty": "3",
+      "BooksPressPaper": "4",
+      "Phonograms": "5"
+    },
+    "tpSusp": {
+      "SuspendedCourtDecision": "1",
+      "SuspendedAdministrativeProcedure": "2"
+    },
+    "tpDedRed": {
+      "FoodAndBeverages": "1",
+      "Materials": "2",
+      "ConsortiumPassThrough": "5",
+      "HealthPlanPassThrough": "6",
+      "Services": "7",
+      "Subcontracting": "8",
+      "Other": "99"
+    },
+    "finNFSe": {
+      "Regular": "0"
+    },
+    "indFinal": {
+      "false": "0",
+      "true": "1"
+    },
+    "indDest": {
+      "SameAsBuyer": "0",
+      "DifferentFromBuyer": "1"
+    },
+    "tpRetPisCofins": {
+      "Retained": "1",
+      "NotRetained": "2",
+      "_note": "XSD v1.01 aceita apenas 1 e 2. Produção usa 0-9 em XSD mais recente."
+    },
+    "opSimpNac": {
+      "MicroempreendedorIndividual": "2",
+      "SimplesNacional": "3",
+      "_default": "1"
+    },
+    "cNaoNIF": {
+      "NotInformedOriginal": "0",
+      "Exempted": "1",
+      "NotRequired": "2"
+    }
+  },
+  "formatting": {
+    "cTribNac": { "padLeft": 6, "padChar": "0", "digitsOnly": true, "maxLength": 6 },
+    "cTribMun": { "digitsOnly": true },
+    "CEP": { "removeChars": "-", "trim": true },
+    "CST": { "padLeft": 2, "padChar": "0" },
+    "cIndOp": { "padLeft": 6, "padChar": "0", "maxLength": 6 },
+    "cClassTrib": { "padLeft": 6, "padChar": "0" },
+    "CSTReg": { "padLeft": 3, "padChar": "0" },
+    "cClassTribReg": { "padLeft": 6, "padChar": "0" },
+    "CNPJ": { "padLeft": 14, "padChar": "0" },
+    "CPF": { "padLeft": 11, "padChar": "0" },
+    "mecAFComexP": { "padLeft": 2, "padChar": "0", "maxValue": 8 },
+    "mecAFComexT": { "padLeft": 2, "padChar": "0", "maxValue": 26 },
+    "nDI": { "maxLength": 12 },
+    "nRE": { "maxLength": 12 },
+    "tpReeRepRes": { "padLeft": 2, "padChar": "0" },
+    "nProcesso": { "digitsOnly": true }
+  },
+  "conditionals": {
+    "toma": { "emitWhen": "tpRetISSQN in [2, 3] OR borrower.federalTaxNumber != 0 OR borrower.address.country != BRA" },
+    "interm": { "emitWhen": "intermediary != null" },
+    "IBSCBS": { "emitWhen": "ibsCbs.classCode != null" },
+    "tpImunidade": { "emitWhen": "tribISSQN == 2" },
+    "cPaisResult": { "emitWhen": "tribISSQN == 3" },
+    "exigSusp": { "emitWhen": "taxationType in [SuspendedCourtDecision, SuspendedAdministrativeProcedure] AND suspension.processNumber != null" },
+    "BM": { "emitWhen": "benefit.id != null AND (benefit.id.length == 14 OR benefit.amount > 0)" },
+    "pAliq": { "emitWhen": "issRate > 0 AND taxationType NOT IN [Export, Immune]" },
+    "tribFed": { "emitWhen": "anyOf(pisAmountWithheld, cofinsAmountWithheld, pisAmount, cofinsAmount, pisRate, cofinsRate, pisCofinsBaseTax, cstPisCofins, inssAmountWithheld, csllAmountWithheld, irAmountWithheld) > 0" },
+    "vDescCondIncond": { "emitWhen": "discountConditionedAmount > 0 OR discountUnconditionedAmount > 0" },
+    "comExt": { "emitWhen": "foreignTrade != null" },
+    "lsadppu": { "emitWhen": "lease != null" },
+    "obra": { "emitWhen": "construction != null" },
+    "atvEvento": { "emitWhen": "activityEvent.name != null" },
+    "infoCompl": { "emitWhen": "additionalInformationGroup hasAnyField OR additionalInformation != null" },
+    "gTribRegular": { "emitWhen": "ibsCbs.regularTaxation.classCode != null" },
+    "gDif": { "emitWhen": "ibsCbs.deferment != null" },
+    "dest": { "emitWhen": "ibsCbs.destinationIndicator == DifferentFromBuyer AND ibsCbs.recipient != null" },
+    "imovel": { "emitWhen": "ibsCbs.realEstate != null AND (realEstate.hasRegistration OR realEstate.hasCib OR realEstate.hasAddress)" },
+    "gReeRepRes": { "emitWhen": "ibsCbs.thirdPartyReimbursements.documents.count > 0" }
+  },
+  "bindings": {
+    "infDPS.@Id": "BuildId",
+    "infDPS.tpAmb": "Environment",
+    "infDPS.dhEmi": "IssuedOn | format:yyyy-MM-ddTHH:mm:sszzz",
+    "infDPS.verAplic": "Version",
+    "infDPS.serie": "Series",
+    "infDPS.nDPS": "Number",
+    "infDPS.dCompet": "CompetenceDate | format:yyyy-MM-dd",
+    "infDPS.tpEmit": "const:1",
+    "infDPS.cLocEmi": "Provider.MunicipalityCode",
+    "infDPS.prest.CNPJ": "Provider.Cnpj | padLeft:14:0",
+    "infDPS.prest.IM": "Provider.MunicipalTaxNumber",
+    "infDPS.prest.regTrib.opSimpNac": "Provider.TaxRegime | enum:opSimpNac",
+    "infDPS.prest.regTrib.regEspTrib": "Provider.SpecialTaxRegime | nullable:0",
+    "infDPS.serv.locPrest.cLocPrestacao": "Provider.MunicipalityCode",
+    "infDPS.serv.cServ.cTribNac": "Service.FederalServiceCode | digitsOnly | padLeft:6:0",
+    "infDPS.serv.cServ.cTribMun": "CityServiceCode",
+    "infDPS.serv.cServ.xDescServ": "Service.Description",
+    "infDPS.serv.cServ.cNBS": "Service.NbsCode | digitsOnly",
+    "infDPS.valores.vServPrest.vServ": "Values.ServicesAmount | decimal:2",
+    "infDPS.valores.trib.tribMun.tribISSQN": "Values.TaxationType | enum:tribISSQN",
+    "infDPS.valores.trib.tribMun.tpRetISSQN": "Values.RetentionType | nullable:1",
+    "infDPS.valores.trib.totTrib.vTotTrib.vTotTribFed": "const:0.00",
+    "infDPS.valores.trib.totTrib.vTotTrib.vTotTribEst": "const:0.00",
+    "infDPS.valores.trib.totTrib.vTotTrib.vTotTribMun": "const:0.00"
+  }
 }

--- a/providers/runtime-xsd-validation-summary.md
+++ b/providers/runtime-xsd-validation-summary.md
@@ -5,14 +5,14 @@
 | Nacional | TCDPS/DPS | Single | PASS | CNPJ/CPF/NIF/cNaoNIF | tpAmb→valores | tpAmb,dhEmi,serie,prest,serv,valores |
 | ABRASF | EnviarLoteRpsEnvio (inline) | Single | PASS | Cpf/Cnpj choice | NumeroLote→ListaRps | None |
 | GISSOnline | EnviarLoteRpsEnvio (inline) | Multi | PASS | Cpf/Cnpj choice | NumeroLote→ListaRps+IBSCBS | None |
-| ISSNet | EnviarLoteDpsEnvio (inline) | Single | FAIL | CNPJ/CPF choice | tpAmb→valores via DPS | Errors: Required complex element 'LoteDps' has no data |
+| ISSNet | EnviarLoteDpsEnvio (inline) | Single | PASS | CNPJ/CPF choice | LoteDps→ListaDps→DPS via binder | None |
 | Paulistana | PedidoEnvioLoteRPS (inline) | Multi | ANALYZED (32 types) | CPF/CNPJ | Cabecalho→ListaRPS | Data bindings not yet configured |
 | Simpliss | nfse (ABRASF-based) | Single | ANALYZED (58 types) | Cpf/Cnpj | NumeroLote→ListaRps | Data bindings not yet configured |
 
 ## Summary
 
 **Total providers:** 6
-**Runtime XML validated (XSD pass):** 3/4 (Nacional, ABRASF, GISSOnline, ISSNet)
+**Runtime XML validated (XSD pass):** 4/4 (Nacional, ABRASF, GISSOnline, ISSNet)
 **Schema analyzed:** Paulistana (32 types), Simpliss (58 types)
 **Inline type support:** Enabled — anonymous complexTypes resolved recursively
 **Multi-namespace support:** Enabled — elements emitted in correct namespace per type
@@ -21,6 +21,5 @@
 
 | Provider | Gap | Reason |
 |----------|-----|--------|
-| ISSNet | Errors: Required complex element 'LoteDps' has no data | LoteDps wrapper requires specific data bindings not yet mapped |
 | Paulistana | Schema analyzed only | Data bindings not yet configured for SP municipal schema |
 | Simpliss | Schema analyzed only | ABRASF-based schema; data bindings not yet configured |

--- a/src/SemanaIA.ServiceInvoice.XmlGeneration/SchemaEngine/ProviderProfile.cs
+++ b/src/SemanaIA.ServiceInvoice.XmlGeneration/SchemaEngine/ProviderProfile.cs
@@ -22,6 +22,18 @@ public class ProviderProfile
     [JsonPropertyName("conditionals")]
     public Dictionary<string, ConditionalRule>? Conditionals { get; set; }
 
+    [JsonPropertyName("rootComplexTypeName")]
+    public string? RootComplexTypeName { get; init; }
+
+    [JsonPropertyName("rootElementName")]
+    public string? RootElementName { get; init; }
+
+    [JsonPropertyName("wrapperBindings")]
+    public Dictionary<string, string>? WrapperBindings { get; init; }
+
+    [JsonPropertyName("bindingPathPrefix")]
+    public string? BindingPathPrefix { get; init; }
+
     [JsonPropertyName("bindings")]
     public Dictionary<string, string>? Bindings { get; set; }
 }

--- a/src/SemanaIA.ServiceInvoice.XmlGeneration/SchemaEngine/SchemaSerializationPipeline.cs
+++ b/src/SemanaIA.ServiceInvoice.XmlGeneration/SchemaEngine/SchemaSerializationPipeline.cs
@@ -60,10 +60,12 @@ public class SchemaSerializationPipeline
 
         var resolvedVersion = version ?? profile.Version;
         var resolver = new ProviderRuleResolver(profile);
+        var resolvedRootComplexTypeName = profile.RootComplexTypeName ?? rootComplexTypeName;
+        var resolvedRootElementName = profile.RootElementName ?? rootElementName;
 
         return _serializer.SerializeAndValidate(
             schema, data, resolver,
-            rootComplexTypeName, rootElementName,
+            resolvedRootComplexTypeName, resolvedRootElementName,
             xsdDir, resolvedVersion);
     }
 

--- a/src/SemanaIA.ServiceInvoice.XmlGeneration/SchemaEngine/ServiceInvoiceSchemaDataBinder.cs
+++ b/src/SemanaIA.ServiceInvoice.XmlGeneration/SchemaEngine/ServiceInvoiceSchemaDataBinder.cs
@@ -9,17 +9,34 @@ public class ServiceInvoiceSchemaDataBinder
     public Dictionary<string, object?> Bind(DpsDocument document, ProviderProfile profile)
     {
         var data = new Dictionary<string, object?>();
+        var resolver = new ProviderRuleResolver(profile);
+
+        if (profile.WrapperBindings is not null)
+        {
+            foreach (var (schemaPath, expression) in profile.WrapperBindings)
+            {
+                var resolvedValue = ResolveExpression(document, expression, resolver, profile);
+                if (resolvedValue is not null)
+                    data[schemaPath] = resolvedValue;
+            }
+        }
 
         if (profile.Bindings is null)
             return data;
 
-        var resolver = new ProviderRuleResolver(profile);
+        var hasPathPrefix = !string.IsNullOrEmpty(profile.BindingPathPrefix);
 
         foreach (var (schemaPath, expression) in profile.Bindings)
         {
-            var value = ResolveExpression(document, expression, resolver, profile);
-            if (value is not null)
-                data[schemaPath] = value;
+            var resolvedValue = ResolveExpression(document, expression, resolver, profile);
+            if (resolvedValue is null)
+                continue;
+
+            var fullSchemaPath = hasPathPrefix
+                ? $"{profile.BindingPathPrefix}.{schemaPath}"
+                : schemaPath;
+
+            data[fullSchemaPath] = resolvedValue;
         }
 
         return data;

--- a/tests/SemanaIA.ServiceInvoice.UnitTests/SchemaEngine/AllProvidersXsdValidationSummaryTests.cs
+++ b/tests/SemanaIA.ServiceInvoice.UnitTests/SchemaEngine/AllProvidersXsdValidationSummaryTests.cs
@@ -1,5 +1,7 @@
 using System.Text;
+using System.Text.Json;
 using System.Xml.Linq;
+using SemanaIA.ServiceInvoice.Domain.Models;
 using SemanaIA.ServiceInvoice.XmlGeneration.SchemaEngine;
 using Shouldly;
 
@@ -14,6 +16,7 @@ public class AllProvidersXsdValidationSummaryTests
 {
     private static readonly SchemaBasedXmlSerializer Serializer = new();
     private static readonly XsdSchemaAnalyzer Analyzer = new();
+    private static readonly ServiceInvoiceSchemaDataBinder Binder = new();
 
     // ==========================================================
     // Nacional — pipeline end-to-end with XSD validation
@@ -295,6 +298,104 @@ public class AllProvidersXsdValidationSummaryTests
         schema.RootInlineType!.Elements.Count.ShouldBeGreaterThan(0);
     }
 
+    [Fact]
+    public void Given_IssnetMinimalDataViaBinder_Should_ProduceXsdValidXml()
+    {
+        // Arrange
+        var schema = AnalyzeProvider("issnet", "schema_v101.xsd");
+        var profile = LoadIssnetProfile();
+        var resolver = new ProviderRuleResolver(profile);
+        var document = CreateIssnetMinimalDocument();
+        var data = Binder.Bind(document, profile);
+
+        // Act
+        var result = Serializer.SerializeAndValidate(
+            schema, data, resolver,
+            profile.RootComplexTypeName!, profile.RootElementName!,
+            FindXsdDir("issnet"));
+
+        // Assert
+        result.Xml.ShouldNotBeNull($"Errors: {string.Join("\n", result.Errors.Select(e => $"{e.Kind}: {e.Field} - {e.Message}"))}");
+        result.ValidationErrors.ShouldBeEmpty($"ISSNet XSD errors:\n{string.Join("\n", result.ValidationErrors)}\nXML:\n{result.Xml}");
+        result.IsValid.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Given_IssnetXml_Should_EmitLoteDpsWrapperWithCorrectStructure()
+    {
+        // Arrange
+        var schema = AnalyzeProvider("issnet", "schema_v101.xsd");
+        var profile = LoadIssnetProfile();
+        var resolver = new ProviderRuleResolver(profile);
+        var document = CreateIssnetMinimalDocument();
+        var data = Binder.Bind(document, profile);
+
+        // Act
+        var result = Serializer.Serialize(
+            schema, data, resolver,
+            profile.RootComplexTypeName!, profile.RootElementName!);
+
+        // Assert
+        result.Xml.ShouldNotBeNull();
+        var ns = XNamespace.Get("http://www.sped.fazenda.gov.br/nfse");
+        var doc = XDocument.Parse(result.Xml!);
+
+        var root = doc.Root!;
+        root.Name.LocalName.ShouldBe("EnviarLoteDpsEnvio");
+
+        var loteDps = root.Element(ns + "LoteDps");
+        loteDps.ShouldNotBeNull("LoteDps wrapper element should be present");
+        loteDps!.Attribute("versao")?.Value.ShouldBe("1.01");
+
+        var numeroLote = loteDps.Element(ns + "NumeroLote");
+        numeroLote.ShouldNotBeNull("NumeroLote should be present inside LoteDps");
+
+        var prestador = loteDps.Element(ns + "Prestador");
+        prestador.ShouldNotBeNull("Prestador should be present inside LoteDps");
+        prestador!.Element(ns + "CNPJ").ShouldNotBeNull("Prestador CNPJ should be present");
+        prestador.Element(ns + "IM").ShouldNotBeNull("Prestador IM should be present");
+
+        var quantidadeDps = loteDps.Element(ns + "QuantidadeDps");
+        quantidadeDps.ShouldNotBeNull("QuantidadeDps should be present inside LoteDps");
+
+        var listaDps = loteDps.Element(ns + "ListaDps");
+        listaDps.ShouldNotBeNull("ListaDps should be present inside LoteDps");
+
+        var dps = listaDps!.Element(ns + "DPS");
+        dps.ShouldNotBeNull("DPS element should be present inside ListaDps");
+
+        var infDps = dps!.Element(ns + "infDPS");
+        infDps.ShouldNotBeNull("infDPS should be present inside DPS");
+    }
+
+    [Fact]
+    public void Given_IssnetBinderData_Should_PrefixAllBindingsWithLoteDpsListaDpsDps()
+    {
+        // Arrange
+        var profile = LoadIssnetProfile();
+        var document = CreateIssnetMinimalDocument();
+
+        // Act
+        var data = Binder.Bind(document, profile);
+
+        // Assert — wrapper bindings should be at top level (LoteDps.*)
+        data.ShouldContainKey("LoteDps.@versao");
+        data.ShouldContainKey("LoteDps.NumeroLote");
+        data.ShouldContainKey("LoteDps.Prestador.CNPJ");
+        data.ShouldContainKey("LoteDps.Prestador.IM");
+        data.ShouldContainKey("LoteDps.QuantidadeDps");
+
+        // Assert — regular bindings should be prefixed with LoteDps.ListaDps.DPS
+        data.ShouldContainKey("LoteDps.ListaDps.DPS.infDPS.tpAmb");
+        data.ShouldContainKey("LoteDps.ListaDps.DPS.infDPS.prest.CNPJ");
+        data.ShouldContainKey("LoteDps.ListaDps.DPS.infDPS.serv.cServ.cTribNac");
+        data.ShouldContainKey("LoteDps.ListaDps.DPS.infDPS.valores.vServPrest.vServ");
+
+        // Assert — no unprefixed binding keys should exist
+        data.Keys.Where(k => k.StartsWith("infDPS.")).ShouldBeEmpty(
+            "All infDPS bindings should be prefixed with LoteDps.ListaDps.DPS");
+    }
+
     // ==========================================================
     // Paulistana — SP municipal schema
     // ==========================================================
@@ -339,14 +440,17 @@ public class AllProvidersXsdValidationSummaryTests
         var gissResult = TestProvider("gissonline", "enviar-lote-rps-envio-v2_04.xsd", "_anon_EnviarLoteRpsEnvio", "EnviarLoteRpsEnvio", GissonlineMinimalData(), null);
         report.AppendLine($"| GISSOnline | EnviarLoteRpsEnvio (inline) | {FormatNamespaceType(gissSchema)} | {FormatValidationStatus(gissResult)} | Cpf/Cnpj choice | NumeroLote→ListaRps+IBSCBS | {DescribeValidationGap(gissResult)} |");
 
-        // ISSNet
+        // ISSNet — binder-based approach with wrapper bindings and path prefix
         var issnetSchema = AnalyzeProvider("issnet", "schema_v101.xsd");
-        var issnetData = new Dictionary<string, object?>();
-        foreach (var (k, v) in NacionalMinimalData()) issnetData[$"DPS.{k}"] = v;
-        issnetData["DPS.infDPS.prest.IM"] = "12345";
-        issnetData["DPS.infDPS.serv.cServ.cTribMun"] = "040101";
-        var issnetResult = TestProvider("issnet", "schema_v101.xsd", "_anon_EnviarLoteDpsEnvio", "EnviarLoteDpsEnvio", issnetData, null);
-        report.AppendLine($"| ISSNet | EnviarLoteDpsEnvio (inline) | {FormatNamespaceType(issnetSchema)} | {FormatValidationStatus(issnetResult)} | CNPJ/CPF choice | tpAmb→valores via DPS | {DescribeValidationGap(issnetResult)} |");
+        var issnetProfile = LoadIssnetProfile();
+        var issnetResolver = new ProviderRuleResolver(issnetProfile);
+        var issnetDocument = CreateIssnetMinimalDocument();
+        var issnetData = Binder.Bind(issnetDocument, issnetProfile);
+        var issnetResult = Serializer.SerializeAndValidate(
+            issnetSchema, issnetData, issnetResolver,
+            issnetProfile.RootComplexTypeName!, issnetProfile.RootElementName!,
+            FindXsdDir("issnet"));
+        report.AppendLine($"| ISSNet | EnviarLoteDpsEnvio (inline) | {FormatNamespaceType(issnetSchema)} | {FormatValidationStatus(issnetResult)} | CNPJ/CPF choice | LoteDps→ListaDps→DPS via binder | {DescribeValidationGap(issnetResult)} |");
 
         // Paulistana
         var paulistanaSchema = AnalyzeProvider("paulistana", "PedidoEnvioLoteRPS_v02.xsd");
@@ -381,7 +485,8 @@ public class AllProvidersXsdValidationSummaryTests
         report.AppendLine();
         report.AppendLine("| Provider | Gap | Reason |");
         report.AppendLine("|----------|-----|--------|");
-        report.AppendLine($"| ISSNet | {DescribeValidationGap(issnetResult)} | LoteDps wrapper requires specific data bindings not yet mapped |");
+        if (!issnetResult.IsValid)
+            report.AppendLine($"| ISSNet | {DescribeValidationGap(issnetResult)} | Binder-based wrapper bindings need adjustment |");
         report.AppendLine($"| Paulistana | Schema analyzed only | Data bindings not yet configured for SP municipal schema |");
         if (simplissIncluded)
             report.AppendLine($"| Simpliss | Schema analyzed only | ABRASF-based schema; data bindings not yet configured |");
@@ -392,6 +497,7 @@ public class AllProvidersXsdValidationSummaryTests
         // Assert
         File.Exists(reportPath).ShouldBeTrue();
         nacResult.IsValid.ShouldBeTrue("Nacional should be XSD valid");
+        issnetResult.IsValid.ShouldBeTrue("ISSNet should be XSD valid via binder");
     }
 
     // ==========================================================
@@ -476,6 +582,42 @@ public class AllProvidersXsdValidationSummaryTests
     // ==========================================================
     // Helpers privados (final da classe)
     // ==========================================================
+
+    private static DpsDocument CreateIssnetMinimalDocument() => new()
+    {
+        Environment = 2,
+        Version = "V_1.00.02",
+        Series = "00001",
+        Number = 1,
+        IssuedOn = new DateTimeOffset(2026, 1, 20, 10, 0, 0, TimeSpan.FromHours(-3)),
+        CompetenceDate = new DateOnly(2026, 1, 20),
+        CityServiceCode = "040101",
+        Provider = new Provider
+        {
+            Cnpj = "00000000000000",
+            MunicipalTaxNumber = "12345",
+            MunicipalityCode = "3550308"
+        },
+        Service = new Service
+        {
+            FederalServiceCode = "01.01",
+            Description = "Servico ISSNet runtime",
+            NbsCode = "101010100",
+            MunicipalityCode = "3550308"
+        },
+        Values = new Values
+        {
+            ServicesAmount = 1000.00m,
+            TaxationType = TaxationType.WithinCity
+        }
+    };
+
+    private static ProviderProfile LoadIssnetProfile()
+    {
+        var path = FindRulesPath("issnet");
+        var json = File.ReadAllText(path);
+        return JsonSerializer.Deserialize<ProviderProfile>(json)!;
+    }
 
     private static SerializationResult TestProvider(string provider, string xsdFile, string rootType, string rootElement, Dictionary<string, object?> data, string? version)
     {

--- a/tests/SemanaIA.ServiceInvoice.UnitTests/SchemaEngine/ServiceInvoiceSchemaDataBinderTests.cs
+++ b/tests/SemanaIA.ServiceInvoice.UnitTests/SchemaEngine/ServiceInvoiceSchemaDataBinderTests.cs
@@ -90,6 +90,141 @@ public class ServiceInvoiceSchemaDataBinderTests
     }
 
     // ==========================================================
+    // WrapperBindings
+    // ==========================================================
+
+    [Fact]
+    public void Given_WrapperBindingsWithStaticValue_Should_AddToData()
+    {
+        // Arrange
+        var doc = CreateMinimalDocument();
+        var profile = new ProviderProfile
+        {
+            WrapperBindings = new Dictionary<string, string>
+            {
+                { "LoteDps.NumeroLote", "const:1" }
+            }
+        };
+
+        // Act
+        var data = _sut.Bind(doc, profile);
+
+        // Assert
+        data.ShouldContainKey("LoteDps.NumeroLote");
+        data["LoteDps.NumeroLote"].ShouldBe("1");
+    }
+
+    [Fact]
+    public void Given_WrapperBindingsWithDynamicExpression_Should_ResolveAndAddToData()
+    {
+        // Arrange
+        var doc = CreateMinimalDocument();
+        doc.Provider.Cnpj = "12345678000100";
+        var profile = new ProviderProfile
+        {
+            WrapperBindings = new Dictionary<string, string>
+            {
+                { "LoteDps.Prestador.CNPJ", "Provider.Cnpj | padLeft:14:0" }
+            }
+        };
+
+        // Act
+        var data = _sut.Bind(doc, profile);
+
+        // Assert
+        data.ShouldContainKey("LoteDps.Prestador.CNPJ");
+        data["LoteDps.Prestador.CNPJ"].ShouldBe("12345678000100");
+    }
+
+    // ==========================================================
+    // BindingPathPrefix
+    // ==========================================================
+
+    [Fact]
+    public void Given_BindingPathPrefix_Should_PrefixAllBindingPaths()
+    {
+        // Arrange
+        var doc = CreateMinimalDocument();
+        var profile = new ProviderProfile
+        {
+            BindingPathPrefix = "LoteDps.ListaDps.DPS",
+            Bindings = new Dictionary<string, string>
+            {
+                { "infDPS.tpAmb", "Environment" }
+            }
+        };
+
+        // Act
+        var data = _sut.Bind(doc, profile);
+
+        // Assert
+        data.ShouldContainKey("LoteDps.ListaDps.DPS.infDPS.tpAmb");
+        data.ShouldNotContainKey("infDPS.tpAmb");
+    }
+
+    [Fact]
+    public void Given_NoWrapperBindingsOrPrefix_Should_PreserveCurrentBehavior()
+    {
+        // Arrange
+        var doc = CreateMinimalDocument();
+        var profile = new ProviderProfile
+        {
+            Bindings = new Dictionary<string, string>
+            {
+                { "infDPS.tpAmb", "Environment" }
+            }
+        };
+
+        // Act
+        var data = _sut.Bind(doc, profile);
+
+        // Assert
+        data.ShouldContainKey("infDPS.tpAmb");
+        data["infDPS.tpAmb"]!.ToString().ShouldBe("2");
+    }
+
+    // ==========================================================
+    // WrapperBindings + BindingPathPrefix combined
+    // ==========================================================
+
+    [Fact]
+    public void Given_WrapperAndRegularBindings_Should_ProcessBothCorrectly()
+    {
+        // Arrange
+        var doc = CreateMinimalDocument();
+        doc.Provider.Cnpj = "11222333000181";
+        var profile = new ProviderProfile
+        {
+            WrapperBindings = new Dictionary<string, string>
+            {
+                { "LoteDps.NumeroLote", "const:1" },
+                { "LoteDps.Prestador.CNPJ", "Provider.Cnpj | padLeft:14:0" }
+            },
+            BindingPathPrefix = "LoteDps.ListaDps.DPS",
+            Bindings = new Dictionary<string, string>
+            {
+                { "infDPS.tpAmb", "Environment" },
+                { "infDPS.serie", "Series" }
+            }
+        };
+
+        // Act
+        var data = _sut.Bind(doc, profile);
+
+        // Assert — wrapper paths exist without prefix
+        data.ShouldContainKey("LoteDps.NumeroLote");
+        data["LoteDps.NumeroLote"].ShouldBe("1");
+        data.ShouldContainKey("LoteDps.Prestador.CNPJ");
+        data["LoteDps.Prestador.CNPJ"].ShouldBe("11222333000181");
+
+        // Assert — regular bindings have prefix applied
+        data.ShouldContainKey("LoteDps.ListaDps.DPS.infDPS.tpAmb");
+        data.ShouldContainKey("LoteDps.ListaDps.DPS.infDPS.serie");
+        data.ShouldNotContainKey("infDPS.tpAmb");
+        data.ShouldNotContainKey("infDPS.serie");
+    }
+
+    // ==========================================================
     // Helpers privados (final da classe)
     // ==========================================================
 


### PR DESCRIPTION
- Add wrapperBindings and bindingPathPrefix to ProviderProfile
- Binder processes wrapper elements before regular bindings
- BindingPathPrefix auto-prefixes all binding paths for deep schemas
- Add rootComplexTypeName/rootElementName to profile config
- ISSNet advances from FAIL to PASS (4/4 providers now runtime valid)
- 8 new tests (5 binder unit + 3 ISSNet XSD), 148/148 total passing
- Specs synced, change archived