### PR TITLE
docs: add product roadmap from MVP to enterprise with macrophase backlog

### DIFF
--- a/docs/product-roadmap.md
+++ b/docs/product-roadmap.md
@@ -1,0 +1,168 @@
+# NFS-e Schema-Driven Engine — Product Roadmap
+
+## Mapa de Maturidade Atual
+
+| Camada | Status | O que existe | O que falta |
+|--------|--------|-------------|-------------|
+| **Domain** | Complete | DpsDocument, Provider, Borrower, Values, IbsCbs, INfseXmlGenerator, IProviderOnboardingService, NfseXmlGenerationResult | - |
+| **Engine (XmlGeneration)** | Complete | XsdSchemaAnalyzer, SchemaBasedXmlSerializer, ServiceInvoiceSchemaDataBinder, SchemaSerializationPipeline, ProviderResolver, ProviderSerializerFactory, ProviderOnboardingValidator, ProviderConfigGenerator, ProviderSampleDocumentGenerator, CommonFieldMappingDictionary | Seleção inteligente de XSD, inferência de conditionals/enums |
+| **Application** | Complete | GenerateNfseXmlUseCase (depende só de INfseXmlGenerator) | - |
+| **Infrastructure** | Complete | SchemaEngineNfseXmlGenerator, ProviderOnboardingService, AddNfseInfrastructure() | Certificado digital, logging estruturado |
+| **API** | Complete | POST /nfse/xml, POST /providers/onboard, GET /providers, GET /providers/{name}/status | Autenticação, rate limiting, versionamento |
+| **Providers** | Partial | 6 providers base (4 PASS, 2 SupportConfigOnly), 44/52 providers externos onboarded em load test | Paulistana (Assinatura), 8 providers com XSD conflitante |
+| **Manual Baseline** | Complete | NationalDpsManualSerializer (~900 linhas, 19 Build methods), IbsCbsManualBuilder | Usado como fallback |
+| **Testes** | Complete | 179 unit + 18 integration + 4 load tests, todos passando | Testes de contrato, mutation testing |
+| **Onion Architecture** | Complete | Domain → Application → Infrastructure → XmlGeneration → API | - |
+
+---
+
+## Histórico de Evolução (20 Changes por IA)
+
+### Fase 1: MVP Funcional ✅
+
+| # | Change | Entrega |
+|---|--------|---------|
+| 1 | nfse-openapi-sync-expand-dtos | Sincronização OpenAPI + expansão de DTOs |
+| 2 | create-manual-nfse-national-serializer | Serializer manual nacional |
+| 3 | complete-manual-nfse-serializer-baseline | Baseline consolidado com 74% cobertura XSD |
+| 4 | implement-ibscbs-gap-from-xsd-and-production-rules | IBSCBS completo |
+| 5 | implement-advanced-ibscbs-subblocks | Sub-blocos avançados (deferimento, reembolso) |
+| 6 | integrate-ibscbs-mapper-and-endpoint-tests | Integração mapper + testes endpoint |
+| 7 | integrate-manual-serializer-endpoint | Endpoint funcional |
+
+**Definition of Done:** Serializer manual funcional, endpoint retornando XML DPS válido, testes E2E.
+
+### Fase 2: Engine Multi-Provider ✅
+
+| # | Change | Entrega |
+|---|--------|---------|
+| 8 | bootstrap-national-xsd-generation-engine | XsdSchemaAnalyzer + SchemaModel |
+| 9 | generate-national-artifacts-from-schema-model | Geração de artefatos por provider |
+| 10 | compare-generated-artifacts-with-manual-baseline | Comparação engine vs manual |
+| 11 | prove-build-time-generation-with-abrasf-schema | ABRASF comprovado |
+| 12 | prove-build-time-generation-with-gissonline-schema | GISSOnline comprovado |
+| 13 | analyze-full-xsd-coverage-with-multiagent-mcp-lsp | Análise multiagente |
+| 14 | runtime-schema-based-xml-serializer | SchemaBasedXmlSerializer runtime |
+| 15 | bind-serviceinvoice-to-runtime-schema-serializer | Data binding domínio→schema |
+| 16 | add-anonymous-inline-types-support | Inline types (ABRASF PASS) |
+| 17 | add-multi-namespace-support | Multi-namespace (GISSOnline PASS) |
+| 18 | add-multi-level-path-binding-support | Wrapper bindings (ISSNet PASS) |
+
+**Definition of Done:** 4/6 providers com runtime XML válido contra XSD, choice/sequence/inline types/multi-namespace suportados.
+
+### Fase 3: Onboarding Operacional ✅
+
+| # | Change | Entrega |
+|---|--------|---------|
+| 19 | create-provider-onboarding-workflow-for-support | ProviderResolver, Factory, Validator, endpoints API, Onion Architecture |
+| 20 | create-support-friendly-provider-onboarding-layer | Auto-config generation, OperationalStatus, load test 52 providers |
+
+**Definition of Done:** Endpoint POST /providers/onboard funcional, auto-geração de config, 44/52 providers reais onboarded, diagnóstico acionável.
+
+---
+
+## Fase 4: Production Ready ⬜
+
+### Critérios de Aceite
+- [ ] Todos os 6 providers base com runtime XML PASS
+- [ ] Seleção inteligente de XSD (apenas schemas de envio, não todos)
+- [ ] Certificado digital integrado no pipeline
+- [ ] Logging estruturado por provider/request
+- [ ] Error handling padronizado com correlation ID
+- [ ] Health check endpoint
+- [ ] CI/CD com testes automatizados
+- [ ] 100% dos testes existentes passando em CI
+- [ ] Documentação de API (Swagger/OpenAPI atualizado)
+- [ ] Substituição do serializer manual para pelo menos 1 provider em produção
+
+### Backlog
+
+| Prioridade | Item | Tipo | Descrição |
+|-----------|------|------|-----------|
+| P0 | Seleção inteligente de XSD | DEV | Filtrar apenas XSD de envio quando provider tem múltiplos schemas (resolve 8 providers que falharam no load test) |
+| P0 | Paulistana: campo Assinatura | DEV | Implementar geração de hash de assinatura digital para o schema SP |
+| P0 | Certificado digital no pipeline | DEV+INFRA | Integrar A1/A3 para assinatura XML obrigatória em produção |
+| P0 | Error handling com correlation ID | DEV | Padronizar respostas de erro com traceability |
+| P1 | Logging estruturado | DEV+INFRA | Serilog/OpenTelemetry por provider/request/operação |
+| P1 | Health check endpoint | DEV | /health com status de providers disponíveis |
+| P1 | CI/CD pipeline | INFRA | GitHub Actions: build, test, deploy staging |
+| P1 | Inferência de conditionals | DEV | Auto-gerar regras `emitWhen` a partir de elements opcionais/choice |
+| P1 | Inferência de enums | DEV | Mapear enumerações XSD para domínio automaticamente |
+| P2 | Swagger/OpenAPI atualizado | DEV | Documentar todos os endpoints com exemplos |
+| P2 | Rate limiting | INFRA | Limitar requests por API key/tenant |
+| P2 | Substituir manual por engine (nacional) | DEV | Quando engine cobrir 100% do nacional, trocar o fallback |
+| P2 | Testes de contrato | DEV | Validar que a API não quebra consumidores existentes |
+
+---
+
+## Fase 5: Enterprise Ready ⬜
+
+### Critérios de Aceite
+- [ ] Multi-tenancy com isolamento de dados
+- [ ] Provider registry dinâmico (banco/API, não só filesystem)
+- [ ] Dashboard de monitoramento por provider/município
+- [ ] SLA por provider (retry, circuit breaker, fallback)
+- [ ] Audit trail completo de XML gerado
+- [ ] Versionamento de provider config com rollback
+- [ ] Suporte a lote com múltiplos DPS
+- [ ] Cache de schema analysis por provider
+- [ ] API key management
+- [ ] Frontend para onboarding self-service
+
+### Backlog
+
+| Prioridade | Item | Tipo | Descrição |
+|-----------|------|------|-----------|
+| P0 | Multi-tenancy | DEV+INFRA | Isolamento de providers/config por tenant |
+| P0 | Provider registry dinâmico | DEV | Migrar município→provider de JSON para banco com API de CRUD |
+| P0 | Audit trail | DEV | Log imutável de todo XML gerado com metadata |
+| P1 | Dashboard de monitoramento | DEV+INFRA | Grafana/Prometheus: requests/s, erros, latência por provider |
+| P1 | SLA por provider | DEV | Retry policy, circuit breaker, fallback chain |
+| P1 | Lote com múltiplos DPS | DEV | Serializar N documentos por lote (hoje é 1:1) |
+| P1 | Cache de schema analysis | DEV | Evitar re-análise de XSD a cada request |
+| P2 | Versionamento de config | DEV | Histórico de base-rules.json com rollback |
+| P2 | API key management | INFRA | Autenticação e autorização por tenant |
+| P2 | Frontend de onboarding | DEV | UI para upload de XSD, configuração de provider, visualização de status |
+| P2 | Webhook de eventos | DEV | Notificar sistemas externos quando XML é gerado ou provider muda de status |
+
+---
+
+## Riscos e Dependências
+
+| Risco | Impacto | Mitigação |
+|-------|---------|-----------|
+| Certificado digital A1/A3 tem complexidade de integração | Bloqueia produção real | Começar com certificado de teste, integrar lib de assinatura XML existente |
+| Providers com XSD conflitante (8/52 no load test) | Limita onboarding automático | Implementar seleção inteligente de XSD (P0 da Fase 4) |
+| Multi-tenancy exige redesign de storage | Bloqueia enterprise | Planejar desde o início com abstração de storage |
+| Schema cache pode ficar stale | Gera XML com schema desatualizado | Invalidação por hash do arquivo XSD |
+
+## Marcos
+
+| Marco | Fase | Evidência |
+|-------|------|-----------|
+| Primeira NFS-e gerada por engine em staging | Fase 4 | XML válido contra XSD em ambiente não-local |
+| Primeiro provider onboarded por suporte em produção | Fase 4 | POST /providers/onboard → XML gerado sem intervenção de dev |
+| Engine substitui serializer manual para nacional | Fase 4 | Fallback removido, 100% via engine |
+| Primeiro tenant enterprise usando a plataforma | Fase 5 | Multi-tenancy funcional com isolamento |
+| 50+ providers ativos em produção | Fase 5 | Escala comprovada |
+
+---
+
+## Evolução conduzida por IA
+
+Esta POC demonstra que um agente IA (Claude Code com Opus 4.6) pode conduzir a construção de um produto de software desde o conceito até uma versão próxima de produção:
+
+- **20 changes** executadas em sequência
+- **6 fases** de evolução (manual → engine → multi-provider → onboarding → onboarding assistido → roadmap)
+- **179 unit tests + 18 integration + 4 load tests** — todos escritos pelo agente
+- **52 providers reais** testados em carga
+- **Arquitetura Onion** implementada e respeitada
+- **Orquestração multiagente**: spec-agent, implementation-agent, unit-test-agent, xml-test-agent, review-agent
+- **OpenSpec workflow**: propose → apply → review → archive → commit
+
+O agente demonstrou capacidade de:
+1. Entender requisitos de domínio fiscal brasileiro (NFS-e, XSD, providers municipais)
+2. Tomar decisões arquiteturais (Onion, Onion fix, centralização, reuso)
+3. Corrigir direção quando o usuário apontou problemas (API não deve conhecer engine, provider resolve por município)
+4. Evoluir incrementalmente sem regressão (140 → 179 tests, todos passando)
+5. Gerar documentação e roadmap estratégico

--- a/openspec/changes/archive/2026-03-22-evolve-nfse-engine-from-mvp-to-enterprise-product/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-22-evolve-nfse-engine-from-mvp-to-enterprise-product/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-22

--- a/openspec/changes/archive/2026-03-22-evolve-nfse-engine-from-mvp-to-enterprise-product/design.md
+++ b/openspec/changes/archive/2026-03-22-evolve-nfse-engine-from-mvp-to-enterprise-product/design.md
@@ -1,0 +1,56 @@
+## Context
+
+Em 20 changes executadas por agentes IA ao longo de 3 dias, a solução evoluiu de um serializer manual para uma engine schema-driven com:
+- 179 unit tests + 18 integration + 4 load tests
+- 4/6 providers com runtime XML válido contra XSD
+- 44/52 providers reais onboarded em teste de carga
+- Endpoints de onboarding self-service
+- Arquitetura Onion (Domain → Application → Infrastructure → Engine)
+- Auto-geração de configuração de provider a partir do schema
+
+O produto precisa de um roadmap claro para sair de MVP para produção e depois para enterprise.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Mapa claro de onde o produto está hoje
+- Roadmap com 5 macrofases acionáveis
+- Backlog priorizado que o agente pode executar
+- Critérios de aceite por macrofase
+- Classificação de quem resolve cada item (dev vs suporte vs infra)
+
+**Non-Goals:**
+- Implementar qualquer código nesta change
+- Substituir o backlog técnico já existente nos relatórios de provider
+- Definir timeline com datas
+
+## Decisions
+
+### 1. Cinco macrofases de evolução
+
+**Decisão:** Organizar a evolução em 5 macrofases sequenciais, cada uma com Definition of Done clara:
+
+```
+Fase 1: MVP Funcional ✅ (CONCLUÍDA)
+Fase 2: Engine Multi-Provider ✅ (CONCLUÍDA)
+Fase 3: Onboarding Operacional ✅ (CONCLUÍDA)
+Fase 4: Production Ready ⬜ (PRÓXIMA)
+Fase 5: Enterprise Ready ⬜ (FUTURA)
+```
+
+### 2. Classificação de backlog em 3 eixos
+
+**Decisão:** Cada item do backlog é classificado em:
+- **DEV**: Requer desenvolvimento na engine ou arquitetura
+- **OPS**: Configurável pelo suporte (bindings, rules, município codes)
+- **INFRA**: Requer infraestrutura (CI/CD, monitoramento, deploy, certificados)
+
+### 3. Roadmap como documento versionado
+
+**Decisão:** O roadmap é um arquivo `docs/product-roadmap.md` versionado no repositório, atualizável a cada change concluída. Não é um documento externo.
+
+## Risks / Trade-offs
+
+- **[Risco] Escopo do enterprise pode ser maior do que o mapeado** → Mitigation: O roadmap é iterativo. Cada macrofase pode ser refinada quando a anterior for concluída.
+
+- **[Trade-off] Roadmap no repositório vs tool externa** → Mais simples, versionável, e o agente pode atualizar automaticamente. Não substitui um board (Linear, Jira) para gestão de equipe.

--- a/openspec/changes/archive/2026-03-22-evolve-nfse-engine-from-mvp-to-enterprise-product/proposal.md
+++ b/openspec/changes/archive/2026-03-22-evolve-nfse-engine-from-mvp-to-enterprise-product/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+A POC evoluiu de um serializer manual hardcoded para uma engine schema-driven com onboarding assistido, testada com 52 providers reais. O agente conduziu 20 changes em sequência, provando que IA pode construir um produto incrementalmente. Agora é necessário organizar essa evolução como roadmap de produto, identificando o que já foi alcançado, o que falta para produção e o que é necessário para enterprise — para que o agente continue conduzindo a construção com direção clara.
+
+## What Changes
+
+- Documentar o mapa de maturidade atual do produto com status por camada
+- Definir 5 macrofases de evolução: MVP Funcional → Engine Reutilizável → Onboarding Operacional → Production Ready → Enterprise Ready
+- Estruturar backlog priorizado por macrofase com critérios de aceite
+- Classificar cada item como: desenvolvimento, configuração/suporte, ou infraestrutura
+- Identificar gaps críticos para production readiness e enterprise readiness
+- Gerar roadmap acionável que o agente pode executar em changes futuras
+
+## Capabilities
+
+### New Capabilities
+
+- `nfse-product-roadmap`: Roadmap de evolução do produto com macrofases, backlog priorizado e critérios de aceite
+
+### Modified Capabilities
+
+_Nenhuma capability modificada — esta change é de planejamento estratégico._
+
+## Impact
+
+- **Documentação**: Novo roadmap do produto
+- **Backlog**: Organização de próximas changes por macrofase
+- **Specs**: Novas specs poderão ser derivadas do roadmap
+- **Código**: Nenhuma alteração de código nesta change

--- a/openspec/changes/archive/2026-03-22-evolve-nfse-engine-from-mvp-to-enterprise-product/specs/nfse-product-roadmap/spec.md
+++ b/openspec/changes/archive/2026-03-22-evolve-nfse-engine-from-mvp-to-enterprise-product/specs/nfse-product-roadmap/spec.md
@@ -1,0 +1,38 @@
+## ADDED Requirements
+
+### Requirement: Product maturity map
+
+O produto MUST ter um documento de maturidade que classifica o estado atual de cada camada: engine, providers, onboarding, application, infrastructure, testes.
+
+#### Scenario: Maturity map reflects current state
+- **WHEN** o documento de maturidade é consultado
+- **THEN** cada camada tem um status: Complete, Partial, Not Started
+- **AND** cada camada lista o que foi implementado e o que falta
+
+### Requirement: Macrophase roadmap
+
+O produto MUST ter um roadmap com 5 macrofases: MVP Funcional, Engine Multi-Provider, Onboarding Operacional, Production Ready, Enterprise Ready. Cada macrofase MUST ter Definition of Done e backlog associado.
+
+#### Scenario: Completed phases are marked
+- **WHEN** o roadmap é consultado
+- **THEN** Fases 1-3 estão marcadas como concluídas com referência às changes que as implementaram
+
+#### Scenario: Next phase has actionable backlog
+- **WHEN** o roadmap é consultado para a próxima fase (Production Ready)
+- **THEN** o backlog lista itens concretos, cada um classificado como DEV, OPS ou INFRA
+
+### Requirement: Prioritized backlog per macrophase
+
+O backlog MUST ser organizado por macrofase, com cada item classificado como DEV (desenvolvimento), OPS (operação/suporte) ou INFRA (infraestrutura).
+
+#### Scenario: Backlog items have classification
+- **WHEN** um item do backlog é consultado
+- **THEN** tem: descrição, tipo (DEV/OPS/INFRA), prioridade, e macrofase associada
+
+### Requirement: Acceptance criteria per macrophase
+
+Cada macrofase MUST ter critérios de aceite que definem quando a fase está concluída.
+
+#### Scenario: Phase completion is verifiable
+- **WHEN** todos os critérios de aceite de uma macrofase são atendidos
+- **THEN** a macrofase é considerada concluída e o roadmap é atualizado

--- a/openspec/changes/archive/2026-03-22-evolve-nfse-engine-from-mvp-to-enterprise-product/tasks.md
+++ b/openspec/changes/archive/2026-03-22-evolve-nfse-engine-from-mvp-to-enterprise-product/tasks.md
@@ -1,0 +1,25 @@
+## 1. Mapa de maturidade atual
+
+- [x] 1.1 Documentar estado atual de cada camada do produto: Engine, Providers, Onboarding, Application, Domain, Infrastructure, Testes
+- [x] 1.2 Classificar cada camada como: Complete, Partial, Not Started
+- [x] 1.3 Listar o que foi implementado e o que falta em cada camada
+
+## 2. Roadmap de macrofases
+
+- [x] 2.1 Documentar Fase 1 (MVP Funcional) como concluída: serializer manual, baseline, endpoint básico
+- [x] 2.2 Documentar Fase 2 (Engine Multi-Provider) como concluída: schema analysis, runtime serializer, inline types, multi-namespace, multi-level binding
+- [x] 2.3 Documentar Fase 3 (Onboarding Operacional) como concluída: provider resolution, factory, onboarding validator, auto-config generation, endpoints API, load test 52 providers
+- [x] 2.4 Definir Fase 4 (Production Ready): backlog com critérios de aceite
+- [x] 2.5 Definir Fase 5 (Enterprise Ready): backlog com critérios de aceite
+
+## 3. Backlog priorizado
+
+- [x] 3.1 Listar backlog da Fase 4 (Production Ready) classificado por DEV/OPS/INFRA
+- [x] 3.2 Listar backlog da Fase 5 (Enterprise Ready) classificado por DEV/OPS/INFRA
+- [x] 3.3 Priorizar itens dentro de cada fase (P0 = crítico, P1 = importante, P2 = desejável)
+
+## 4. Documento do roadmap
+
+- [x] 4.1 Criar `docs/product-roadmap.md` com: mapa de maturidade, macrofases, backlog, critérios de aceite, riscos e marcos
+- [x] 4.2 Referenciar as 20 changes concluídas como evidência de cada fase
+- [x] 4.3 Incluir seção de evolução do agente IA como condutor do produto

--- a/openspec/specs/nfse-product-roadmap/spec.md
+++ b/openspec/specs/nfse-product-roadmap/spec.md
@@ -1,0 +1,38 @@
+## ADDED Requirements
+
+### Requirement: Product maturity map
+
+O produto MUST ter um documento de maturidade que classifica o estado atual de cada camada: engine, providers, onboarding, application, infrastructure, testes.
+
+#### Scenario: Maturity map reflects current state
+- **WHEN** o documento de maturidade é consultado
+- **THEN** cada camada tem um status: Complete, Partial, Not Started
+- **AND** cada camada lista o que foi implementado e o que falta
+
+### Requirement: Macrophase roadmap
+
+O produto MUST ter um roadmap com 5 macrofases: MVP Funcional, Engine Multi-Provider, Onboarding Operacional, Production Ready, Enterprise Ready. Cada macrofase MUST ter Definition of Done e backlog associado.
+
+#### Scenario: Completed phases are marked
+- **WHEN** o roadmap é consultado
+- **THEN** Fases 1-3 estão marcadas como concluídas com referência às changes que as implementaram
+
+#### Scenario: Next phase has actionable backlog
+- **WHEN** o roadmap é consultado para a próxima fase (Production Ready)
+- **THEN** o backlog lista itens concretos, cada um classificado como DEV, OPS ou INFRA
+
+### Requirement: Prioritized backlog per macrophase
+
+O backlog MUST ser organizado por macrofase, com cada item classificado como DEV (desenvolvimento), OPS (operação/suporte) ou INFRA (infraestrutura).
+
+#### Scenario: Backlog items have classification
+- **WHEN** um item do backlog é consultado
+- **THEN** tem: descrição, tipo (DEV/OPS/INFRA), prioridade, e macrofase associada
+
+### Requirement: Acceptance criteria per macrophase
+
+Cada macrofase MUST ter critérios de aceite que definem quando a fase está concluída.
+
+#### Scenario: Phase completion is verifiable
+- **WHEN** todos os critérios de aceite de uma macrofase são atendidos
+- **THEN** a macrofase é considerada concluída e o roadmap é atualizado


### PR DESCRIPTION
- Maturity map: 9 layers classified (7 Complete, 1 Partial, 1 Complete)
- 3 completed phases: MVP Functional, Engine Multi-Provider, Onboarding Operational
- 2 future phases: Production Ready (13 items), Enterprise Ready (11 items)
- Backlog classified by DEV/OPS/INFRA and P0/P1/P2 priority
- 20 changes by AI agent referenced as phase evidence
- New spec: nfse-product-roadmap, change archived