### PR TITLE
docs: add product README, wiki documentation, and AI journey guide (#33)

### DIFF
--- a/.claude/agents/diagram-agent.md
+++ b/.claude/agents/diagram-agent.md
@@ -1,0 +1,40 @@
+---
+name: diagram-agent
+description: Gera diagramas Mermaid coerentes com a documentação funcional, priorizando clareza, simplicidade e aderência ao comportamento real
+tools: Read, Glob, Grep, LS
+---
+
+# Objetivo
+
+Atuar como agente responsável por gerar diagramas Mermaid para complementar documentação funcional de produto.
+
+# Responsabilidades
+
+- Ler a documentação funcional existente.
+- Identificar onde um diagrama agrega clareza.
+- Escolher o tipo de diagrama mais adequado.
+- Gerar Mermaid simples, legível e coerente com o domínio.
+- Garantir aderência total ao texto documentado.
+
+# Regras obrigatórias
+
+- Não inventar fluxo, dependência, etapa ou estado.
+- Não gerar diagrama decorativo.
+- Manter simplicidade.
+- Usar nomes reais do domínio.
+- Priorizar legibilidade.
+- Só gerar diagrama quando houver ganho claro de entendimento.
+
+# Prioridades de tipo
+
+- `flowchart` para fluxo funcional
+- `sequenceDiagram` para interação entre atores e sistemas
+- `stateDiagram-v2` para status e transições
+
+# Saída esperada
+
+Entregar:
+- tipo do diagrama escolhido
+- justificativa curta da escolha
+- bloco Mermaid pronto para uso no Markdown
+- observações sobre limitações ou lacunas, se houver

--- a/.claude/agents/product-doc-agent.md
+++ b/.claude/agents/product-doc-agent.md
@@ -1,0 +1,341 @@
+---
+name: product-doc-agent
+description: Gera documentação funcional de produto clara, estruturada e útil para produto, suporte, QA e desenvolvimento, distinguindo explicitamente objetivo, comportamento atual, comportamento esperado, itens implementados e pendências
+tools: Read, Glob, Grep, LS
+---
+
+# Objetivo
+
+Atuar como agente responsável por gerar documentação funcional de produto a partir de requisitos, código, specs, tasks, propostas e contexto existente.
+
+A documentação deve refletir o comportamento real da funcionalidade, deixando explícito:
+- qual é o objetivo da funcionalidade ou da change
+- o que já está implementado e confirmado
+- o que está previsto, mas ainda não confirmado
+- o que ainda falta implementar, validar ou definir
+- quais são as lacunas de entendimento
+
+A saída deve ser útil para produto, suporte, QA e desenvolvimento.
+
+# Responsabilidades
+
+- Identificar a funcionalidade central que está sendo documentada.
+- Identificar o objetivo de negócio da funcionalidade ou da change.
+- Consolidar o contexto funcional a partir de código, spec, proposta, tasks e demais artefatos disponíveis.
+- Separar claramente:
+  - objetivo da entrega
+  - estado atual confirmado
+  - estado esperado
+  - itens pendentes ou não implementados
+  - visão geral
+  - escopo
+  - fluxo principal
+  - regras de negócio
+  - validações
+  - exceções
+  - dependências
+  - impactos
+  - critérios de aceite
+- Gerar documentação em Markdown clara e estruturada.
+- Incluir diagramas Mermaid quando eles realmente ajudarem no entendimento.
+- Sinalizar lacunas, ambiguidades e suposições de forma explícita.
+- Não inventar regra de negócio.
+- Não tratar proposta futura como comportamento já implementado.
+
+# Princípios obrigatórios
+
+- Documentar comportamento real, não intenção presumida.
+- Não gerar texto genérico ou com cara de marketing.
+- Não focar só em tela, endpoint, classe ou job isolado.
+- Sempre documentar o fluxo ponta a ponta quando isso for relevante.
+- Sempre deixar explícito o que é certeza e o que é suposição.
+- Quando o contexto for insuficiente, documentar parcialmente e listar lacunas.
+- Priorizar clareza funcional sobre detalhamento técnico desnecessário.
+- Usar nomes coerentes com o domínio.
+- Quando houver status, documentar estados e transições.
+- Quando houver parametrização, documentar como ela altera o comportamento.
+- Quando houver comportamento multi-tenant, destacar impacto e isolamento.
+- Quando houver processamento assíncrono, deixar explícito o que é síncrono e o que é assíncrono.
+- Sempre distinguir claramente o que já existe do que ainda será implementado.
+- Não documentar como comportamento atual algo que exista apenas em proposta, task ou intenção.
+- Quando a documentação envolver uma change em andamento, separar explicitamente:
+  - estado atual
+  - estado futuro esperado
+  - lacunas de implementação
+- Quando houver conflito entre código, spec e proposta, deixar a divergência explícita.
+- Quando não houver evidência suficiente, registrar como lacuna e não como fato.
+
+# Estrutura obrigatória da saída
+
+A saída deve seguir esta estrutura.
+
+## 0. Contexto da entrega
+
+Documentar explicitamente:
+
+### Objetivo da funcionalidade ou da change
+Informar:
+- qual problema pretende resolver
+- qual valor entrega
+- qual transformação funcional é esperada
+
+### Estado atual confirmado
+Listar apenas o que está confirmado nos artefatos analisados, especialmente no código e em evidências concretas.
+
+### Estado esperado
+Listar o comportamento esperado após a entrega, quando isso estiver descrito em spec, proposal, task ou requisito.
+
+### Não implementado / pendente
+Listar explicitamente:
+- o que ainda não está implementado
+- o que não foi possível confirmar
+- o que ainda depende de definição
+- o que depende de validação com negócio, suporte, QA ou desenvolvimento
+
+### Divergências identificadas
+Quando existirem, registrar diferenças entre:
+- código
+- spec
+- proposta
+- task
+- documentação prévia
+
+## 1. Visão geral
+Informar:
+- nome da funcionalidade
+- objetivo de negócio
+- problema que resolve
+- valor para o usuário ou operação
+- contexto no produto
+
+## 2. Escopo
+Informar:
+- o que cobre
+- o que não cobre
+- limites explícitos
+- premissas importantes
+
+## 3. Perfis envolvidos
+Informar:
+- quem usa
+- quem é impactado
+- diferenças por perfil, tenant, permissão ou contexto
+
+## 4. Fluxo funcional principal
+Descrever passo a passo:
+- gatilho inicial
+- entradas esperadas
+- decisões relevantes
+- processamento principal
+- saída esperada
+- persistência, integrações e efeitos gerados
+
+Sempre que aplicável, distinguir:
+- fluxo atual implementado
+- fluxo esperado após a change
+
+## 5. Regras de negócio
+Para cada regra, usar preferencialmente:
+
+- Regra:
+- Quando:
+- Então:
+- Observações:
+
+Sempre deixar claro:
+- se a regra está implementada
+- se a regra está apenas prevista
+- se a regra está parcialmente implementada
+- se há dúvida sobre sua aplicação real
+
+## 6. Validações e restrições
+Documentar:
+- obrigatoriedades
+- formatos
+- combinações inválidas
+- restrições por status
+- restrições por permissão
+- bloqueios de processamento
+
+Sempre que aplicável, informar:
+- validações já implementadas
+- validações esperadas mas não confirmadas
+- validações pendentes
+
+## 7. Exceções e cenários alternativos
+Documentar:
+- rejeições
+- falhas esperadas
+- fallback
+- reprocessamento
+- idempotência, quando aplicável
+- efeito para usuário e sistema
+
+Sempre que aplicável, distinguir:
+- comportamento existente
+- comportamento desejado
+- comportamento ainda indefinido
+
+## 8. Entradas e saídas
+Documentar:
+- entradas relevantes
+- origem das entradas
+- saídas produzidas
+- alterações de estado
+- eventos
+- arquivos
+- persistência relevante
+
+Sempre deixar claro:
+- o que já acontece hoje
+- o que deveria acontecer após a entrega
+- o que ainda não está implementado
+
+## 9. Dependências e integrações
+Documentar:
+- módulos internos
+- serviços externos
+- banco
+- filas
+- cache
+- storage
+- impacto funcional de falhas
+
+Sempre informar:
+- dependências confirmadas
+- dependências previstas
+- dependências não confirmadas
+
+## 10. Impactos no sistema
+Documentar:
+- entidades, tabelas ou coleções afetadas
+- relatórios impactados
+- auditoria e rastreabilidade
+- impacto operacional
+- impacto para suporte e QA
+
+Quando aplicável, destacar:
+- impacto multi-tenant
+- impacto de parametrização
+- impacto em integrações assíncronas
+
+## 11. Critérios de aceite
+Listar critérios objetivos, verificáveis e sem ambiguidade.
+
+Cada critério deve ser:
+- observável
+- validável por QA ou produto
+- coerente com o comportamento esperado
+- claramente separado entre:
+  - já atendido
+  - esperado para a entrega
+  - ainda pendente
+
+## 12. Exemplos práticos
+Sempre que possível incluir:
+- cenário feliz
+- cenário de rejeição
+- cenário alternativo relevante
+- cenário atual
+- cenário esperado após a entrega
+
+## 13. Pontos de atenção
+Documentar:
+- riscos
+- ambiguidades
+- dependência de parametrização
+- sensibilidade por configuração
+- impacto multi-tenant
+- riscos operacionais
+
+## 14. Lacunas identificadas
+Listar:
+- o que não foi possível confirmar
+- o que precisa ser validado
+- o que depende de definição adicional
+- o que parece divergente entre os artefatos analisados
+
+# Diagramas
+
+Quando ajudarem no entendimento, incluir diagramas Mermaid no próprio Markdown.
+
+Preferências:
+- fluxo funcional principal -> `flowchart`
+- interação entre atores e sistemas -> `sequenceDiagram`
+- transição de status -> `stateDiagram-v2`
+
+Regras:
+- usar nomes do domínio
+- manter o diagrama simples
+- não gerar diagrama decorativo
+- não inventar dependências ou fluxos
+- se houver incerteza, registrar observação abaixo do diagrama
+- quando aplicável, distinguir no diagrama:
+  - fluxo atual
+  - fluxo esperado
+  - pontos pendentes
+
+# Regras de qualidade
+
+- Não repetir a mesma ideia com palavras diferentes.
+- Não usar frases vagas como:
+  - "o sistema trata"
+  - "o sistema gerencia"
+  - "o usuário poderá"
+- Explicar exatamente o que acontece.
+- Não confundir requisito, comportamento atual e sugestão futura.
+- Não esconder incertezas.
+- Não inventar validações.
+- Não omitir exceções relevantes.
+- Não transformar a documentação em tutorial técnico de implementação.
+- Não chamar de implementado algo que está apenas em proposta.
+- Não chamar de pendente algo que já esteja confirmado no código.
+- Quando houver mudança em andamento, sempre marcar claramente:
+  - implementado
+  - parcialmente implementado
+  - previsto
+  - pendente
+  - não confirmado
+
+# Processo esperado
+
+1. Identificar a feature ou módulo principal.
+2. Identificar o objetivo da funcionalidade ou da change.
+3. Levantar os artefatos relevantes disponíveis.
+4. Separar explicitamente:
+  - comportamento atual confirmado
+  - comportamento esperado
+  - pontos ainda não implementados
+  - lacunas de definição
+5. Consolidar o comportamento real.
+6. Separar fluxo principal de regras e exceções.
+7. Identificar ambiguidades, dependências e divergências.
+8. Gerar a documentação em Markdown.
+9. Incluir diagramas Mermaid quando agregarem clareza.
+10. Destacar dúvidas restantes no final.
+
+# Checklist obrigatório antes de finalizar
+
+Antes de concluir, validar se a documentação respondeu claramente:
+
+- Qual é o objetivo da funcionalidade ou da entrega?
+- O que está implementado hoje e foi confirmado?
+- O que está previsto, mas ainda não foi confirmado?
+- O que ainda falta implementar?
+- O que depende de definição adicional?
+- Quais são as regras de negócio?
+- Quais são as validações e restrições?
+- Quais são as exceções?
+- Quais são as entradas, saídas e impactos?
+- Quais dependências afetam o comportamento?
+- Existem divergências entre código e especificação?
+- Existem lacunas que precisam ser registradas?
+
+# Saída esperada
+
+Entregar:
+- documentação funcional completa em Markdown
+- distinção explícita entre estado atual, estado esperado e pendências
+- critérios de aceite
+- lacunas identificadas
+- diagramas Mermaid quando úteis

--- a/.claude/agents/product-doc-review-agent.md
+++ b/.claude/agents/product-doc-review-agent.md
@@ -1,0 +1,153 @@
+---
+name: product-doc-review-agent
+description: Revisa tecnicamente e funcionalmente a documentação de produto gerada, verificando clareza, aderência ao comportamento real, lacunas, ambiguidades e utilidade prática
+tools: Read, Glob, Grep, LS
+---
+
+# Objetivo
+
+Atuar como agente revisor da documentação funcional de produto.
+
+Sua função é avaliar se a documentação gerada está realmente útil para produto, suporte, QA e desenvolvimento, e se ela representa com fidelidade o comportamento real da funcionalidade.
+
+# Responsabilidades
+
+- Revisar a documentação funcional gerada.
+- Verificar se a documentação está aderente ao comportamento real identificado nos artefatos disponíveis.
+- Identificar generalizações, ambiguidades, omissões e inconsistências.
+- Verificar se regras de negócio, validações, exceções e impactos estão explícitos.
+- Verificar se critérios de aceite são testáveis.
+- Verificar se os diagramas Mermaid refletem corretamente o texto.
+- Apontar lacunas e riscos de interpretação.
+- Sugerir correções objetivas e acionáveis.
+
+# Princípios obrigatórios
+
+- Revisar com foco em utilidade prática, não em estética.
+- Priorizar problemas concretos.
+- Não sugerir mudança sem ganho claro.
+- Ser objetivo, técnico e acionável.
+- Não aceitar documentação genérica.
+- Não aceitar regra implícita mal explicada.
+- Não aceitar critérios de aceite vagos.
+- Não aceitar diagrama que contradiz o texto.
+- Não aceitar documentação que esconda incertezas.
+- Quando houver falta de evidência, exigir sinalização explícita como lacuna ou suposição.
+
+# Itens obrigatórios de revisão
+
+## 1. Clareza funcional
+Verificar se está claro:
+- o que a funcionalidade faz
+- por que existe
+- qual problema resolve
+- qual é o fluxo principal
+
+## 2. Escopo
+Verificar se está claro:
+- o que cobre
+- o que não cobre
+- quais são os limites
+- quais são as premissas
+
+## 3. Regras de negócio
+Verificar se:
+- as regras estão explícitas
+- as condições estão claras
+- o comportamento esperado está descrito
+- exceções foram tratadas
+- não há regras inventadas
+
+## 4. Validações e restrições
+Verificar se:
+- obrigatoriedades estão claras
+- restrições por status, permissão e contexto estão explícitas
+- combinações inválidas foram documentadas
+- bloqueios foram descritos corretamente
+
+## 5. Exceções e cenários alternativos
+Verificar se:
+- falhas esperadas foram documentadas
+- rejeições foram descritas
+- cenários alternativos relevantes aparecem
+- reprocessamento e idempotência foram tratados quando aplicável
+
+## 6. Entradas, saídas e efeitos
+Verificar se:
+- entradas relevantes estão claras
+- saídas relevantes estão claras
+- alterações de estado foram descritas
+- persistência, eventos e integrações relevantes foram citados
+
+## 7. Dependências e integrações
+Verificar se:
+- dependências funcionais relevantes foram documentadas
+- impacto de falhas está claro
+- responsabilidades entre sistemas ficaram compreensíveis
+
+## 8. Impactos
+Verificar se:
+- impactos operacionais foram registrados
+- impactos para suporte, QA e auditoria foram considerados
+- impactos multi-tenant foram destacados quando aplicável
+
+## 9. Critérios de aceite
+Verificar se cada critério:
+- é objetivo
+- é verificável
+- não é ambíguo
+- pode ser validado por QA ou produto
+
+## 10. Diagramas
+Verificar se:
+- o diagrama agrega clareza
+- o tipo escolhido faz sentido
+- os nomes estão coerentes com o domínio
+- o fluxo do diagrama bate com o texto
+- não há etapas ou relações inventadas
+
+## 11. Lacunas
+Verificar se:
+- incertezas foram assumidas explicitamente
+- dependências de validação futura foram registradas
+- a documentação não vende como certeza algo que não foi comprovado
+
+# Como revisar
+
+Ao revisar:
+1. identificar primeiro os problemas de maior impacto
+2. apontar inconsistências entre texto e comportamento esperado
+3. destacar trechos vagos, genéricos ou incompletos
+4. sugerir correções específicas
+5. separar problemas críticos de melhorias desejáveis
+
+# Formato esperado da revisão
+
+A saída deve ser em Markdown e conter:
+
+## Resultado geral
+- aprovado sem ressalvas
+- aprovado com ajustes
+- reprovado
+
+## Problemas encontrados
+Para cada problema, informar:
+- severidade: crítica, média ou baixa
+- seção afetada
+- problema identificado
+- por que isso é um problema
+- ajuste recomendado
+
+## Pontos positivos
+Registrar o que ficou bom e deve ser preservado.
+
+## Lacunas remanescentes
+Listar dúvidas que ainda não foram resolvidas.
+
+# O que não fazer
+
+- Não fazer revisão cosmética.
+- Não focar em estilo textual sem impacto real.
+- Não sugerir “melhorias” vagas.
+- Não aprovar documentação genérica.
+- Não ignorar inconsistências entre texto, regra e diagrama.

--- a/.claude/commands/opsx/apply-orchestrate.md
+++ b/.claude/commands/opsx/apply-orchestrate.md
@@ -321,6 +321,25 @@ Ao final da execução, apresente um resumo estruturado contendo:
 - ajustes recomendados
 - veredito final
 
+## Etapa opcional — Documentação funcional
+
+Se a change:
+- introduzir funcionalidade nova
+- alterar regra de negócio
+- modificar fluxo operacional
+- alterar contrato funcional
+- impactar suporte, QA ou onboarding
+
+então usar o `product-doc-agent` para gerar ou atualizar a documentação funcional da feature.
+
+Após isso, usar o `product-doc-review-agent` para revisar a documentação gerada.
+
+A documentação deve:
+- refletir o comportamento real da change
+- explicitar fluxo principal, regras, validações, exceções e integrações
+- listar lacunas quando houver incerteza
+- incluir diagramas Mermaid quando agregarem clareza
+
 # Critério de conclusão
 
 Só considerar a execução concluída quando:

--- a/.claude/skills/product-documentation-generator/SKILL.md
+++ b/.claude/skills/product-documentation-generator/SKILL.md
@@ -1,0 +1,214 @@
+---
+name: product-documentation-generator
+description: Gera documentação de produto clara, estruturada e acionável, alinhada ao contexto real do sistema e útil para negócio, suporte, QA e desenvolvimento
+---
+
+# Objetivo
+
+Gerar documentação de produto com foco em clareza funcional, alinhamento com a regra de negócio real e utilidade prática para diferentes públicos do time.
+
+A documentação deve explicar o que a funcionalidade é, por que existe, como funciona, quais regras possui, quais fluxos cobre, quais exceções existem, quais dependências possui e quais impactos causa no sistema.
+
+# Quando usar
+
+Usar esta spec quando for necessário:
+- documentar uma funcionalidade nova
+- documentar um módulo existente
+- registrar comportamento funcional antes de refatoração
+- criar material para onboarding de time
+- produzir base para suporte, QA, produto e desenvolvimento
+- consolidar regra de negócio dispersa em código, tickets e conhecimento tácito
+
+# Princípios obrigatórios
+
+- A documentação deve ser objetiva, útil e baseada no comportamento real do sistema.
+- Não escrever texto genérico, abstrato ou com cara de marketing.
+- Explicar a regra de negócio de forma concreta.
+- Sempre priorizar comportamento, fluxo, exceções e impacto.
+- Sempre deixar explícito o que é certeza e o que é suposição.
+- Quando faltar contexto, sinalizar lacunas de informação.
+- Não inventar regras de negócio.
+- Não descrever apenas tela ou endpoint; documentar o comportamento funcional completo.
+- Escrever para leitura humana, com linguagem clara e técnica na medida certa.
+- A documentação deve poder ser usada por produto, suporte, QA e desenvolvimento.
+- Sempre que possível, relacionar a funcionalidade com entradas, processamento e saídas.
+- Sempre que possível, registrar restrições, validações, dependências e efeitos colaterais.
+- Se houver risco de ambiguidade, preferir exemplos concretos.
+
+# Estrutura obrigatória da documentação
+
+A saída deve seguir esta estrutura.
+
+## 1. Visão geral
+Descrever:
+- nome da funcionalidade
+- objetivo de negócio
+- problema que resolve
+- valor para o usuário ou operação
+- contexto dentro do produto
+
+## 2. Escopo
+Descrever:
+- o que a funcionalidade cobre
+- o que não cobre
+- limites explícitos do comportamento
+- premissas importantes
+
+## 3. Perfis envolvidos
+Descrever:
+- quem usa
+- quem é impactado
+- perfis e responsabilidades
+- diferenças de comportamento por perfil, tenant, permissão ou contexto
+
+## 4. Fluxo funcional principal
+Descrever o fluxo principal passo a passo, em ordem lógica, desde a entrada até a saída.
+
+Deve conter:
+- gatilho de início
+- entradas esperadas
+- decisões relevantes
+- processamento principal
+- resultado esperado
+- persistência, integrações ou efeitos produzidos
+
+## 5. Regras de negócio
+Listar as regras de negócio de forma explícita.
+
+Para cada regra, informar:
+- nome curto da regra
+- descrição objetiva
+- condição
+- comportamento esperado
+- impacto no fluxo
+- exceções, se existirem
+
+Preferir estrutura como:
+- Regra:
+- Quando:
+- Então:
+- Observações:
+
+## 6. Validações e restrições
+Documentar:
+- campos obrigatórios
+- formatos esperados
+- combinações inválidas
+- limites de uso
+- validações de permissão
+- validações por status
+- bloqueios de processamento
+
+## 7. Exceções e cenários alternativos
+Descrever:
+- erros esperados
+- cenários de rejeição
+- comportamentos alternativos
+- fallback
+- reprocessamento
+- idempotência, se aplicável
+- mensagens ou efeitos para usuário e sistema
+
+## 8. Entradas e saídas
+Documentar:
+- dados de entrada relevantes
+- origem das entradas
+- dados gerados
+- saídas para usuário
+- saídas para integrações
+- alterações de estado
+- eventos publicados
+- arquivos, logs ou registros persistidos
+
+## 9. Dependências e integrações
+Descrever:
+- módulos internos envolvidos
+- serviços externos
+- filas, banco, cache, storage, APIs
+- dependências funcionais
+- impacto caso uma dependência falhe
+
+## 10. Impactos no sistema
+Documentar:
+- tabelas, coleções ou entidades afetadas
+- campos alterados
+- eventos gerados
+- impactos em relatórios
+- impactos em auditoria, rastreabilidade ou observabilidade
+- efeitos para suporte e operação
+
+## 11. Critérios de aceite
+Listar critérios verificáveis e objetivos.
+
+Cada critério deve ser testável e sem ambiguidade.
+
+## 12. Exemplos práticos
+Sempre que possível, incluir:
+- exemplo de uso feliz
+- exemplo de rejeição
+- exemplo com exceção relevante
+- exemplo de entrada e resultado esperado
+
+## 13. Pontos de atenção
+Registrar:
+- riscos funcionais
+- ambiguidades
+- dependência de parametrização
+- comportamento sensível por configuração
+- impacto multi-tenant
+- riscos operacionais ou fiscais, se aplicável
+
+## 14. Lacunas identificadas
+Quando houver incerteza, listar explicitamente:
+- o que não foi possível confirmar
+- o que precisa ser validado com negócio, suporte ou desenvolvimento
+- o que depende de análise adicional
+
+# Regras de qualidade da saída
+
+- Não repetir conteúdo com palavras diferentes.
+- Não usar frases vagas como “o sistema trata”, “o sistema gerencia”, “o usuário poderá”.
+- Explicar exatamente o que acontece.
+- Evitar adjetivos sem valor funcional.
+- Priorizar listas estruturadas quando melhorar a leitura.
+- Preferir exemplos concretos a descrições abstratas.
+- Nomear conceitos com coerência de domínio.
+- Se existir status, enumerar os status e seus significados.
+- Se existir transição de estado, deixar explícita.
+- Se existir parametrização, dizer quem configura, onde impacta e como altera o comportamento.
+- Se existir comportamento por tenant, perfil ou ambiente, destacar isso.
+- Se existir integração assíncrona, deixar claro onde começa e onde termina a responsabilidade da funcionalidade.
+- Se existir processamento em lote, detalhar unidade de processamento, critério de sucesso parcial e reprocessamento.
+
+# Instruções extras para o agente
+
+Ao gerar a documentação:
+1. identificar primeiro a funcionalidade central
+2. separar fluxo principal de regras de negócio
+3. explicitar exceções e validações
+4. evitar documentação superficial orientada apenas à interface
+5. incluir impactos técnicos somente quando forem relevantes para entendimento funcional
+6. sinalizar toda suposição como suposição
+7. organizar a resposta para leitura por humanos, não para impressionar
+8. quando houver contexto insuficiente, gerar a documentação parcial e uma seção de lacunas
+9. quando houver código, inferir comportamento com cautela e não assumir intenção sem evidência
+10. quando houver endpoint, tela, job, consumidor ou workflow, documentar o processo ponta a ponta, não apenas o ponto de entrada
+
+# Formato esperado da saída
+
+A saída deve ser em Markdown, com títulos claros e seções bem definidas.
+
+Sempre gerar:
+- documentação principal
+- lista final de dúvidas/lacunas
+- lista final de critérios de aceite
+
+# O que não fazer
+
+- Não gerar texto promocional
+- Não inventar decisão de produto
+- Não escrever documentação genérica que serviria para qualquer sistema
+- Não confundir requisito com implementação
+- Não omitir exceções
+- Não esconder incertezas
+- Não focar apenas em endpoint, classe ou tela isoladamente

--- a/README.md
+++ b/README.md
@@ -1,32 +1,190 @@
-# spec-mcp-poc
+# SemanaIA - NFSe Service Invoice Engine
 
-POC para geração de XML de NFS-e a partir de:
-- contrato OpenAPI/YAML
-- schemas XSD
-- regras de negócio já existentes no serializer legado
-- fluxo com OpenSpec + MCP + LSP + OpenCode + Claude Code
+![.NET 10](https://img.shields.io/badge/.NET-10-512BD4?style=flat-square)
+![MongoDB](https://img.shields.io/badge/MongoDB-7-47A248?style=flat-square)
+![Tests](https://img.shields.io/badge/tests-727%20passing-brightgreen?style=flat-square)
+![Providers](https://img.shields.io/badge/providers-48%20testados-blue?style=flat-square)
+![Status](https://img.shields.io/badge/status-MVP-orange?style=flat-square)
 
-## Objetivo
-Demonstrar uma abordagem guiada por especificação para evoluir o serializer atual para uma arquitetura mais testável e legível:
+## O que é
 
-request -> mapper -> modelo canônico -> builders XML -> XML final
+Engine de geração de XML de NFS-e (Nota Fiscal de Serviço Eletrônica) orientada por schema XSD. Em vez de escrever serializers manuais para cada município brasileiro, a engine analisa o XSD do provider em runtime, aplica regras tipadas de mapeamento e gera XML válido automaticamente.
 
-## Escopo inicial
-Primeira iteração limitada a:
-- infDPS
-- prest
-- toma
-- serv
-- valores
+O projeto nasceu durante a **Semana IA** como uma prova de conceito de como inteligência artificial pode acelerar a construção de software complexo. Em 34 commits, saiu de zero até uma API funcional com 727 testes, 48 providers testados e 3 providers MVP validados contra XSD.
 
-## Próximos passos
-1. Consolidar a spec da POC em `openspec/`.
-2. Evoluir o request C# a partir do YAML enviado.
-3. Implementar o modelo canônico e os builders XML.
-4. Conectar o MCP `spec-assistant` ao OpenCode e ao Claude Code.
-5. Gerar testes BDD + 3A para os primeiros critérios de aceite.
+## Funcionalidades principais
 
+- **Análise de schema XSD em runtime** — `XsdSchemaAnalyzer` transforma qualquer XSD em um `SchemaDocument` navegável
+- **Serialização orientada por schema** — `SchemaBasedXmlSerializer` gera XML respeitando a estrutura do XSD (sequence, choice, attributes, inline types, multi-namespace)
+- **DSL de regras tipadas** — 6 tipos de regra (Binding, Default, EnumMapping, ConditionalEmission, Choice, Formatting) configurados por provider
+- **Auto-geração de regras** — `ProviderConfigGenerator` gera automaticamente regras a partir do dicionário de campos comuns
+- **Resolução de provider por município** — código IBGE do município determina qual provider usar, com fallback para nacional
+- **Validação XSD integrada** — `XsdValidator` valida o XML gerado contra o schema original do provider
+- **Diagnósticos enriquecidos** — `ValidationDiagnosticEnricher` sugere correções para cada erro de validação
+- **API REST completa** — CRUD de providers, gestão de municípios, regras tipadas, catálogo da DSL e geração de XML
 
-## Ajuste aplicado
+## Status dos providers MVP
 
-Esta versão inicial da POC foi ajustada para usar o **XBuilder** como tecnologia de infraestrutura para geração de XML, refletindo o framework já utilizado no projeto real. O fluxo agora é `request -> mapper -> modelo canônico -> builder XML com XBuilder -> XML final`.
+| Provider | XSD Validation | Erros | Observação |
+|----------|---------------|-------|------------|
+| Nacional | **PASS** | 0 | Totalmente funcional, schema DPS/TCDPS |
+| ISSNet | PASS* | tracked | Funcional; gaps: atributo versão no root, envelope incompleto |
+| GISSOnline | PASS* | tracked | Funcional; gaps: versão, pattern RegimeEspecialTributacao |
+| ABRASF | Schema only | - | Sem regras tipadas configuradas |
+| Paulistana | Schema only | - | Requer assinatura digital |
+| Simpliss | Schema only | - | Gaps de configuração pendentes |
+| WebISS | Schema only | - | Onboarded, validação pendente |
+
+\* Providers com gaps conhecidos e filtrados nos testes. Detalhes em `providers/runtime-xsd-validation-summary.md`
+
+## Quick start
+
+### Pré-requisitos
+
+- [.NET 10 SDK](https://dotnet.microsoft.com/download)
+- [Docker](https://www.docker.com/) (para MongoDB nos testes de integração)
+
+### Executar a API
+
+```bash
+# Subir MongoDB
+docker compose up -d
+
+# Executar a API
+dotnet run --project src/SemanaIA.ServiceInvoice.Api
+```
+
+A API estará disponível em `http://localhost:5211` com Swagger em `/swagger`.
+
+### Executar os testes
+
+```bash
+# Testes unitários (611 testes)
+dotnet test tests/SemanaIA.ServiceInvoice.UnitTests
+
+# Testes de integração (116 testes) — requer MongoDB rodando
+dotnet test tests/SemanaIA.ServiceInvoice.IntegrationsTests
+
+# Todos os testes
+dotnet test
+```
+
+### Gerar XML via API
+
+```bash
+curl -X POST http://localhost:5211/api/v1/nfse/xml \
+  -H "Content-Type: application/json" \
+  -d '{
+    "provider": {
+      "federalTaxNumber": 12345678000199,
+      "municipalTaxNumber": "12345678",
+      "taxRegime": "SimplesNacional",
+      "address": {
+        "country": "BRA",
+        "postalCode": "01000-000",
+        "street": "RUA DO PRESTADOR",
+        "number": "500",
+        "district": "CENTRO",
+        "city": { "code": "3550308" },
+        "state": "SP"
+      }
+    },
+    "borrower": {
+      "name": "TOMADOR EXEMPLO LTDA",
+      "federalTaxNumber": 191,
+      "address": {
+        "country": "BRA",
+        "postalCode": "01000-000",
+        "street": "RUA DO TOMADOR",
+        "number": "100",
+        "district": "CENTRO",
+        "city": { "code": "3550308" },
+        "state": "SP"
+      }
+    },
+    "externalId": "NFSE-001",
+    "federalServiceCode": "01.01",
+    "description": "Serviço de consultoria e assessoria",
+    "servicesAmount": 1000.00,
+    "issuedOn": "2026-01-20T10:00:00-03:00",
+    "taxationType": "WithinCity",
+    "location": {
+      "country": "BRA",
+      "postalCode": "01000-000",
+      "street": "RUA DA PRESTAÇÃO",
+      "number": "50",
+      "district": "CENTRO",
+      "city": { "code": "3550308" },
+      "state": "SP"
+    },
+    "nbsCode": "101010100"
+  }'
+```
+
+## Arquitetura
+
+```
+Request → Mapper → DpsDocument → ProviderResolver → SchemaSerializationPipeline → XML → XsdValidator
+                                       ↓
+                              MongoDB / Filesystem / Fallback Nacional
+```
+
+O projeto segue **Onion Architecture** com 5 camadas:
+
+```
+SemanaIA.ServiceInvoice.Api            → Controllers, Contracts, Mappers
+SemanaIA.ServiceInvoice.Application    → Use Cases
+SemanaIA.ServiceInvoice.Domain         → Models, Repositories, Services
+SemanaIA.ServiceInvoice.Infrastructure → MongoDB, Resolution, Validation
+SemanaIA.ServiceInvoice.XmlGeneration  → SchemaEngine (core da engine)
+```
+
+Para detalhes, veja [Arquitetura](docs/04-architecture.md).
+
+## Documentacao
+
+| Doc | Descrição |
+|-----|-----------|
+| [Visão do Produto](docs/01-product-overview.md) | O que é NFSe, o que a engine resolve, capacidades atuais |
+| [Jornada de Evolução](docs/02-evolution-journey.md) | 6 fases, 34 commits, do zero ao MVP |
+| [Jornada com IA](docs/03-ai-journey.md) | 10 formas como IA foi usada neste projeto |
+| [Arquitetura](docs/04-architecture.md) | Pipeline, componentes, fluxos de dados |
+| [API de Providers](docs/05-provider-management-api.md) | Endpoints, exemplos curl, request/response |
+| [Guia de Onboarding (Suporte)](docs/06-support-onboarding-guide.md) | Passo a passo para cadastrar e validar providers |
+| [Regras e Configuração](docs/07-rules-and-configuration.md) | Modelo de regras, dicionário, profiles |
+| [Estratégia de Testes](docs/08-testing-strategy.md) | 727 testes, pirâmide, como executar |
+| [Limitações e Roadmap](docs/09-limitations-and-roadmap.md) | Gaps conhecidos e próximos passos |
+
+## Stack
+
+| Tecnologia | Uso |
+|-----------|-----|
+| .NET 10 / C# | Runtime e linguagem principal |
+| MongoDB 7 | Persistência de providers gerenciados |
+| xUnit + Shouldly | Framework de testes |
+| Bogus + Moq | Geracao de dados e mocks |
+| Docker Compose | Infraestrutura local |
+| Claude Code / Cursor | Assistência de IA durante o desenvolvimento |
+
+## Estrutura do projeto
+
+```
+SemanaIA/
+├── src/
+│   ├── SemanaIA.ServiceInvoice.Api/           # API REST
+│   ├── SemanaIA.ServiceInvoice.Application/   # Use cases
+│   ├── SemanaIA.ServiceInvoice.Domain/        # Modelos de dominio
+│   ├── SemanaIA.ServiceInvoice.Infrastructure/# MongoDB, resolucao
+│   └── SemanaIA.ServiceInvoice.XmlGeneration/ # Engine de serializacao
+├── tests/
+│   ├── SemanaIA.ServiceInvoice.UnitTests/     # 611 testes unitários
+│   └── SemanaIA.ServiceInvoice.IntegrationsTests/ # 116 testes de integração
+├── providers/                                  # 7 providers com XSD e regras
+├── docs/                                       # Documentação do projeto
+├── ia/                                         # MCP spec server
+└── openspec/                                   # Especificações OpenSpec
+```
+
+## Licenca
+
+A definir.

--- a/docs/01-product-overview.md
+++ b/docs/01-product-overview.md
@@ -1,0 +1,87 @@
+# Visao do Produto — NFSe Service Invoice Engine
+
+## O que e NFS-e
+
+A **Nota Fiscal de Servico Eletronica (NFS-e)** e o documento fiscal digital que registra a prestacao de servicos no Brasil. Cada municipio brasileiro pode adotar um padrao tecnico diferente para recepcao dessas notas — o que significa schemas XSD distintos, campos obrigatorios diferentes, formatos de data variados e regras de negocio especificas.
+
+Na pratica, o Brasil tem dezenas de provedores de NFS-e (Nacional, ABRASF, ISSNet, GISSOnline, Paulistana, Simpliss, WebISS, entre muitos outros), cada um com seu proprio schema XML. Uma empresa que emite notas em multiplos municipios precisa gerar XML valido para cada um desses provedores.
+
+## O problema
+
+A abordagem tradicional para lidar com essa diversidade e escrever um **serializer manual** para cada provedor. Isso significa:
+
+- Centenas de linhas de codigo por provider (o serializer manual do Nacional tem ~900 linhas com 19 metodos Build)
+- Duplicacao massiva de logica entre providers que compartilham campos comuns
+- Cada novo municipio exige semanas de desenvolvimento
+- Qualquer mudanca no schema de um provider requer alteracao manual no codigo
+- Testes ficam frageis porque estao acoplados a implementacao especifica
+
+## O que esta engine resolve
+
+A **NFSe Service Invoice Engine** substitui serializers manuais por uma abordagem orientada por schema:
+
+1. **O provider entrega o XSD** — a engine analisa a estrutura automaticamente
+2. **Regras tipadas mapeiam dominio para schema** — sem codigo novo por provider
+3. **O XML e gerado em runtime** — respeitando sequence, choice, attributes, namespaces
+4. **Validacao XSD integrada** — o XML gerado e validado contra o schema original
+
+O resultado: **onboarding de um novo provider sem escrever codigo C#**, apenas configurando regras de mapeamento.
+
+## Quem usa
+
+| Perfil | Como usa |
+|--------|----------|
+| **Desenvolvedor** | Cadastra providers via API, configura regras tipadas, integra a geracao de XML no fluxo de emissao |
+| **Suporte tecnico** | Onboarda novos municipios via API REST, valida providers sob demanda, diagnostica erros com enriquecimento automatico |
+| **Operacao** | Monitora status de providers (Ready, Blocked, Inactive), gerencia municipios por provider |
+
+## Capacidades atuais
+
+### Engine de serializacao
+- Analise de schema XSD com suporte a complexType, sequence, choice, simpleType, restriction, attributes, inline types anonimos e multi-namespace
+- Serializacao runtime orientada por schema com `SchemaBasedXmlSerializer`
+- Data binding automatico de `DpsDocument` para qualquer schema via `ServiceInvoiceSchemaDataBinder`
+- Pipeline completo: analise → binding → serializacao → validacao (`SchemaSerializationPipeline`)
+
+### Sistema de regras tipadas
+- 6 tipos de regra: **Binding**, **Default**, **EnumMapping**, **ConditionalEmission**, **Choice**, **Formatting**
+- Auto-geracao de regras a partir de `CommonFieldMappingDictionary` (dicionario de 40+ campos comuns)
+- Resolucao de regras via `TypedRuleResolver` com suporte a condicoes compostas
+- API de catalogo para consultar sources, targets, operadores e tipos de regra disponiveis
+
+### Gestao de providers
+- CRUD completo de providers com persistencia em MongoDB
+- Upload de arquivos XSD com selecao inteligente do schema de envio (`SendXsdSelector`)
+- Gestao de municipios por provider com unicidade garantida
+- Validacao sob demanda com diagnosticos enriquecidos
+- Transicoes de status: Draft → Ready → Active / Blocked → Inactive
+
+### Resolucao de provider
+- Resolucao por codigo IBGE do municipio
+- Cadeia de resolucao: MongoDB → Filesystem → Fallback Nacional
+- Suporte a providers gerenciados (MongoDB) e providers de filesystem (pasta `providers/`)
+
+### Cobertura de testes
+- **611 testes unitarios** cobrindo engine, regras, binding, serializacao e validacao
+- **116 testes de integracao** com MongoDB e API completa
+- **48 providers** na suite de testes de dados
+- **727 testes no total**, todos passando
+
+### Providers validados
+
+| Provider | Tecnologia | Status XSD |
+|----------|-----------|------------|
+| Nacional | Schema DPS/TCDPS, namespace unico | PASS (0 erros) |
+| ISSNet | Envelope EnviarLoteDpsEnvio, inline types | PASS |
+| GISSOnline | Multi-namespace, inline types | PASS |
+| ABRASF | Envelope EnviarLoteRpsEnvio | Schema analisado, sem regras tipadas |
+| Paulistana | Multi-namespace | Requer assinatura digital |
+| Simpliss | ABRASF-based | Gaps de configuracao |
+| WebISS | Onboarded | Validacao pendente |
+
+## Links relacionados
+
+- [Jornada de Evolucao](02-evolution-journey.md) — como o projeto foi construido em 34 commits
+- [Jornada com IA](03-ai-journey.md) — como IA foi usada em cada fase
+- [Arquitetura](04-architecture.md) — componentes e fluxos de dados
+- [API de Providers](05-provider-management-api.md) — endpoints e exemplos

--- a/docs/02-evolution-journey.md
+++ b/docs/02-evolution-journey.md
@@ -1,0 +1,260 @@
+# Jornada de Evolucao — Do Zero ao MVP em 34 Commits
+
+Este documento descreve como o projeto evoluiu ao longo de 6 fases, 34 commits e centenas de testes. Cada fase representa uma mudanca de paradigma na forma como a engine gera XML de NFS-e.
+
+---
+
+## Fase 1: Baseline Manual (Commits #1 a #9)
+
+**Periodo:** Configuracao inicial e serializer manual para o provider Nacional.
+
+### O que foi construido
+
+- Configuracao do projeto com spec OpenAPI/YAML e estrutura de testes
+- Modelo canonico `DpsDocument` com todos os blocos do DPS (infDPS, prest, toma, serv, valores, IbsCbs)
+- `NationalDpsManualSerializer` — serializer manual com ~900 linhas e 19 metodos `Build`
+- `IbsCbsManualBuilder` — builder manual para o bloco complexo de IBSCBS (deferimento, reembolso, sub-blocos avancados)
+- Mapper de request para modelo canonico
+- Endpoint `POST /nfse/xml` funcional
+
+### Decisoes chave
+
+- Usar **XBuilder** como tecnologia de infraestrutura XML (framework ja usado no projeto real)
+- Construir o serializer manual primeiro para entender a complexidade real do dominio antes de automatizar
+- Separar modelo canonico (`DpsDocument`) de montagem de XML — regra fundamental do projeto
+
+### Metricas
+
+| Metrica | Valor |
+|---------|-------|
+| Linhas do serializer manual | ~900 |
+| Metodos Build | 19 |
+| Cobertura XSD Nacional | 74% |
+| Testes | Primeiros testes de endpoint e mapper |
+
+### Commits
+
+| # | Commit | Entrega |
+|---|--------|---------|
+| 1 | Configuracao para usar IA para refatoracao do projeto | Setup inicial |
+| 2 | Add spec e projeto de tests | Estrutura de testes |
+| 3 | Feature/definicao specs | Definicao das especificacoes |
+| 4 | Add execucao da geracao da documentacao em cima do YAML | Geracao a partir do YAML |
+| 5 | Add execucao da serializacao | Primeira serializacao |
+| 6 | Finalizado criacao do backlog | Backlog tecnico |
+| 7 | Finalizado a implementacao do IbsCbs | Bloco IbsCbs completo |
+| 8 | feat(serializer): integrate ibscbs mapper and endpoint tests | Integracao mapper + testes |
+| 9 | feat: implement ibscbs diferiment | Deferimento e sub-blocos avancados |
+
+---
+
+## Fase 2: Engine de Schema (Commits #10 a #18)
+
+**Periodo:** Construcao do motor de analise XSD e geracao de codigo.
+
+### O que foi construido
+
+- `XsdSchemaAnalyzer` — analisa qualquer XSD e produz um `SchemaDocument` com tipos complexos, elementos, restricoes, enumeracoes
+- `SchemaModel` — modelo intermediario que representa a estrutura do XSD de forma navegavel
+- `SchemaCodeGenerator` — gera artefatos C# a partir do modelo de schema
+- `SchemaGenerationRunner` — executa a geracao completa (analise → modelo → codigo)
+- Comparacao automatizada engine vs serializer manual
+- Prova de conceito com schemas ABRASF e GISSOnline
+
+### Decisoes chave
+
+- **Nao gerar codigo em build time** — a decisao critica foi gerar XML em **runtime** diretamente do schema, sem etapa de code generation
+- Manter o `SchemaCodeGenerator` como ferramenta de analise, nao como pipeline de producao
+- Investir em um modelo de schema rico o suficiente para suportar qualquer provider
+
+### Metricas
+
+| Metrica | Valor |
+|---------|-------|
+| Providers analisados | 3 (Nacional, ABRASF, GISSOnline) |
+| Tipos complexos suportados | complexType, sequence, choice, simpleType, restriction |
+| Cobertura do schema model | Elementos, atributos, inline types, enumeracoes |
+
+### Commits
+
+| # | Commit | Entrega |
+|---|--------|---------|
+| 10-13 | Melhorias diversas no serializer | Refinamento do serializer e modelo |
+| 14 | feat(engine): runtime schema-based XML serializer | `SchemaBasedXmlSerializer` runtime |
+| 15 | feat(engine): bind serviceinvoice to runtime schema serializer | Data binding dominio → schema |
+| 16 | Feature/runtime serializer anonymous inline types | Suporte a inline types anonimos |
+| 17 | feat(engine): add multi-namespace support to runtime serializer | Multi-namespace (GISSOnline PASS) |
+| 18 | feat(engine): add multi-level path binding support to runtime binder | Wrapper bindings (ISSNet PASS) |
+
+---
+
+## Fase 3: Runtime Serializer (Commits #19 a #22)
+
+**Periodo:** O serializer deixa de ser experimental e vira o pipeline principal.
+
+### O que foi construido
+
+- `SchemaSerializationPipeline` — pipeline completo: analise XSD → load profile → data binding → serializacao → validacao
+- `ServiceInvoiceSchemaDataBinder` — binding automatico de `DpsDocument` para qualquer schema
+- Suporte a **anonymous inline types** — tipos complexos definidos diretamente dentro de elements
+- Suporte a **multi-namespace** — elementos emitidos no namespace correto conforme o tipo
+- Suporte a **multi-level path binding** — caminhos como `LoteDps.ListaDps.DPS.infDPS` resolvidos via wrappers
+
+### Decisoes chave
+
+- O pipeline faz analise XSD em **toda requisicao** (sem cache) — decisao pragmatica para MVP, com otimizacao futura planejada
+- Inline types resolvidos **recursivamente** — suporta profundidade arbitraria
+- Multi-namespace resolvido no `SchemaBasedXmlSerializer` com mapa de namespace por tipo
+
+### Metricas
+
+| Metrica | Valor |
+|---------|-------|
+| Providers com XML runtime valido | 4/6 (Nacional, ABRASF, GISSOnline, ISSNet) |
+| Capacidades de schema suportadas | sequence, choice, inline types, multi-namespace, wrapper paths |
+
+---
+
+## Fase 4: Onboarding de Providers (Commits #23 a #27)
+
+**Periodo:** De providers hard-coded para um fluxo operacional de onboarding.
+
+### O que foi construido
+
+- `ProviderResolver` — resolucao de provider por nome com listagem de providers disponiveis
+- `ProviderSerializerFactory` — factory que monta o pipeline completo para um provider especifico
+- `ProviderOnboardingValidator` — valida se um provider esta pronto para producao (5 checks: schema, analise, bindings, runtime, XSD)
+- `ProviderConfigGenerator` — gera automaticamente regras de mapeamento a partir do `CommonFieldMappingDictionary`
+- `CommonFieldMappingDictionary` — dicionario de 40+ campos comuns entre providers (CNPJ, CPF, datas, valores, codigos de servico)
+- `ProviderSampleDocumentGenerator` — gera `DpsDocument` de exemplo para teste de providers
+- `SendXsdSelector` — selecao inteligente do XSD de envio (filtra schemas de consulta, cancelamento etc.)
+- Suite de testes com **48 providers** de dados reais
+
+### Decisoes chave
+
+- **Auto-geracao de config** — em vez de exigir configuracao manual, a engine gera o perfil inicial automaticamente
+- **Diagnostic-driven** — cada check de validacao retorna diagnostico acionavel
+- **48-provider test suite** — testar com dados reais de 48 municipios brasileiros desde o inicio
+
+### Metricas
+
+| Metrica | Valor |
+|---------|-------|
+| Providers na suite de testes | 48 |
+| Providers com XSD detectado | 48/48 |
+| Campos no dicionario comum | 40+ |
+| Checks de validacao | 5 (SchemaExists, AnalysisSuccess, BindingsPresent, RuntimeProducible, XsdValid) |
+
+### Commits
+
+| # | Commit | Entrega |
+|---|--------|---------|
+| 23 | feat(engine): add provider onboarding workflow with municipality-based resolution | ProviderResolver, Factory, endpoints, Onion Architecture |
+| 24 | Feature/support friendly provider onboarding | Auto-config, OperationalStatus, load test 52 providers |
+| 25 | docs: add product roadmap from MVP to enterprise with macrophase backlog | Roadmap do produto |
+| 26 | feat(engine): add intelligent send XSD selection with 48-provider test suite | SendXsdSelector, 48-provider suite |
+| 27 | feat(engine): implement 6 provider onboarding fixes for expanded coverage | 6 correcoes de onboarding |
+
+---
+
+## Fase 5: API e Gestao (Commits #28 a #29)
+
+**Periodo:** De endpoints basicos para uma API completa de gestao de providers.
+
+### O que foi construido
+
+- `ProviderManagementController` — CRUD completo de providers com upload de XSD
+- `ProviderManagementService` — logica de negocio para gestao (create, update, delete, activate, deactivate, validate)
+- `MongoProviderRepository` — persistencia em MongoDB com `ManagedProvider`
+- `MongoProviderResolver` — resolucao de provider por codigo IBGE via MongoDB
+- Gestao de municipios (add/remove codigos IBGE por provider)
+- `RuleCatalogController` — API de catalogo da DSL de regras (sources, targets, operators, actions, types)
+- `TypedRuleResolver` — resolucao de regras tipadas com suporte a 6 tipos
+- `ProviderRule` — modelo tipado com Binding, Default, EnumMapping, ConditionalEmission, Choice, Formatting
+- CRUD completo de regras por provider (GET, PUT, POST, DELETE por indice)
+
+### Decisoes chave
+
+- **MongoDB para providers gerenciados** — providers cadastrados via API vivem no MongoDB; providers de filesystem continuam funcionando
+- **Upload de XSD via multipart/form-data** — decisao pragmatica para facilitar integracao com ferramentas de suporte
+- **DSL de regras tipada** — cada regra tem um `type` que define sua semantica e campos obrigatorios
+- **Catalogo da DSL via API** — quem consome a API consegue consultar todos os campos, operadores e tipos disponiveis
+
+### Metricas
+
+| Metrica | Valor |
+|---------|-------|
+| Endpoints de API | 16+ |
+| Tipos de regra | 6 (Binding, Default, EnumMapping, ConditionalEmission, Choice, Formatting) |
+| Operadores de condicao | 10 (Equals, NotEquals, GreaterThan, LessThan, etc.) |
+
+### Commits
+
+| # | Commit | Entrega |
+|---|--------|---------|
+| 28 | feat(api): add provider management API with MongoDB persistence | CRUD, MongoDB, municipios |
+| 29 | feat(engine): add typed rule DSL with auto-generation, CRUD endpoints, and catalog API | DSL tipada, catalogo, CRUD de regras |
+
+---
+
+## Fase 6: Fechamento do MVP (Commits #30 a #32)
+
+**Periodo:** Correcao de gaps, suporte a atributos XSD, envelope ABRASF e validacao E2E.
+
+### O que foi construido
+
+- **Deep autogen** — `ProviderConfigGenerator` gera regras recursivamente para tipos complexos aninhados
+- **Scoped XSD validation** — validacao parcial (por bloco) alem da validacao completa
+- **`ValidationDiagnosticEnricher`** — enriquece cada erro de validacao XSD com sugestao de correcao, campo de origem e confianca
+- **Suporte a `xs:attribute`** — atributos XSD agora sao mapeados e emitidos corretamente
+- **Deteccao de envelope ABRASF** — identifica automaticamente schemas que usam o padrao ABRASF (EnviarLoteRpsEnvio)
+- **Correcao de mapeamento enum-to-code** — enums do dominio mapeados para codigos do provider via `EnumMapping`
+- **Correcao de formato de data** — formato de data correto por provider (ISO 8601, formatos custom)
+- **Correcao de gaps ABRASF** — campos faltantes do padrao ABRASF resolvidos
+- **Testes E2E** — testes ponta a ponta validando o fluxo completo: request → API → XML → validacao XSD
+
+### Decisoes chave
+
+- **Diagnosticos > erros** — em vez de apenas falhar, a engine explica o que falta e como corrigir
+- **Testes E2E como definition of done** — MVP so e considerado entregue com testes validando o fluxo completo contra XSD
+- **Provider request no contrato** — campo `provider` no request da API permite informar dados do prestador para resolucao
+
+### Metricas finais do MVP
+
+| Metrica | Valor |
+|---------|-------|
+| Testes unitarios | 611 |
+| Testes de integracao | 116 |
+| Total de testes | 727 |
+| Providers MVP (XSD valid) | 3 (Nacional, ISSNet, GISSOnline) |
+| Providers onboarded | 7 |
+| Providers na suite de dados | 48 |
+| Commits totais | 34 |
+
+### Commits
+
+| # | Commit | Entrega |
+|---|--------|---------|
+| 30 | feat(engine): add deep autogen, scoped XSD validation, enriched diagnostics, provider request, and E2E tests | Deep autogen, diagnosticos, E2E |
+| 31 | feat(engine): add xs:attribute support, ABRASF envelope detection, and MVP provider XSD validation | Atributos, ABRASF, validacao MVP |
+| 32 | fix(engine): resolve enum-to-code mappings, date format, and ABRASF field gaps for MVP providers | Correcoes finais do MVP |
+
+---
+
+## Timeline visual
+
+```
+Commits  #1─────#9   #10────#18   #19──#22   #23────#27   #28─#29   #30──#32
+         │           │            │           │            │         │
+Fase     1:Manual    2:Schema     3:Runtime   4:Onboard    5:API     6:MVP
+         │           │            │           │            │         │
+Testes   ~20         ~80          ~150        ~350         ~500      727
+         │           │            │           │            │         │
+Providers 1          3            4           48(dados)    +MongoDB  3 MVP
+```
+
+## Links relacionados
+
+- [Visao do Produto](01-product-overview.md) — capacidades atuais
+- [Jornada com IA](03-ai-journey.md) — como IA acelerou cada fase
+- [Arquitetura](04-architecture.md) — componentes construidos ao longo das fases

--- a/docs/03-ai-journey.md
+++ b/docs/03-ai-journey.md
@@ -1,0 +1,364 @@
+# Jornada com IA — 10 Formas de Usar Inteligencia Artificial no Desenvolvimento
+
+Este documento descreve como inteligencia artificial foi utilizada na construcao da NFSe Service Invoice Engine. Nao e uma lista teorica — cada secao descreve uma ferramenta ou tecnica real, como foi aplicada neste projeto e qual foi o resultado concreto.
+
+O projeto saiu do zero ate 727 testes, 48 providers testados e 3 providers MVP validados contra XSD em 34 commits. IA nao escreveu tudo sozinha, mas participou de cada etapa.
+
+---
+
+## 1. Terminal / IDE — Claude Code CLI e Cursor IDE
+
+### O que e
+
+**Claude Code** e a CLI oficial da Anthropic para interagir com o Claude diretamente no terminal. Funciona como um par programmer que le seu codigo, entende o contexto e executa comandos. **Cursor** e uma IDE baseada em VS Code com integracao nativa de IA para sugestoes inline, chat contextual e edicao assistida.
+
+### Como foi usado neste projeto
+
+O Claude Code foi a interface principal de desenvolvimento. Em vez de alternar entre IDE e browser, o fluxo era:
+
+1. Descrever a tarefa no terminal (`"implementar suporte a xs:attribute no SchemaBasedXmlSerializer"`)
+2. O Claude Code le os arquivos relevantes, entende a estrutura existente e propoe a implementacao
+3. Revisar, ajustar e aplicar
+
+No Cursor, sugestoes inline ajudaram em completions rapidos — especialmente em testes unitarios onde o padrao `Given_<context>_Should_<expected_behavior>` se repete.
+
+### Exemplo concreto
+
+Na Fase 3 (commit #19), o `SchemaSerializationPipeline` foi criado inteiramente via Claude Code. O prompt foi algo como *"criar um pipeline que recebe DpsDocument e provider name, faz analise XSD, load de profile, data binding e serializacao, retornando SerializationResult com XML ou erros"*. O Claude Code leu `XsdSchemaAnalyzer`, `SchemaBasedXmlSerializer`, `ServiceInvoiceSchemaDataBinder`, entendeu as interfaces e produziu o pipeline com error handling correto por etapa.
+
+---
+
+## 2. Docker — MongoDB e Infraestrutura de Testes
+
+### O que e
+
+Docker para provisionar dependencias de infraestrutura. Neste projeto, MongoDB 7 via `docker-compose.yml` para persistencia de providers gerenciados.
+
+### Como foi usado neste projeto
+
+O `docker-compose.yml` foi gerado por IA a partir do requisito *"preciso de MongoDB para testes de integracao"*:
+
+```yaml
+services:
+  mongodb:
+    image: mongo:7
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongodb_data:/data/db
+```
+
+Simples e funcional. A IA tambem gerou a classe `MongoDbSettings` e a configuracao de DI (`ServiceCollectionExtensions.cs`) para conectar a API ao MongoDB, incluindo a logica de resolucao de provider via `MongoProviderResolver`.
+
+### Exemplo concreto
+
+Quando os 116 testes de integracao foram criados (Fase 5-6), a IA configurou o `WebApplicationFactory` com MongoDB de teste, incluindo setup e teardown de collections. O resultado: testes de integracao rodando contra MongoDB real em vez de mocks.
+
+---
+
+## 3. Assistente — IA como Par Programmer
+
+### O que e
+
+Usar IA como par programmer durante o desenvolvimento: discutir decisoes, pedir review, explorar alternativas antes de implementar.
+
+### Como foi usado neste projeto
+
+Antes de cada fase major, houve conversas exploratoras. Exemplos reais:
+
+- **Fase 2:** *"Devo gerar codigo C# a partir do XSD em build time ou serializar em runtime?"* — A discussao levou a decisao de runtime serialization, que se provou correta quando 48 providers precisaram ser suportados sem code generation.
+- **Fase 4:** *"Qual a melhor estrategia para resolver provider por municipio?"* — Resultou na cadeia MongoDB → Filesystem → Fallback Nacional.
+- **Fase 6:** *"O diagnostico de erro XSD nao e acionavel. Como enriquecer?"* — Nasceu o `ValidationDiagnosticEnricher` que sugere correcao, campo de origem e confianca para cada erro.
+
+### Exemplo concreto
+
+O `CommonFieldMappingDictionary` — dicionario de 40+ campos comuns entre providers — nasceu de uma sessao de pair programming com IA. O prompt foi *"quais campos sao comuns entre DPS Nacional, ABRASF e ISSNet?"*. A IA analisou os 3 schemas XSD, listou os campos compartilhados e seus caminhos XSD em cada provider. Isso virou a base para auto-geracao de regras.
+
+---
+
+## 4. Agente Unico — Uma Tarefa, Uma Execucao Completa
+
+### O que e
+
+Delegar uma tarefa completa a um unico agente de IA: desde entender o requisito ate implementar, testar e validar. Diferente do assistente (que sugere), o agente **executa**.
+
+### Como foi usado neste projeto
+
+Muitos commits foram implementados como tarefas de agente unico. O fluxo:
+
+1. Descrever o objetivo com contexto (`"adicionar suporte a multi-namespace no runtime serializer"`)
+2. O agente le o codigo existente, identifica os pontos de mudanca
+3. Implementa as alteracoes
+4. Gera ou atualiza testes
+5. Executa testes e corrige falhas
+
+### Exemplo concreto
+
+O commit #17 (`feat(engine): add multi-namespace support to runtime serializer`) foi feito como agente unico. O GISSOnline usa dois namespaces diferentes no mesmo schema — o `SchemaBasedXmlSerializer` precisava emitir elementos no namespace correto conforme o tipo. O agente:
+
+1. Leu o XSD do GISSOnline e identificou os dois namespaces
+2. Modificou `XsdSchemaAnalyzer` para rastrear namespace por tipo
+3. Modificou `SchemaBasedXmlSerializer` para consultar o namespace ao emitir
+4. Criou testes validando XML contra XSD do GISSOnline
+5. Executou e confirmou PASS
+
+Tudo em uma unica sessao de agente.
+
+---
+
+## 5. Multi Agentes — Orquestracao de Especialistas
+
+### O que e
+
+Em vez de um unico agente fazendo tudo, dividir o trabalho entre agentes especializados que colaboram:
+
+- **spec-agent** — le a especificacao e traduz em backlog tecnico
+- **implementation-agent** — implementa codigo C#
+- **unit-test-agent** — gera testes unitarios
+- **xml-test-agent** — gera testes especificos de XML com validacao XSD
+- **review-agent** — faz revisao tecnica final
+
+### Como foi usado neste projeto
+
+O arquivo `AGENTS.md` na raiz do projeto define os papeis. O fluxo orquestrado (`/opsx-apply-orchestrated`) segue:
+
+1. spec-agent analisa o requisito e lista criterios de aceite
+2. implementation-agent implementa respeitando SOLID e Clean Code
+3. unit-test-agent gera testes com xUnit + Shouldly no padrao `Given_Should`
+4. xml-test-agent valida schema XSD quando aplicavel
+5. review-agent revisa o conjunto e aponta problemas
+
+### Exemplo concreto
+
+O commit #29 (`feat(engine): add typed rule DSL with auto-generation, CRUD endpoints, and catalog API`) envolveu:
+
+- **spec-agent**: definiu os 6 tipos de regra (Binding, Default, EnumMapping, ConditionalEmission, Choice, Formatting) com campos obrigatorios e exemplos
+- **implementation-agent**: implementou `ProviderRule`, `TypedRuleResolver`, endpoints CRUD e catalogo
+- **unit-test-agent**: gerou testes para cada tipo de regra, resolucao, validacao
+- **xml-test-agent**: validou que regras EnumMapping e ConditionalEmission produzem XML correto contra XSD
+- **review-agent**: identificou que `ProviderRuleValidator` precisava validar campos obrigatorios por tipo
+
+Resultado: implementacao mais robusta do que um agente unico teria produzido.
+
+---
+
+## 6. Agent Skills — Capacidades Reutilizaveis
+
+### O que e
+
+**Skills** sao capacidades especializadas configuradas como prompts reutilizaveis. Cada skill encapsula conhecimento de dominio e instrucoes especificas para um tipo de tarefa. Neste projeto, as skills ficam em `.github/prompts/` e `.github/skills/`.
+
+### Skills utilizadas
+
+| Skill | Funcao |
+|-------|--------|
+| `opsx-apply` | Mudancas simples e localizadas |
+| `opsx-apply-orchestrated` | Mudancas com multiplas etapas, testes obrigatorios e revisao |
+| `opsx-archive` | Arquivamento de changes concluidos |
+| `opsx-explore` | Exploracao de codigo e analise |
+| `opsx-propose` | Proposta de mudanca antes da implementacao |
+| `dotnet-implementation` | Implementacao C# seguindo SOLID/Clean Code |
+| `write-dotnet-unit-tests` | Geracao de testes com xUnit, Shouldly, padrao Given_Should |
+
+### Como foi usado neste projeto
+
+O `CLAUDE.md` na raiz define as regras que todas as skills respeitam. Por exemplo:
+
+- *"Sempre seguir SOLID com pragmatismo"*
+- *"Preferir classes especializadas com nomes orientados ao dominio"*
+- *"Nao criar UseCase por padrao"*
+- *"Testes no padrao `Given_<context>_Should_<expected_behavior>`"*
+
+Isso garante consistencia: qualquer agente que execute uma skill produz codigo no mesmo padrao.
+
+### Exemplo concreto
+
+A skill `write-dotnet-unit-tests` foi usada extensivamente na Fase 6. Ao pedir *"gerar testes para TypedRuleResolver com regras EnumMapping"*, a skill automaticamente:
+
+- Cria fixtures com Bogus para dados aleatorios
+- Usa Shouldly para assertions (`result.ShouldBe(...)`)
+- Nomeia como `Given_EnumMappingRule_WithValidSource_Should_MapToProviderCode`
+- Estrutura em Arrange / Act / Assert
+- Coloca helpers privados no final da classe
+
+---
+
+## 7. MCP / LSP — Context Servers e Documentacao
+
+### O que e
+
+**MCP (Model Context Protocol)** e um protocolo para fornecer contexto estruturado a modelos de IA. **LSP (Language Server Protocol)** fornece inteligencia de linguagem (types, references, diagnostics). Juntos, dao ao agente de IA acesso a documentacao atualizada e entendimento profundo do codigo.
+
+### MCP Servers utilizados
+
+| Server | Funcao |
+|--------|--------|
+| `mcp-spec-server` | Server local em `ia/mcp-spec-server/` que serve a especificacao OpenSpec do projeto |
+| `microsoft-docs` | Busca e fetch de documentacao oficial Microsoft/.NET |
+| `context7` | Documentacao atualizada de bibliotecas (xUnit, Shouldly, MongoDB.Driver) |
+
+### Como foi usado neste projeto
+
+O `mcp-spec-server` (em `ia/mcp-spec-server/`) e um server Node.js que serve as specs do projeto via MCP. Quando um agente precisa entender o contrato da API ou o modelo de dominio, consulta o server em vez de ler arquivos avulsos.
+
+O `microsoft-docs` foi usado quando houve duvida sobre APIs do .NET — por exemplo, ao implementar o `XsdSchemaAnalyzer`, foi necessario consultar a documentacao de `System.Xml.Schema.XmlSchemaSet` para entender como iterar sobre complex types com anonymous inline types.
+
+O `context7` foi usado para consultar documentacao de xUnit (como usar `[Theory]` com `[MemberData]`) e MongoDB.Driver (como configurar `IMongoCollection` com indexes).
+
+### Exemplo concreto
+
+Na Fase 2, ao implementar `XsdSchemaAnalyzer`, o agente precisava entender como `XmlSchemaComplexType.ContentTypeParticle` se comporta com sequences aninhadas. O `microsoft-docs` MCP retornou a documentacao exata da API, incluindo exemplos de iteracao sobre `XmlSchemaSequence.Items`. Isso evitou horas de tentativa e erro.
+
+---
+
+## 8. Tools / Plugins — Firecrawl, Sentry, GitHub CLI
+
+### O que e
+
+Ferramentas externas integradas ao fluxo de desenvolvimento via plugins e CLIs.
+
+### Ferramentas utilizadas
+
+| Ferramenta | Funcao neste projeto |
+|-----------|---------------------|
+| **GitHub CLI (`gh`)** | Criacao de PRs, gestao de issues, checks de CI |
+| **Firecrawl** | Scraping de documentacao de providers quando XSD nao era suficiente |
+| **Sentry** | Monitoramento de erros em providers durante testes de carga |
+
+### Como foi usado neste projeto
+
+O **GitHub CLI** foi integrado ao fluxo de commits. Cada PR era criado via `gh pr create` com descricao gerada pela IA baseada nos commits incluidos. O formato padrao:
+
+```
+## Summary
+- <bullets descrevendo o que mudou>
+
+## Test plan
+- [ ] Testes unitarios passando
+- [ ] Testes de integracao passando
+- [ ] Validacao XSD para providers afetados
+```
+
+### Exemplo concreto
+
+O **Firecrawl** foi usado na Fase 4 para obter documentacao tecnica de providers que nao tinham XSD publico. Por exemplo, para entender o formato de envelope do provider Paulistana (que usa `PedidoEnvioLoteRPS` com cabecalho separado), o Firecrawl fez scraping da documentacao tecnica do municipio de Sao Paulo e extraiu os campos obrigatorios do cabecalho.
+
+---
+
+## 9. Commands — Slash Commands e Custom Skills
+
+### O que e
+
+**Slash commands** sao atalhos que disparam fluxos predefinidos. Podem ser nativos (como `/commit`, `/review-pr`) ou customizados (como `/opsx-apply`, `/opsx-propose`).
+
+### Commands utilizados
+
+| Command | Funcao |
+|---------|--------|
+| `/commit` | Cria commit com mensagem descritiva baseada no diff |
+| `/review-pr` | Revisao de PR com foco em SOLID, Clean Code e cobertura |
+| `/opsx-apply` | Aplica mudanca simples com implementacao + testes |
+| `/opsx-apply-orchestrated` | Aplica mudanca complexa com multi agentes |
+| `/opsx-propose` | Propoe mudanca sem implementar (spec + criterios de aceite) |
+| `/opsx-archive` | Arquiva change concluido com documentacao |
+| `/opsx-explore` | Explora codebase para entender contexto |
+
+### Como foi usado neste projeto
+
+O `/opsx-propose` era sempre usado antes de mudancas grandes. Exemplo do commit #26:
+
+```
+/opsx-propose "Selecao inteligente de XSD de envio para providers com multiplos schemas"
+```
+
+Resultado: proposta com analise dos 48 providers, identificacao de padroes de nomeacao de XSD (`*_envio*.xsd`, `*enviar*.xsd`), criterios de aceite e estimativa de impacto.
+
+### Exemplo concreto
+
+O `/opsx-apply-orchestrated` foi usado no commit #30 (deep autogen + scoped validation + E2E tests). O fluxo completo:
+
+1. Proposta revisada e aprovada
+2. spec-agent listou 5 criterios de aceite
+3. implementation-agent implementou `ProviderConfigGenerator` com deep autogen
+4. unit-test-agent gerou 40+ testes para geracao de regras
+5. xml-test-agent gerou testes E2E com validacao XSD
+6. review-agent aprovou com 2 ajustes menores
+
+Total: ~200 linhas de implementacao + ~400 linhas de testes, em uma unica sessao orquestrada.
+
+---
+
+## 10. Scheduling — Automação, Background Tasks e Worktrees
+
+### O que é
+
+**Scheduling** refere-se à automação de tarefas: execução em background, isolamento de contexto via worktrees, tarefas recorrentes e paralelismo de agentes. No Claude Code, isso se manifesta em três capacidades:
+
+- **`run_in_background`** — executar comandos ou agentes sem bloquear a sessão principal
+- **`isolation: worktree`** — agentes trabalham em cópias isoladas do repositório
+- **Cron/Loop** — execução periódica de validações e relatórios
+
+### Como foi usado neste projeto
+
+**Background tasks** foram usadas extensivamente durante a orquestração multiagente. Quando o `implementation-agent` estava implementando uma feature, testes de build eram executados em background:
+
+```
+# Agente de implementação trabalhando em foreground
+implementation-agent: implementando SchemaAttribute no SchemaModel...
+
+# Build de verificação rodando em background (run_in_background: true)
+dotnet build --verbosity quiet  →  notificação quando completa
+```
+
+**Worktrees isoladas** foram usadas quando agentes paralelos precisavam modificar os mesmos arquivos sem conflito. Na Fase 6 (commit #30), dois `implementation-agent` rodaram em paralelo:
+- Agente A: Deep Envelope Detection no `ProviderConfigGenerator`
+- Agente B: Scoped XSD Validation no `SchemaBasedXmlSerializer`
+
+Cada um em sua worktree, sem interferir no outro. O resultado era mergeado ao final.
+
+**Automação via CI** — o GitHub Actions (`.github/workflows/ci.yml`) executa automaticamente:
+1. Restore + Build
+2. 611 testes unitários
+3. 116 testes de integração (com MongoDB via service container)
+
+A cada push ou PR, o CI garante que nenhum provider MVP regride.
+
+### Exemplo concreto
+
+Durante a implementação do commit #31 (xs:attribute support), três agentes trabalharam em paralelo com isolamento:
+
+```
+Agent 1 (foreground): SchemaModel + XsdSchemaAnalyzer  →  modelo e extração
+Agent 2 (background): SchemaBasedXmlSerializer         →  emissão de atributos
+Agent 3 (background): ProviderConfigGenerator          →  auto-gen de rules
+
+→ Build check em background após cada agente completar
+→ Test suite completa ao final: 611 unit tests, 0 failures
+```
+
+O relatório `providers/runtime-xsd-validation-summary.md` era regenerado após cada merge significativo, servindo como definition of done: *"nenhum provider MVP pode regredir de PASS para FAIL"*.
+
+---
+
+## Resumo
+
+| # | Tema | Impacto principal |
+|---|------|------------------|
+| 1 | Terminal / IDE | Desenvolvimento 100% assistido por IA, sem alternar entre ferramentas |
+| 2 | Docker | Infraestrutura de testes em 5 linhas de YAML |
+| 3 | Assistente | Decisoes arquiteturais mais informadas (runtime vs build-time, resolucao por municipio) |
+| 4 | Agente unico | Features completas em uma sessao (multi-namespace em 1 commit) |
+| 5 | Multi agentes | Implementacoes mais robustas com spec + code + test + review |
+| 6 | Agent Skills | Consistencia entre agentes via regras compartilhadas |
+| 7 | MCP / LSP | Acesso a documentacao atualizada sem sair do fluxo |
+| 8 | Tools/Plugins | Integracao com GitHub, scraping de docs, monitoramento |
+| 9 | Commands | Fluxos padronizados que reduzem fricao |
+| 10 | Scheduling | Validacao continua e trabalho paralelo sem conflito |
+
+O aprendizado principal: IA nao substitui o desenvolvedor, mas **muda o tipo de trabalho**. Em vez de escrever cada linha de codigo, o trabalho vira **especificar, revisar, orquestrar e validar**. O resultado e mais codigo, mais testes, mais cobertura — em menos tempo.
+
+## Links relacionados
+
+- [Visao do Produto](01-product-overview.md) — o que foi construido
+- [Jornada de Evolucao](02-evolution-journey.md) — como foi construido
+- [Arquitetura](04-architecture.md) — a estrutura resultante

--- a/docs/04-architecture.md
+++ b/docs/04-architecture.md
@@ -1,0 +1,412 @@
+# Arquitetura — NFSe Service Invoice Engine
+
+## Visao geral
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                        API Layer                                     │
+│  ServiceIncoiceController  ProviderManagementController              │
+│  RuleCatalogController                                               │
+├─────────────────────────────────────────────────────────────────────┤
+│                     Application Layer                                │
+│  GenerateNfseXmlUseCase    ProviderManagementService                 │
+├─────────────────────────────────────────────────────────────────────┤
+│                    Infrastructure Layer                               │
+│  SchemaEngineNfseXmlGenerator  MongoProviderResolver                 │
+│  MongoProviderRepository       ProviderOnboardingService             │
+│  EngineProviderValidator                                             │
+├─────────────────────────────────────────────────────────────────────┤
+│                    XmlGeneration Layer (Engine Core)                  │
+│  XsdSchemaAnalyzer          SchemaBasedXmlSerializer                 │
+│  ServiceInvoiceSchemaDataBinder  SchemaSerializationPipeline         │
+│  ProviderResolver           ProviderSerializerFactory                │
+│  ProviderConfigGenerator    CommonFieldMappingDictionary             │
+│  TypedRuleResolver          ProviderRuleResolver                     │
+│  SendXsdSelector            XsdValidator                             │
+│  ValidationDiagnosticEnricher                                        │
+├─────────────────────────────────────────────────────────────────────┤
+│                      Domain Layer                                    │
+│  DpsDocument   ServiceInvoice   ManagedProvider   IbsCbsModels       │
+│  INfseXmlGenerator  IProviderOnboardingService  IProviderRepository  │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+O projeto segue **Onion Architecture**: Domain no centro, sem dependencias externas. Application depende so de Domain. Infrastructure implementa interfaces de Domain. XmlGeneration e a engine core. API e o ponto de entrada.
+
+---
+
+## Pipeline de geracao de XML
+
+### Fluxo principal: Request → XML
+
+```
+HTTP POST /api/v1/nfse/xml
+        │
+        ▼
+┌─────────────────────┐
+│  NfseRequestToDps   │  Mapper: request JSON → DpsDocument
+│  DocumentModelMapper│
+└────────┬────────────┘
+         │
+         ▼
+┌─────────────────────┐
+│  GenerateNfseXml    │  Use case: orquestra geracao
+│  UseCase            │
+└────────┬────────────┘
+         │
+         ▼
+┌─────────────────────┐
+│  SchemaEngineNfse   │  Resolve provider e delega para engine
+│  XmlGenerator       │
+└────────┬────────────┘
+         │
+         ▼
+┌─────────────────────────────────────────┐
+│  Resolucao de Provider                   │
+│  MongoProviderResolver → ProviderResolver│
+│  (MongoDB → Filesystem → Fallback)       │
+└────────┬────────────────────────────────┘
+         │
+         ▼
+┌─────────────────────────────────────────┐
+│  SchemaSerializationPipeline             │
+│                                          │
+│  1. XsdSchemaAnalyzer.Analyze(xsd)       │
+│     → SchemaDocument                     │
+│                                          │
+│  2. LoadProfile(rules.json)              │
+│     → ProviderProfile + ProviderRules    │
+│                                          │
+│  3. ServiceInvoiceSchemaDataBinder.Bind  │
+│     (DpsDocument, Profile, Schema)       │
+│     → Dictionary<string, object?>        │
+│                                          │
+│  4. SchemaBasedXmlSerializer             │
+│     .SerializeAndValidate(...)           │
+│     → SerializationResult (XML + erros)  │
+└─────────────────────────────────────────┘
+         │
+         ▼
+┌─────────────────────┐
+│  Response JSON      │  XML + provider info + diagnostics
+│  {xml, providerName,│
+│   municipalityCode} │
+└─────────────────────┘
+```
+
+---
+
+## Componentes principais
+
+### XsdSchemaAnalyzer
+
+**Responsabilidade:** Analisar um arquivo XSD e produzir um `SchemaDocument` navegavel.
+
+**Entrada:** Caminho para arquivo `.xsd`
+
+**Saida:** `SchemaDocument` contendo:
+- `ComplexTypes` — lista de `SchemaComplexType` com elementos, atributos e inline types
+- `RootInlineType` — tipo anonimo do elemento raiz (quando inline)
+- `Namespaces` — mapa de prefixos para URIs
+
+**Suporta:** `xs:complexType`, `xs:sequence`, `xs:choice`, `xs:simpleType`, `xs:restriction`, `xs:attribute`, tipos anonimos inline, multi-namespace.
+
+### SchemaBasedXmlSerializer
+
+**Responsabilidade:** Gerar XML a partir de um `SchemaDocument` e dados bindados.
+
+**Entrada:**
+- `SchemaDocument` — estrutura do schema
+- `Dictionary<string, object?>` — dados bindados por path
+- `IProviderRuleResolver` — resolver de regras tipadas
+- Root complex type name e root element name
+
+**Saida:** `SerializationResult` com XML string, elemento raiz, erros de validacao.
+
+**Capacidades:**
+- Emite elementos na ordem do schema (sequence)
+- Resolve choices baseado em dados presentes
+- Emite atributos XSD
+- Suporta inline types recursivos
+- Emite namespaces corretos por tipo
+
+### ServiceInvoiceSchemaDataBinder
+
+**Responsabilidade:** Transformar um `DpsDocument` em um dicionario flat de paths e valores que o serializer consome.
+
+**Fluxo:**
+1. Resolve regras tipadas do provider via `TypedRuleResolver`
+2. Para cada regra, extrai o valor do `DpsDocument` e mapeia para o path XSD
+3. Aplica formatacao (digitsOnly, padLeft, maxLength)
+4. Aplica mapeamento de enum (EnumMapping)
+5. Avalia condicoes (ConditionalEmission)
+6. Resolve choices (Choice)
+
+### ProviderResolver
+
+**Responsabilidade:** Encontrar o provider correto para um dado municipio.
+
+**Estrategia de resolucao (cadeia):**
+
+```
+1. MongoProviderResolver
+   → Busca no MongoDB por provider com municipalityCode correspondente
+   → Retorna ManagedProvider se encontrado
+
+2. ProviderResolver (Filesystem)
+   → Busca na pasta providers/ por provider com rules e XSD
+   → Retorna ProviderResolution se encontrado
+
+3. Fallback Nacional
+   → Se nenhum provider atende o municipio, usa provider "nacional"
+```
+
+### TypedRuleResolver
+
+**Responsabilidade:** Resolver regras tipadas de um `ProviderProfile` para produzir bindings concretos.
+
+**6 tipos de regra:**
+
+| Tipo | Funcao | Campos obrigatorios |
+|------|--------|-------------------|
+| **Binding** | Vincula campo do dominio a path XSD | target, source |
+| **Default** | Binding com fallback quando nulo | target, source, fallbackValue |
+| **EnumMapping** | Mapeia enum para codigo do provider | target, source, mappings |
+| **ConditionalEmission** | Emite/omite campo por condicao | target, source, condition, action |
+| **Choice** | Seleciona elemento por discriminador | target, choiceField, options |
+| **Formatting** | Aplica formatacao no valor | target, + opcoes de formato |
+
+### ProviderConfigGenerator
+
+**Responsabilidade:** Gerar automaticamente regras tipadas para um provider a partir do `CommonFieldMappingDictionary`.
+
+**Fluxo:**
+1. Analisa o XSD do provider com `XsdSchemaAnalyzer`
+2. Percorre todos os elementos do schema recursivamente
+3. Para cada elemento, consulta o `CommonFieldMappingDictionary`
+4. Se houver match, gera regra tipada (Binding, EnumMapping, Choice conforme o caso)
+5. Retorna `ProviderProfile` com regras geradas
+
+### XsdValidator
+
+**Responsabilidade:** Validar XML gerado contra o schema XSD original.
+
+**Entrada:** XML string + caminho do diretorio XSD
+
+**Saida:** Lista de erros de validacao com severity, mensagem e posicao.
+
+### ValidationDiagnosticEnricher
+
+**Responsabilidade:** Enriquecer erros de validacao XSD com informacoes acionaveis.
+
+**Para cada erro, adiciona:**
+- Campo de origem no `DpsDocument` (quando identificavel)
+- Sugestao de correcao
+- Nivel de confianca da sugestao
+- Razao do erro
+
+---
+
+## Fluxo de analise de schema
+
+```
+arquivo.xsd
+    │
+    ▼
+XsdSchemaAnalyzer.Analyze()
+    │
+    ├── XmlSchemaSet.Compile()        // .NET System.Xml.Schema
+    │
+    ├── Iterar GlobalTypes             // xs:complexType nomeados
+    │   └── Para cada complexType:
+    │       ├── Extrair elements (sequence/choice)
+    │       ├── Extrair attributes
+    │       ├── Resolver inline types recursivamente
+    │       └── Adicionar a SchemaDocument.ComplexTypes
+    │
+    ├── Iterar GlobalElements          // xs:element raiz
+    │   └── Detectar inline type do root
+    │
+    └── Coletar namespaces
+
+    ▼
+SchemaDocument
+├── ComplexTypes: List<SchemaComplexType>
+│   └── SchemaComplexType
+│       ├── Name: string
+│       ├── Elements: List<SchemaElement>
+│       │   └── SchemaElement
+│       │       ├── Name, TypeName, IsRequired
+│       │       ├── InlineType: SchemaComplexType?
+│       │       └── IsChoice: bool
+│       └── Attributes: List<SchemaAttribute>
+├── RootInlineType: SchemaComplexType?
+└── Namespaces: Dictionary<string, string>
+```
+
+---
+
+## Sistema de regras
+
+### De onde vem as regras
+
+```
+CommonFieldMappingDictionary
+    │ (40+ campos comuns: CNPJ, CPF, datas, valores, codigos)
+    │
+    ▼
+ProviderConfigGenerator.Generate(providerName)
+    │ (analisa XSD + dicionario → regras tipadas)
+    │
+    ▼
+ProviderProfile (rules.json)
+    │ (persistido no filesystem ou MongoDB)
+    │
+    ▼
+TypedRuleResolver.Resolve(DpsDocument, Schema)
+    │ (aplica regras em runtime)
+    │
+    ▼
+Dictionary<string, object?> (dados bindados para o serializer)
+```
+
+### Exemplo de regra tipada
+
+```json
+{
+  "type": "Binding",
+  "target": "infDPS.dhEmi",
+  "source": "IssuedOn",
+  "format": "yyyy-MM-ddTHH:mm:sszzz"
+}
+```
+
+Significado: o campo `IssuedOn` do `DpsDocument` sera formatado como ISO 8601 e emitido no elemento `infDPS.dhEmi` do XML.
+
+```json
+{
+  "type": "EnumMapping",
+  "target": "infDPS.tpAmb",
+  "source": "Values.EnvironmentType",
+  "mappings": {
+    "Production": "1",
+    "Homologation": "2"
+  },
+  "defaultMapping": "1"
+}
+```
+
+Significado: o enum `EnvironmentType` sera convertido para "1" ou "2" conforme o provider espera.
+
+---
+
+## Resolucao de provider por municipio
+
+```
+Request com cityCode = "3550308" (Sao Paulo)
+    │
+    ▼
+MongoProviderResolver.Resolve("3550308")
+    │
+    ├── Encontrou? → Retorna ManagedProvider (com XSD e regras do MongoDB)
+    │
+    └── Nao encontrou?
+        │
+        ▼
+    ProviderResolver (Filesystem)
+        │
+        ├── Algum provider em providers/ tem "3550308"? → Retorna ProviderResolution
+        │
+        └── Nao encontrou?
+            │
+            ▼
+        Fallback → Provider "nacional"
+            (response inclui isFallback=true e fallbackReason)
+```
+
+---
+
+## Estrutura de projetos e dependencias
+
+```
+SemanaIA.ServiceInvoice.Api
+    ├── depende de → Application
+    ├── depende de → Infrastructure
+    └── depende de → Domain
+
+SemanaIA.ServiceInvoice.Application
+    └── depende de → Domain
+
+SemanaIA.ServiceInvoice.Infrastructure
+    ├── depende de → Domain
+    └── depende de → XmlGeneration
+
+SemanaIA.ServiceInvoice.XmlGeneration
+    └── depende de → Domain
+
+SemanaIA.ServiceInvoice.Domain
+    └── sem dependencias externas (exceto BCL)
+```
+
+---
+
+## Estrutura de um provider no filesystem
+
+```
+providers/
+└── nacional/
+    ├── xsd/
+    │   └── servico_enviar_lote_rps_envio_v1.00.xsd
+    ├── rules/
+    │   └── rules.json           # ProviderProfile com regras tipadas
+    └── generated/               # Artefatos gerados (analise, codigo)
+```
+
+O `rules.json` contem o `ProviderProfile`:
+
+```json
+{
+  "rootComplexTypeName": "TCDPS",
+  "rootElementName": "DPS",
+  "version": "1.00",
+  "rules": [
+    { "type": "Binding", "target": "infDPS.Id", "source": "Id" },
+    { "type": "Binding", "target": "infDPS.dhEmi", "source": "IssuedOn", "format": "yyyy-MM-ddTHH:mm:sszzz" },
+    ...
+  ]
+}
+```
+
+---
+
+## Fluxo de dados completo
+
+```
+┌──────────┐    ┌──────────┐    ┌─────────────┐    ┌────────────┐    ┌──────────┐
+│  Request │───▶│  Mapper  │───▶│ DpsDocument  │───▶│  Binder    │───▶│ Dict<>   │
+│  JSON    │    │          │    │ (canonico)   │    │            │    │ (flat)   │
+└──────────┘    └──────────┘    └─────────────┘    └────────────┘    └────┬─────┘
+                                                                          │
+┌──────────┐    ┌──────────┐    ┌─────────────┐    ┌────────────┐         │
+│  XSD     │───▶│ Analyzer │───▶│ SchemaDoc   │───▶│ Serializer │◀────────┘
+│  file    │    │          │    │             │    │            │
+└──────────┘    └──────────┘    └─────────────┘    └────┬───────┘
+                                                         │
+                                                         ▼
+                                                  ┌─────────────┐    ┌────────────┐
+                                                  │  XML string │───▶│ XsdValidator│
+                                                  │             │    │            │
+                                                  └─────────────┘    └────┬───────┘
+                                                                          │
+                                                                          ▼
+                                                                   ┌─────────────┐
+                                                                   │ Diagnostics │
+                                                                   │ Enricher    │
+                                                                   └─────────────┘
+```
+
+## Links relacionados
+
+- [Visao do Produto](01-product-overview.md) — capacidades atuais
+- [Jornada de Evolucao](02-evolution-journey.md) — como cada componente foi construido
+- [API de Providers](05-provider-management-api.md) — endpoints que expoe essa arquitetura

--- a/docs/05-provider-management-api.md
+++ b/docs/05-provider-management-api.md
@@ -1,0 +1,606 @@
+# API de Gestao de Providers
+
+Documentacao completa dos endpoints da API REST para gestao de providers, geracao de XML e catalogo de regras.
+
+**Base URL:** `https://localhost:5001`
+
+---
+
+## Emissao de NFS-e
+
+### POST /api/v1/nfse/xml — Gerar XML
+
+Gera XML de NFS-e a partir dos dados do documento. O provider e resolvido automaticamente pelo codigo IBGE do municipio do prestador.
+
+```bash
+curl -X POST https://localhost:5001/api/v1/nfse/xml \
+  -H "Content-Type: application/json" \
+  -d '{
+    "externalId": "NFSe-2026-001",
+    "issuedOn": "2026-03-23T10:00:00-03:00",
+    "provider": {
+      "name": "Empresa Exemplo LTDA",
+      "cnpj": "12345678000195",
+      "municipalInscription": "12345",
+      "cityCode": "3550308"
+    },
+    "borrower": {
+      "name": "Tomador Exemplo LTDA",
+      "cnpj": "98765432000100"
+    },
+    "service": {
+      "description": "Consultoria em tecnologia da informacao",
+      "cityTaxCode": "010501",
+      "nationalServiceCode": "010501"
+    },
+    "values": {
+      "serviceAmount": 5000.00,
+      "issRate": 5.00,
+      "issAmount": 250.00
+    }
+  }'
+```
+
+**Resposta 200 OK:**
+
+```json
+{
+  "externalId": "NFSe-2026-001",
+  "xml": "<?xml version=\"1.0\" encoding=\"utf-8\"?><DPS xmlns=\"http://www.sped.fazenda.gov.br/nfse\">...</DPS>",
+  "rootElement": "DPS",
+  "generatedBy": "SchemaEngine",
+  "providerName": "nacional",
+  "municipalityCode": "3550308",
+  "isFallback": false,
+  "fallbackReason": null
+}
+```
+
+**Resposta com fallback (municipio sem provider especifico):**
+
+```json
+{
+  "externalId": "NFSe-2026-002",
+  "xml": "<?xml version=\"1.0\"...>",
+  "rootElement": "DPS",
+  "generatedBy": "SchemaEngine",
+  "providerName": "nacional",
+  "municipalityCode": "9999999",
+  "isFallback": true,
+  "fallbackReason": "Nenhum provider configurado para o municipio 9999999. Usando provider nacional como fallback."
+}
+```
+
+---
+
+## Gestao de Providers
+
+### POST /api/v1/providers — Cadastrar provider
+
+Cadastra um novo provider com upload de arquivos XSD. Dispara validacao automatica apos o cadastro.
+
+```bash
+curl -X POST https://localhost:5001/api/v1/providers \
+  -F "name=meu-provider" \
+  -F "xsdFiles=@servico_enviar_lote_rps_envio.xsd" \
+  -F "xsdFiles=@tipos_v1.xsd" \
+  -F "municipalityCodes=3550308,3509502" \
+  -F "primaryXsdFile=servico_enviar_lote_rps_envio.xsd"
+```
+
+**Resposta 201 Created:**
+
+```json
+{
+  "id": "683f1a2b4e5d6c7890abcdef",
+  "name": "meu-provider",
+  "version": null,
+  "status": "Ready",
+  "blockReason": null,
+  "xsdFileNames": [
+    "servico_enviar_lote_rps_envio.xsd",
+    "tipos_v1.xsd"
+  ],
+  "municipalityCodes": ["3550308", "3509502"],
+  "hasRulesConfig": true,
+  "typedRuleCount": 28,
+  "primaryXsdFile": "servico_enviar_lote_rps_envio.xsd",
+  "validationCount": 1,
+  "createdAt": "2026-03-23T10:00:00Z",
+  "updatedAt": "2026-03-23T10:00:00Z"
+}
+```
+
+**Resposta 409 Conflict (nome duplicado):**
+
+```json
+{
+  "error": "Ja existe um provider com o nome 'meu-provider'."
+}
+```
+
+### GET /api/v1/providers — Listar providers
+
+```bash
+# Todos os providers
+curl https://localhost:5001/api/v1/providers
+
+# Filtrar por status
+curl "https://localhost:5001/api/v1/providers?status=Ready"
+```
+
+**Resposta 200 OK:**
+
+```json
+[
+  {
+    "id": "683f1a2b4e5d6c7890abcdef",
+    "name": "meu-provider",
+    "status": "Ready",
+    "municipalityCount": 2,
+    "hasRulesConfig": true,
+    "updatedAt": "2026-03-23T10:00:00Z"
+  }
+]
+```
+
+### GET /api/v1/providers/{id} — Detalhes do provider
+
+```bash
+curl https://localhost:5001/api/v1/providers/683f1a2b4e5d6c7890abcdef
+```
+
+### PUT /api/v1/providers/{id} — Atualizar provider
+
+Atualizacao parcial. Campos omitidos nao sao alterados.
+
+```bash
+curl -X PUT https://localhost:5001/api/v1/providers/683f1a2b4e5d6c7890abcdef \
+  -F "name=meu-provider-v2" \
+  -F "version=2.0"
+```
+
+### DELETE /api/v1/providers/{id} — Excluir provider
+
+```bash
+curl -X DELETE https://localhost:5001/api/v1/providers/683f1a2b4e5d6c7890abcdef
+```
+
+**Resposta 204 No Content** (sucesso, sem body).
+
+---
+
+## Status e Ciclo de Vida
+
+### GET /api/v1/providers/{id}/status — Status operacional
+
+```bash
+curl https://localhost:5001/api/v1/providers/683f1a2b4e5d6c7890abcdef/status
+```
+
+**Resposta 200 OK:**
+
+```json
+{
+  "id": "683f1a2b4e5d6c7890abcdef",
+  "name": "meu-provider",
+  "status": "Ready",
+  "blockReason": null,
+  "lastValidation": {
+    "passed": true,
+    "checks": [
+      { "name": "SchemaExists", "passed": true, "detail": "XSD files found." },
+      { "name": "AnalysisSuccess", "passed": true, "detail": "Schema analyzed successfully." },
+      { "name": "BindingsPresent", "passed": true, "detail": "28 typed rules configured." },
+      { "name": "RuntimeProducible", "passed": true, "detail": "XML generated successfully." },
+      { "name": "XsdValid", "passed": true, "detail": "XML validates against XSD." }
+    ],
+    "blockReason": null,
+    "timestamp": "2026-03-23T10:00:00Z",
+    "pendingFields": null
+  },
+  "validationCount": 1
+}
+```
+
+**Resposta com provider bloqueado:**
+
+```json
+{
+  "id": "...",
+  "name": "provider-com-gap",
+  "status": "Blocked",
+  "blockReason": "XSD validation failed: 3 errors.",
+  "lastValidation": {
+    "passed": false,
+    "checks": [
+      { "name": "SchemaExists", "passed": true, "detail": "..." },
+      { "name": "AnalysisSuccess", "passed": true, "detail": "..." },
+      { "name": "BindingsPresent", "passed": true, "detail": "..." },
+      { "name": "RuntimeProducible", "passed": true, "detail": "..." },
+      { "name": "XsdValid", "passed": false, "detail": "3 validation errors." }
+    ],
+    "blockReason": "XSD validation failed: 3 errors.",
+    "pendingFields": [
+      {
+        "fieldPath": "infDPS.tpAmb",
+        "isRequired": true,
+        "suggestedSource": "Values.EnvironmentType",
+        "confidence": "High",
+        "reason": "Campo obrigatorio no schema, mapeamento sugerido via CommonFieldMappingDictionary."
+      }
+    ]
+  }
+}
+```
+
+### POST /api/v1/providers/{id}/activate — Ativar provider
+
+```bash
+curl -X POST https://localhost:5001/api/v1/providers/683f1a2b4e5d6c7890abcdef/activate
+```
+
+### POST /api/v1/providers/{id}/deactivate — Desativar provider
+
+```bash
+curl -X POST https://localhost:5001/api/v1/providers/683f1a2b4e5d6c7890abcdef/deactivate
+```
+
+### POST /api/v1/providers/{id}/validate — Validar sob demanda
+
+Executa validacao completa e atualiza o status do provider.
+
+```bash
+curl -X POST https://localhost:5001/api/v1/providers/683f1a2b4e5d6c7890abcdef/validate
+```
+
+---
+
+## Gestao de Municipios
+
+### POST /api/v1/providers/{id}/municipalities — Adicionar municipios
+
+Cada codigo IBGE so pode pertencer a um provider.
+
+```bash
+curl -X POST https://localhost:5001/api/v1/providers/683f1a2b4e5d6c7890abcdef/municipalities \
+  -H "Content-Type: application/json" \
+  -d '{
+    "codes": ["3304557", "3106200"]
+  }'
+```
+
+**Resposta 409 Conflict (municipio ja atribuido):**
+
+```json
+{
+  "error": "Municipio '3550308' ja esta atribuido ao provider 'outro-provider'."
+}
+```
+
+### DELETE /api/v1/providers/{id}/municipalities — Remover municipios
+
+```bash
+curl -X DELETE https://localhost:5001/api/v1/providers/683f1a2b4e5d6c7890abcdef/municipalities \
+  -H "Content-Type: application/json" \
+  -d '{
+    "codes": ["3304557"]
+  }'
+```
+
+---
+
+## Gestao de Regras Tipadas
+
+### GET /api/v1/providers/{id}/rules — Listar regras
+
+```bash
+curl https://localhost:5001/api/v1/providers/683f1a2b4e5d6c7890abcdef/rules
+```
+
+**Resposta 200 OK:**
+
+```json
+[
+  {
+    "type": "Binding",
+    "target": "infDPS.Id",
+    "source": "Id"
+  },
+  {
+    "type": "Binding",
+    "target": "infDPS.dhEmi",
+    "source": "IssuedOn",
+    "format": "yyyy-MM-ddTHH:mm:sszzz"
+  },
+  {
+    "type": "EnumMapping",
+    "target": "infDPS.tpAmb",
+    "source": "Values.EnvironmentType",
+    "mappings": {
+      "Production": "1",
+      "Homologation": "2"
+    },
+    "defaultMapping": "1"
+  },
+  {
+    "type": "Choice",
+    "target": "infDPS.prest",
+    "choiceField": "Provider.PersonType",
+    "options": {
+      "LegalEntity": {
+        "element": "CNPJ",
+        "source": "Provider.Cnpj",
+        "padLeft": 14,
+        "padChar": "0"
+      },
+      "Individual": {
+        "element": "CPF",
+        "source": "Provider.Cpf",
+        "padLeft": 11,
+        "padChar": "0"
+      }
+    }
+  },
+  {
+    "type": "ConditionalEmission",
+    "target": "infDPS.pAliq",
+    "source": "Values.IssRate",
+    "action": "Emit",
+    "condition": {
+      "field": "Values.IssRate",
+      "operator": "GreaterThan",
+      "value": "0"
+    }
+  },
+  {
+    "type": "Formatting",
+    "target": "cTribNac",
+    "digitsOnly": true,
+    "padLeft": 6,
+    "padChar": "0",
+    "maxLength": 6
+  }
+]
+```
+
+### PUT /api/v1/providers/{id}/rules — Substituir todas as regras
+
+Substitui a lista completa de regras. A engine valida antes de salvar.
+
+```bash
+curl -X PUT https://localhost:5001/api/v1/providers/683f1a2b4e5d6c7890abcdef/rules \
+  -H "Content-Type: application/json" \
+  -d '[
+    { "type": "Binding", "target": "infDPS.Id", "source": "Id" },
+    { "type": "Binding", "target": "infDPS.dhEmi", "source": "IssuedOn", "format": "yyyy-MM-ddTHH:mm:sszzz" }
+  ]'
+```
+
+**Resposta 400 Bad Request (regra invalida):**
+
+```json
+{
+  "error": "Uma ou mais regras sao invalidas.",
+  "ruleValidationErrors": [
+    {
+      "rule": "Binding target='infDPS.campoInexistente'",
+      "message": "Target 'infDPS.campoInexistente' nao encontrado no schema XSD do provider."
+    }
+  ]
+}
+```
+
+### POST /api/v1/providers/{id}/rules — Adicionar regras
+
+Adiciona regras sem remover as existentes.
+
+```bash
+curl -X POST https://localhost:5001/api/v1/providers/683f1a2b4e5d6c7890abcdef/rules \
+  -H "Content-Type: application/json" \
+  -d '[
+    {
+      "type": "Default",
+      "target": "infDPS.tpRetISSQN",
+      "source": "Values.RetentionType",
+      "fallbackValue": "1"
+    }
+  ]'
+```
+
+### DELETE /api/v1/providers/{id}/rules/{index} — Remover regra por indice
+
+Indice base zero. Use GET rules para consultar indices.
+
+```bash
+curl -X DELETE https://localhost:5001/api/v1/providers/683f1a2b4e5d6c7890abcdef/rules/3
+```
+
+---
+
+## Catalogo de Regras (DSL)
+
+Endpoints de consulta para entender a DSL de regras tipadas.
+
+### GET /api/v1/rules/sources — Campos de dominio disponiveis
+
+Lista todos os campos do `DpsDocument` que podem ser usados como `source` em regras.
+
+```bash
+curl https://localhost:5001/api/v1/rules/sources
+```
+
+**Resposta 200 OK (exemplo parcial):**
+
+```json
+[
+  {
+    "path": "Id",
+    "type": "string",
+    "description": "Identificador unico do documento DPS.",
+    "allowedValues": null
+  },
+  {
+    "path": "IssuedOn",
+    "type": "DateTimeOffset",
+    "description": "Data/hora de emissao do documento.",
+    "allowedValues": null
+  },
+  {
+    "path": "Provider.Cnpj",
+    "type": "string",
+    "description": "CNPJ do prestador de servicos.",
+    "allowedValues": null
+  },
+  {
+    "path": "Values.EnvironmentType",
+    "type": "enum:EnvironmentType",
+    "description": "Tipo de ambiente (producao ou homologacao).",
+    "allowedValues": ["Production", "Homologation"]
+  }
+]
+```
+
+### GET /api/v1/rules/targets/{providerName} — Campos XSD do provider
+
+Lista todos os campos do schema XSD de um provider que podem ser usados como `target` em regras.
+
+```bash
+curl https://localhost:5001/api/v1/rules/targets/nacional
+```
+
+**Resposta 200 OK (exemplo parcial):**
+
+```json
+[
+  { "path": "infDPS.Id", "typeName": "xs:string", "isRequired": true },
+  { "path": "infDPS.tpAmb", "typeName": "tpAmb", "isRequired": true },
+  { "path": "infDPS.dhEmi", "typeName": "xs:dateTime", "isRequired": true },
+  { "path": "infDPS.verAplic", "typeName": "xs:string", "isRequired": false },
+  { "path": "infDPS.serie", "typeName": "xs:string", "isRequired": true }
+]
+```
+
+### GET /api/v1/rules/operators — Operadores de condicao
+
+```bash
+curl https://localhost:5001/api/v1/rules/operators
+```
+
+**Resposta 200 OK:**
+
+```json
+[
+  { "name": "Equals", "description": "Igualdade entre o valor do campo e o valor esperado." },
+  { "name": "NotEquals", "description": "Diferenca entre o valor do campo e o valor esperado." },
+  { "name": "GreaterThan", "description": "Valor do campo maior que o valor esperado (comparacao numerica)." },
+  { "name": "LessThan", "description": "Valor do campo menor que o valor esperado (comparacao numerica)." },
+  { "name": "GreaterThanOrEqual", "description": "Valor do campo maior ou igual ao valor esperado." },
+  { "name": "LessThanOrEqual", "description": "Valor do campo menor ou igual ao valor esperado." },
+  { "name": "IsNull", "description": "Campo nao possui valor (null ou vazio)." },
+  { "name": "HasValue", "description": "Campo possui valor (nao nulo e nao vazio)." },
+  { "name": "Contains", "description": "Valor do campo contem o texto esperado." },
+  { "name": "In", "description": "Valor do campo esta na lista de valores esperados (separados por virgula)." }
+]
+```
+
+### GET /api/v1/rules/actions — Acoes disponiveis
+
+```bash
+curl https://localhost:5001/api/v1/rules/actions
+```
+
+**Resposta 200 OK:**
+
+```json
+[
+  { "name": "Emit", "description": "Emitir o campo no XML quando a condicao for verdadeira." },
+  { "name": "Skip", "description": "Omitir o campo do XML quando a condicao for verdadeira." }
+]
+```
+
+### GET /api/v1/rules/types — Tipos de regra
+
+```bash
+curl https://localhost:5001/api/v1/rules/types
+```
+
+**Resposta 200 OK:**
+
+```json
+[
+  {
+    "name": "Binding",
+    "description": "Vincula um campo do dominio a um campo do XML do provider.",
+    "requiredFields": ["target", "source (ou sourceType + constantValue)"],
+    "example": "{ \"type\": \"Binding\", \"target\": \"infDPS.dhEmi\", \"source\": \"IssuedOn\", \"format\": \"yyyy-MM-ddTHH:mm:sszzz\" }"
+  },
+  {
+    "name": "Default",
+    "description": "Vincula um campo do dominio com valor fallback quando nulo.",
+    "requiredFields": ["target", "source", "fallbackValue"],
+    "example": "{ \"type\": \"Default\", \"target\": \"infDPS.tpRetISSQN\", \"source\": \"Values.RetentionType\", \"fallbackValue\": \"1\" }"
+  },
+  {
+    "name": "EnumMapping",
+    "description": "Mapeia um enum do dominio para valores do provider.",
+    "requiredFields": ["target", "source", "mappings"],
+    "example": "{ \"type\": \"EnumMapping\", \"target\": \"infDPS.tribISSQN\", \"source\": \"Values.TaxationType\", \"mappings\": { \"WithinCity\": \"1\", \"Immune\": \"2\" }, \"defaultMapping\": \"1\" }"
+  },
+  {
+    "name": "ConditionalEmission",
+    "description": "Emite ou omite um campo com base em uma condicao composta.",
+    "requiredFields": ["target", "source", "condition", "action"],
+    "example": "{ \"type\": \"ConditionalEmission\", \"target\": \"infDPS.pAliq\", \"source\": \"Values.IssRate\", \"action\": \"Emit\", \"condition\": { \"field\": \"Values.IssRate\", \"operator\": \"GreaterThan\", \"value\": \"0\" } }"
+  },
+  {
+    "name": "Choice",
+    "description": "Seleciona um elemento XML com base no valor de um campo discriminador.",
+    "requiredFields": ["target", "choiceField", "options"],
+    "example": "{ \"type\": \"Choice\", \"target\": \"infDPS.prest\", \"choiceField\": \"Provider.PersonType\", \"options\": { \"LegalEntity\": { \"element\": \"CNPJ\", \"source\": \"Provider.Cnpj\" } } }"
+  },
+  {
+    "name": "Formatting",
+    "description": "Define regras de formatacao (digitsOnly, padLeft, maxLength, trim).",
+    "requiredFields": ["target"],
+    "example": "{ \"type\": \"Formatting\", \"target\": \"cTribNac\", \"digitsOnly\": true, \"padLeft\": 6, \"padChar\": \"0\", \"maxLength\": 6 }"
+  }
+]
+```
+
+---
+
+## Codigos de status HTTP
+
+| Codigo | Significado |
+|--------|------------|
+| 200 OK | Operacao bem-sucedida |
+| 201 Created | Provider criado com sucesso |
+| 204 No Content | Provider excluido com sucesso |
+| 400 Bad Request | Dados invalidos ou erro de validacao |
+| 404 Not Found | Provider ou recurso nao encontrado |
+| 409 Conflict | Nome de provider duplicado ou municipio ja atribuido |
+
+---
+
+## Transicoes de status do provider
+
+```
+          create
+            │
+            ▼
+         Draft ──── validate ───▶ Ready (validacao OK)
+            │                       │
+            │                       ├── activate ──▶ Active
+            │                       │
+            │                       └── deactivate ──▶ Inactive
+            │
+            └── validate ──▶ Blocked (validacao falhou)
+                               │
+                               └── corrigir + validate ──▶ Ready
+```
+
+## Links relacionados
+
+- [Arquitetura](04-architecture.md) — como os componentes se conectam
+- [Visao do Produto](01-product-overview.md) — capacidades da engine

--- a/docs/06-support-onboarding-guide.md
+++ b/docs/06-support-onboarding-guide.md
@@ -1,0 +1,408 @@
+# Guia de Onboarding de Providers para Suporte
+
+## Visao Geral
+
+Este guia descreve o processo completo para cadastrar, validar e ativar um novo provider de NFS-e na engine. O fluxo e 100% via API REST e nao requer acesso ao codigo-fonte.
+
+A engine gera XML de NFS-e a partir de schemas XSD. Cada provider representa um padrao municipal (ex: ABRASF, ISSNet, GISSOnline) e e associado a um ou mais municipios pelo codigo IBGE.
+
+---
+
+## Pre-requisitos
+
+Antes de iniciar o onboarding de um provider, o suporte precisa:
+
+1. **Arquivos XSD do municipio** — os schemas que definem a estrutura do XML de NFS-e. Normalmente fornecidos pela prefeitura ou disponibilizados no portal de documentacao do webservice. Incluir **todos** os arquivos `.xsd` referenciados (tipos, servicos, schemas auxiliares).
+2. **Codigo IBGE do municipio** — codigo de 7 digitos que identifica o municipio (ex: `3550308` para Sao Paulo, `4106902` para Curitiba).
+3. **Compreensao basica de NFS-e** — saber o que e um RPS, o que e DPS, quais campos sao obrigatorios no municipio.
+4. **Acesso a API** — URL base do ambiente (ex: `http://localhost:5000`) e ferramenta como curl ou Swagger UI.
+
+---
+
+## Passo a Passo
+
+### 1. Coletar os arquivos XSD
+
+Obtenha todos os arquivos `.xsd` do municipio. Para providers ABRASF, normalmente sao:
+- `servico_enviar_lote_rps_envio.xsd` (schema principal de envio)
+- `tipos_v*.xsd` (tipos compartilhados)
+- `cabecalho_v*.xsd` (cabecalho, quando aplicavel)
+
+**Importante:** se o schema principal faz `xs:include` ou `xs:import` de outros arquivos, **todos** os arquivos referenciados devem ser incluidos. A falta de um arquivo auxiliar causa falha na analise do schema.
+
+### 2. Cadastrar o provider via API
+
+```bash
+curl -X POST http://localhost:5000/api/v1/providers \
+  -F "name=meu-provider" \
+  -F "xsdFiles=@servico_enviar_lote_rps_envio.xsd" \
+  -F "xsdFiles=@tipos_v2.03.xsd" \
+  -F "municipalityCodes=3550308,3509502" \
+  -F "primaryXsdFile=servico_enviar_lote_rps_envio.xsd"
+```
+
+**Parametros:**
+
+| Parametro | Obrigatorio | Descricao |
+|-----------|-------------|-----------|
+| `name` | Sim | Nome unico do provider (ex: `gissonline`, `betha`, `curitiba`) |
+| `xsdFiles` | Sim | Um ou mais arquivos `.xsd` (multipart/form-data) |
+| `municipalityCodes` | Nao | Codigos IBGE separados por virgula |
+| `primaryXsdFile` | Condicional | Nome do XSD principal. Obrigatorio quando ha mais de um arquivo XSD |
+
+**O que acontece internamente:**
+1. A engine salva os arquivos XSD no MongoDB.
+2. `ProviderConfigGenerator.GenerateFromXsdFiles` analisa o schema, percorre a arvore XSD e gera regras automaticamente usando o `CommonFieldMappingDictionary`.
+3. Uma validacao automatica e executada (4 etapas: XsdSelection, SchemaAnalysis, XmlSerialization, XsdValidation).
+4. O provider recebe status `Ready` (se tudo passou) ou `Blocked` (se alguma etapa falhou).
+
+**Resposta de sucesso (201 Created):**
+
+```json
+{
+  "id": "a1b2c3d4e5f6...",
+  "name": "meu-provider",
+  "version": "2.03",
+  "status": "Ready",
+  "blockReason": null,
+  "xsdFileNames": ["servico_enviar_lote_rps_envio.xsd", "tipos_v2.03.xsd"],
+  "municipalityCodes": ["3550308", "3509502"],
+  "hasRulesConfig": true,
+  "typedRuleCount": 35,
+  "validationCount": 1,
+  "createdAt": "2026-03-23T10:00:00Z",
+  "updatedAt": "2026-03-23T10:00:00Z"
+}
+```
+
+### 3. Verificar o status
+
+```bash
+curl http://localhost:5000/api/v1/providers/{id}/status
+```
+
+**Resposta:**
+
+```json
+{
+  "id": "a1b2c3d4e5f6...",
+  "name": "meu-provider",
+  "status": "Ready",
+  "blockReason": null,
+  "lastValidation": {
+    "passed": true,
+    "checks": [
+      { "name": "XsdSelection", "passed": true, "detail": "Selected: servico_enviar_lote_rps_envio.xsd" },
+      { "name": "SchemaAnalysis", "passed": true, "detail": "Analyzed 12 complex types" },
+      { "name": "XmlSerialization", "passed": true, "detail": "XML generated successfully" },
+      { "name": "XsdValidation", "passed": true, "detail": "0 XSD errors" }
+    ],
+    "timestamp": "2026-03-23T10:00:01Z"
+  },
+  "validationCount": 1
+}
+```
+
+### 4. Se o status for Blocked
+
+Quando o provider esta com status `Blocked`, investigue:
+
+```bash
+# Ver detalhes completos do provider
+curl http://localhost:5000/api/v1/providers/{id}
+
+# Ver detalhes da validacao com campos pendentes
+curl http://localhost:5000/api/v1/providers/{id}/status
+```
+
+O campo `blockReason` indica a causa principal. O array `checks` mostra qual etapa falhou. O array `pendingFields` (quando presente) mostra campos que precisam de mapeamento manual.
+
+**Exemplo de resposta com campos pendentes:**
+
+```json
+{
+  "passed": false,
+  "checks": [
+    { "name": "XsdSelection", "passed": true },
+    { "name": "SchemaAnalysis", "passed": true },
+    { "name": "XmlSerialization", "passed": false, "detail": "3 missing fields" }
+  ],
+  "pendingFields": [
+    {
+      "fieldPath": "InfRps.CodigoObra",
+      "isRequired": true,
+      "suggestedSource": null,
+      "confidence": "None",
+      "reason": "Manual mapping required"
+    },
+    {
+      "fieldPath": "InfRps.Art",
+      "isRequired": true,
+      "suggestedSource": null,
+      "confidence": "None",
+      "reason": "Manual mapping required"
+    }
+  ]
+}
+```
+
+### 5. Re-validar apos ajustes
+
+Apos adicionar ou modificar regras, dispare uma nova validacao:
+
+```bash
+curl -X POST http://localhost:5000/api/v1/providers/{id}/validate
+```
+
+A validacao atualiza o status automaticamente: se todas as etapas passarem, o provider transiciona para `Ready`.
+
+### 6. Testar a geracao de XML
+
+Com o provider em status `Ready`, teste a geracao de XML com dados reais:
+
+```bash
+curl -X POST http://localhost:5000/api/v1/nfse/xml \
+  -H "Content-Type: application/json" \
+  -d '{
+    "provider": {
+      "federalTaxNumber": 12345678000199,
+      "municipalTaxNumber": "12345678",
+      "taxRegime": "SimplesNacional",
+      "address": {
+        "country": "BRA",
+        "postalCode": "01000-000",
+        "street": "RUA DO PRESTADOR",
+        "number": "500",
+        "district": "CENTRO",
+        "city": { "code": "3550308" },
+        "state": "SP"
+      }
+    },
+    "borrower": {
+      "name": "CONSUMIDOR LTDA",
+      "federalTaxNumber": 191,
+      "address": {
+        "country": "BRA",
+        "postalCode": "01000-000",
+        "street": "RUA DAS FLORES",
+        "number": "100",
+        "district": "CENTRO",
+        "city": { "code": "3550308" },
+        "state": "SP"
+      }
+    },
+    "externalId": "NFSE-TEST-001",
+    "federalServiceCode": "01.01",
+    "description": "Servico de consultoria e assessoria.",
+    "servicesAmount": 1000.00,
+    "issuedOn": "2026-03-23T10:00:00-03:00",
+    "taxationType": "WithinCity",
+    "location": {
+      "country": "BRA",
+      "city": { "code": "3550308" },
+      "state": "SP"
+    },
+    "nbsCode": "101010100"
+  }'
+```
+
+**Resposta:**
+
+```json
+{
+  "externalId": "NFSE-TEST-001",
+  "xml": "<?xml version=\"1.0\"?><DPS xmlns=\"http://www.sped.fazenda.gov.br/nfse\">...</DPS>",
+  "rootElement": "DPS",
+  "generatedBy": "SchemaEngine",
+  "providerName": "meu-provider",
+  "municipalityCode": "3550308",
+  "isFallback": false,
+  "fallbackReason": null
+}
+```
+
+**Nota:** o provider e resolvido automaticamente pelo campo `provider.address.city.code` (codigo IBGE). Se nenhum provider atender o municipio, a engine usa o provider `nacional` como fallback.
+
+### 7. Monitorar historico de validacao
+
+```bash
+# Ver contagem de validacoes e ultima validacao
+curl http://localhost:5000/api/v1/providers/{id}/status
+
+# Listar todos os providers com filtro por status
+curl "http://localhost:5000/api/v1/providers?status=Blocked"
+curl "http://localhost:5000/api/v1/providers?status=Ready"
+```
+
+---
+
+## Gestao de Regras
+
+As regras (rules) controlam como os campos do dominio sao mapeados para o XML do provider. A auto-geracao cobre a maioria dos casos, mas campos especificos podem precisar de ajuste manual.
+
+### Consultar regras atuais
+
+```bash
+curl http://localhost:5000/api/v1/providers/{id}/rules
+```
+
+Retorna a lista completa de `ProviderRule` em JSON.
+
+### Substituir todas as regras
+
+```bash
+curl -X PUT http://localhost:5000/api/v1/providers/{id}/rules \
+  -H "Content-Type: application/json" \
+  -d '[
+    { "type": "Binding", "target": "Numero", "source": "Number" },
+    { "type": "Binding", "target": "DataEmissao", "source": "IssuedOn", "format": "yyyy-MM-dd" },
+    { "type": "Binding", "target": "CNPJ", "source": "Provider.Cnpj" },
+    { "type": "Formatting", "target": "CNPJ", "digitsOnly": true, "padLeft": 14, "padChar": "0" }
+  ]'
+```
+
+### Adicionar regras (sem remover as existentes)
+
+```bash
+curl -X POST http://localhost:5000/api/v1/providers/{id}/rules \
+  -H "Content-Type: application/json" \
+  -d '[
+    { "type": "Binding", "target": "CodigoObra", "sourceType": "constant", "constantValue": "000" }
+  ]'
+```
+
+### Remover uma regra por indice
+
+```bash
+# Primeiro consulte as regras para ver os indices (base zero)
+curl http://localhost:5000/api/v1/providers/{id}/rules
+
+# Remover a regra no indice 5
+curl -X DELETE http://localhost:5000/api/v1/providers/{id}/rules/5
+```
+
+### Consultar catalogo de regras
+
+A API expoe endpoints de catalogo para auxiliar na construcao de regras:
+
+```bash
+# Campos disponiveis como source (campos do DpsDocument)
+curl http://localhost:5000/api/v1/rules/sources
+
+# Campos disponiveis como target para um provider especifico
+curl http://localhost:5000/api/v1/rules/targets/nacional
+
+# Operadores de comparacao para condicoes
+curl http://localhost:5000/api/v1/rules/operators
+
+# Tipos de regra disponiveis com exemplos
+curl http://localhost:5000/api/v1/rules/types
+```
+
+---
+
+## Gestao de Municipios
+
+### Adicionar municipios
+
+```bash
+curl -X POST http://localhost:5000/api/v1/providers/{id}/municipalities \
+  -H "Content-Type: application/json" \
+  -d '{ "codes": ["3550308", "3509502"] }'
+```
+
+**Regra importante:** cada codigo IBGE e exclusivo — um municipio so pode pertencer a um provider. Tentar adicionar um codigo ja atribuido a outro provider retorna erro `409 Conflict`.
+
+### Remover municipios
+
+```bash
+curl -X DELETE http://localhost:5000/api/v1/providers/{id}/municipalities \
+  -H "Content-Type: application/json" \
+  -d '{ "codes": ["3509502"] }'
+```
+
+---
+
+## Troubleshooting
+
+### "Schema analysis failed"
+
+**Causa:** falta um ou mais arquivos XSD. Se o schema principal faz `xs:include` de `tipos_v2.03.xsd` e esse arquivo nao foi enviado, a analise falha.
+
+**Solucao:** envie **todos** os arquivos `.xsd` referenciados pelo schema principal. Atualize o provider:
+
+```bash
+curl -X PUT http://localhost:5000/api/v1/providers/{id} \
+  -F "xsdFiles=@servico_enviar_lote_rps_envio.xsd" \
+  -F "xsdFiles=@tipos_v2.03.xsd" \
+  -F "xsdFiles=@cabecalho_v2.03.xsd"
+```
+
+### "Type not declared" / "tipo nao declarado"
+
+**Causa:** o arquivo de tipos (`tipos_*.xsd`) nao foi incluido no upload. O schema principal referencia tipos como `tcInfRps`, `tcDadosServico` que estao definidos em outro arquivo.
+
+**Solucao:** mesma do item anterior — inclua todos os XSDs auxiliares.
+
+### Status Blocked sem motivo claro
+
+**Acao:** verifique o campo `blockReason` na resposta de status:
+
+```bash
+curl http://localhost:5000/api/v1/providers/{id}/status | jq '.blockReason'
+```
+
+Valores comuns:
+- `"Falha na selecao do XSD de envio"` — a engine nao identificou qual XSD e de envio. Configure `primaryXsdFile`.
+- `"Falha na analise do schema"` — XSD invalido ou incompleto.
+- `"XML nao validou contra o schema"` — XML foi gerado mas tem erros XSD. Verifique os checks detalhados.
+
+### XML vazio ou sem conteudo esperado
+
+**Causa:** o provider nao tem regras configuradas ou as regras nao mapeiam os campos corretos.
+
+**Acao:**
+1. Verifique se tem regras: `curl http://localhost:5000/api/v1/providers/{id}/rules`
+2. Se o array estiver vazio, a auto-geracao pode ter falhado. Re-crie o provider com os XSDs corretos.
+3. Compare os targets das regras com os campos do schema: `curl http://localhost:5000/api/v1/rules/targets/{providerName}`
+
+### Fallback para nacional
+
+**Causa:** o codigo IBGE informado no campo `provider.address.city.code` do request de geracao de XML nao esta atribuido a nenhum provider.
+
+**Acao:**
+1. Verifique se o provider tem o municipio atribuido: `curl http://localhost:5000/api/v1/providers/{id}`
+2. Se nao, adicione: `POST /api/v1/providers/{id}/municipalities` com o codigo IBGE.
+3. Verifique se outro provider ja possui esse municipio (conflito).
+
+### Provider com status Draft
+
+O status `Draft` indica que o provider foi criado mas a validacao automatica nao mudou o status para `Ready`. Isso pode acontecer se a validacao falhou internamente. Tente:
+
+```bash
+curl -X POST http://localhost:5000/api/v1/providers/{id}/activate
+```
+
+Se a validacao nao existir, o endpoint executa uma e transiciona para `Ready` ou `Blocked`.
+
+---
+
+## Ciclo de Vida do Provider
+
+```
+Draft --> [validacao automatica] --> Ready (validacao OK)
+Draft --> [validacao automatica] --> Blocked (validacao falhou)
+Blocked --> [POST /validate] --> Ready (apos correcao)
+Blocked --> [POST /validate] --> Blocked (ainda com erros)
+Ready --> [POST /deactivate] --> Inactive
+Inactive --> [POST /activate] --> Ready (se validacao OK)
+```
+
+**Status possiveis:**
+
+| Status | Significado |
+|--------|-------------|
+| `Draft` | Recem-criado, aguardando validacao |
+| `Ready` | Validado e disponivel para geracao de XML |
+| `Blocked` | Validacao falhou — ver `blockReason` |
+| `Inactive` | Desativado manualmente pelo suporte |

--- a/docs/07-rules-and-configuration.md
+++ b/docs/07-rules-and-configuration.md
@@ -1,0 +1,467 @@
+# Modelo de Regras e Configuracao de Providers
+
+## O que sao Regras
+
+Regras sao instrucoes tipadas que definem como os campos do dominio (`DpsDocument`) sao mapeados para os elementos do XML do provider. Cada provider possui um conjunto de regras que a engine utiliza em tempo de serializacao para gerar o XML conforme o schema XSD do municipio.
+
+As regras sao armazenadas como JSON dentro do `ProviderProfile` e processadas pelo `TypedRuleResolver` durante a geracao do XML.
+
+---
+
+## Tipos de Regra
+
+A engine suporta 6 tipos de regra, definidos no enum `RuleType`:
+
+### 1. Binding
+
+Vincula um campo do dominio a um elemento do XML. E o tipo mais comum.
+
+**Binding de campo:**
+```json
+{
+  "type": "Binding",
+  "target": "CNPJ",
+  "source": "Provider.Cnpj"
+}
+```
+
+**Binding com formato:**
+```json
+{
+  "type": "Binding",
+  "target": "dhEmi",
+  "source": "IssuedOn",
+  "format": "yyyy-MM-ddTHH:mm:sszzz"
+}
+```
+
+**Binding de constante:**
+```json
+{
+  "type": "Binding",
+  "target": "tpEmit",
+  "sourceType": "constant",
+  "constantValue": "1"
+}
+```
+
+**Binding com @Id (atributo auto-gerado):**
+```json
+{
+  "type": "Binding",
+  "target": "infDPS.@Id",
+  "source": "BuildId"
+}
+```
+
+### 2. Default
+
+Vincula um campo do dominio com valor fallback quando o valor original e nulo ou vazio.
+
+```json
+{
+  "type": "Default",
+  "target": "tpRetISSQN",
+  "source": "Values.RetentionType",
+  "fallbackValue": "1"
+}
+```
+
+### 3. EnumMapping
+
+Mapeia valores de um enum do dominio para codigos especificos do provider.
+
+```json
+{
+  "type": "EnumMapping",
+  "target": "tribISSQN",
+  "source": "Values.TaxationType",
+  "mappings": {
+    "WithinCity": "1",
+    "OutsideCity": "1",
+    "Immune": "2",
+    "Export": "3",
+    "Free": "4"
+  },
+  "defaultMapping": "1"
+}
+```
+
+### 4. ConditionalEmission
+
+Emite ou omite um campo com base em uma condicao. Suporta condicoes compostas (And/Or).
+
+**Condicao simples:**
+```json
+{
+  "type": "ConditionalEmission",
+  "target": "pAliq",
+  "source": "Values.IssRate",
+  "action": "Emit",
+  "condition": {
+    "field": "Values.IssRate",
+    "operator": "GreaterThan",
+    "value": "0"
+  }
+}
+```
+
+**Condicao composta:**
+```json
+{
+  "type": "ConditionalEmission",
+  "target": "toma",
+  "source": "Borrower.FederalTaxNumber",
+  "action": "Emit",
+  "condition": {
+    "logicalOperator": "Or",
+    "conditions": [
+      { "field": "Values.RetentionType", "operator": "In", "value": "WithheldByBuyer,WithheldByIntermediary" },
+      { "field": "Borrower.FederalTaxNumber", "operator": "GreaterThan", "value": "0" }
+    ]
+  }
+}
+```
+
+**Operadores disponiveis:** `Equals`, `NotEquals`, `GreaterThan`, `LessThan`, `GreaterThanOrEqual`, `LessThanOrEqual`, `IsNull`, `HasValue`, `Contains`, `In`
+
+**Acoes:** `Emit` (emite o campo), `Skip` (omite o campo)
+
+### 5. Choice
+
+Seleciona um elemento XML com base no valor de um campo discriminador. Usado para escolhas exclusivas como CNPJ vs CPF.
+
+```json
+{
+  "type": "Choice",
+  "target": "prest",
+  "choiceField": "Provider.PersonType",
+  "options": {
+    "LegalEntity": {
+      "element": "CNPJ",
+      "source": "Provider.Cnpj",
+      "padLeft": 14,
+      "padChar": "0"
+    },
+    "NaturalPerson": {
+      "element": "CPF",
+      "source": "Provider.Cnpj",
+      "padLeft": 11,
+      "padChar": "0"
+    }
+  }
+}
+```
+
+### 6. Formatting
+
+Define regras de formatacao aplicadas pelo serializer ao valor ja resolvido. Nao faz binding — apenas formata.
+
+```json
+{
+  "type": "Formatting",
+  "target": "cTribNac",
+  "digitsOnly": true,
+  "padLeft": 6,
+  "padChar": "0",
+  "maxLength": 6
+}
+```
+
+---
+
+## CommonFieldMappingDictionary
+
+O `CommonFieldMappingDictionary` e o dicionario central de mapeamentos campo-a-campo entre nomes de elementos XSD e campos do dominio. E usado pela auto-geracao de regras (`ProviderConfigGenerator`) para mapear automaticamente elementos reconhecidos.
+
+### Mapeamentos de Identificacao do Prestador
+
+| Elemento XSD | Campo do Dominio |
+|-------------|-----------------|
+| `CNPJ` | `Provider.Cnpj` |
+| `CPF` | `Borrower.FederalTaxNumber` |
+| `IM`, `InscricaoMunicipal` | `Provider.MunicipalTaxNumber` |
+| `cLocEmi`, `CodigoMunicipio` | `Provider.MunicipalityCode` |
+
+### Mapeamentos de Servico
+
+| Elemento XSD | Campo do Dominio |
+|-------------|-----------------|
+| `cTribNac`, `CodigoServico`, `ItemListaServico` | `Service.FederalServiceCode` |
+| `xDescServ`, `Discriminacao` | `Service.Description` |
+| `cNBS`, `CodigoNbs` | `Service.NbsCode` |
+| `cTribMun` | `CityServiceCode` |
+| `CodigoCnae` | `Service.CnaeCode` |
+
+### Mapeamentos de Valores
+
+| Elemento XSD | Campo do Dominio |
+|-------------|-----------------|
+| `vServ`, `ValorServicos` | `Values.ServicesAmount` |
+| `Aliquota` | `Values.IssRate` |
+| `BaseCalculo` | `Values.ServicesAmount` |
+| `ValorLiquidoNfse` | `Values.ServicesAmount` |
+
+### Mapeamentos de Tributos (constantes)
+
+| Elemento XSD | Valor | Significado |
+|-------------|-------|-------------|
+| `tribISSQN` | `const:1` | Tributado no municipio |
+| `opSimpNac` | `const:1` | Normal (nao Simples) |
+| `regEspTrib` | `const:0` | Sem regime especial |
+| `tpRetISSQN` | `const:1` | Nao retido |
+| `IssRetido` | `const:2` | Nao retido (ABRASF) |
+| `tpEmit` | `const:1` | Emitente padrao |
+
+### Mapeamentos de RPS (ABRASF)
+
+| Elemento XSD | Campo do Dominio |
+|-------------|-----------------|
+| `tpRps`, `Tipo`, `TipoRps` | `const:1` |
+| `NumeroRps` | `Number` |
+| `SerieRps` | `Series` |
+| `DataEmissaoRps` | `IssuedOn \| format:yyyy-MM-ddTHH:mm:sszzz` |
+| `Status`, `StatusRps` | `const:1` |
+| `NaturezaOperacao` | `const:1` |
+
+### Mapeamentos de Tomador (ABRASF)
+
+| Elemento XSD | Campo do Dominio |
+|-------------|-----------------|
+| `xNome`, `RazaoSocial` | `Borrower.Name` |
+| `xEmail`, `Email` | `Borrower.Email` |
+| `Telefone`, `Fone` | `Borrower.PhoneNumber` |
+| `Endereco` | `Borrower.Address.Street` |
+| `Bairro` | `Borrower.Address.District` |
+| `Cep` | `Borrower.Address.PostalCode` |
+| `Uf` | `Borrower.Address.State` |
+
+### Mapeamentos de Data e Documento
+
+| Elemento XSD | Campo do Dominio |
+|-------------|-----------------|
+| `dhEmi` | `IssuedOn \| format:yyyy-MM-ddTHH:mm:sszzz` |
+| `DataEmissao` | `IssuedOn \| format:yyyy-MM-dd` |
+| `dCompet`, `Competencia` | `CompetenceDate \| format:yyyy-MM-dd` |
+| `nDPS` | `Number` |
+| `serie` | `Series` |
+| `tpAmb` | `Environment` |
+
+---
+
+## Estrutura do ProviderProfile
+
+O `ProviderProfile` e o objeto central de configuracao de cada provider, serializado como JSON:
+
+```json
+{
+  "provider": "issnet",
+  "version": "2.03",
+  "rootComplexTypeName": "_anon_EnviarLoteRpsEnvio",
+  "rootElementName": "EnviarLoteRpsEnvio",
+  "bindingPathPrefix": "LoteRps.ListaRps.Rps.InfRps",
+  "wrapperBindings": {
+    "LoteRps.@Id": "const:lote1",
+    "LoteRps.@versao": "const:2.03",
+    "LoteRps.NumeroLote": "const:1",
+    "LoteRps.Cnpj": "Provider.Cnpj",
+    "LoteRps.InscricaoMunicipal": "Provider.MunicipalTaxNumber",
+    "LoteRps.QuantidadeRps": "const:1"
+  },
+  "rules": [
+    { "type": "Binding", "target": "Numero", "source": "Number" },
+    { "type": "Binding", "target": "DataEmissao", "source": "IssuedOn", "format": "yyyy-MM-dd" },
+    { "type": "Formatting", "target": "CNPJ", "padLeft": 14, "padChar": "0" }
+  ],
+  "municipalityCodes": ["3550308"]
+}
+```
+
+**Campos do ProviderProfile:**
+
+| Campo | Descricao |
+|-------|-----------|
+| `provider` | Nome do provider |
+| `version` | Versao do schema (extraida do XSD ou configurada) |
+| `rootComplexTypeName` | Nome do tipo complexo raiz no schema XSD |
+| `rootElementName` | Nome do elemento raiz do XML gerado |
+| `bindingPathPrefix` | Prefixo de caminho para regras em schemas com envelope (ABRASF) |
+| `wrapperBindings` | Mapeamentos do envelope externo (LoteRps, cabecalho) |
+| `rules` | Lista de regras tipadas (`ProviderRule[]`) |
+| `municipalityCodes` | Codigos IBGE dos municipios atendidos |
+| `primaryXsdFile` | Nome do arquivo XSD principal (quando configurado) |
+
+### bindingPathPrefix e wrapperBindings
+
+Em schemas ABRASF, o XML tem uma estrutura de envelope:
+
+```xml
+<EnviarLoteRpsEnvio>
+  <LoteRps Id="lote1" versao="2.03">
+    <NumeroLote>1</NumeroLote>
+    <Cnpj>12345678000199</Cnpj>
+    <InscricaoMunicipal>12345678</InscricaoMunicipal>
+    <QuantidadeRps>1</QuantidadeRps>
+    <ListaRps>
+      <Rps>
+        <InfRps>
+          <!-- dados da NFS-e aqui -->
+        </InfRps>
+      </Rps>
+    </ListaRps>
+  </LoteRps>
+</EnviarLoteRpsEnvio>
+```
+
+O `bindingPathPrefix` (`LoteRps.ListaRps.Rps.InfRps`) indica onde comecar a aplicar as regras de dados. Os `wrapperBindings` mapeiam os campos do envelope.
+
+---
+
+## Auto-geracao de Regras
+
+O metodo `ProviderConfigGenerator.GenerateFromXsdFiles` e chamado automaticamente quando um provider e criado via API. O processo:
+
+1. **Selecao do XSD de envio** — `SendXsdSelector` identifica o arquivo XSD de envio (prioridade: `EnviarLoteRpsEnvio`, `EnviarLoteRps`, `GerarNfseEnvio`, `RecepcionarLoteRps`).
+
+2. **Analise do schema** — `XsdSchemaAnalyzer` percorre o XSD e extrai tipos complexos, elementos, atributos e restricoes.
+
+3. **Deteccao de envelope** — para schemas ABRASF, a engine detecta o padrao de envelope (LoteRps > ListaRps > Rps > InfRps) e separa os mapeamentos de envelope (`wrapperBindings`) dos mapeamentos de dados (`rules`).
+
+4. **Mapeamento automatico** — percorre a arvore de elementos e, para cada elemento simples:
+   - Se o nome existe no `CommonFieldMappingDictionary`, cria uma regra `Binding` automaticamente.
+   - Se o elemento e obrigatorio e nao tem mapeamento, registra como campo pendente (`TODO: manual mapping required`).
+
+5. **Inferencia de formatacao** — analisa restricoes XSD (`maxLength`, `pattern`, `minLength`) e gera regras `Formatting` automaticamente:
+   - Pattern `[0-9]{7}` → `padLeft: 7, padChar: "0", digitsOnly: true`
+   - `maxLength: 100` → `maxLength: 100`
+   - `minLength == maxLength` → `padLeft` com o tamanho fixo
+
+6. **Atributos obrigatorios** — gera regras para atributos `@Id` (em elementos `inf*`) e `@versao`.
+
+7. **Resultado** — retorna a lista de regras geradas, o `ProviderProfile` completo e a lista de campos sem mapeamento.
+
+---
+
+## Pipes de Formatacao
+
+Nas expressoes de binding do `CommonFieldMappingDictionary`, pipes sao usados para transformar valores:
+
+| Pipe | Descricao | Exemplo |
+|------|-----------|---------|
+| `format:pattern` | Aplica formato de data/numero | `IssuedOn \| format:yyyy-MM-dd` |
+| `digitsOnly` | Remove caracteres nao-numericos | `Provider.Cnpj \| digitsOnly` |
+| `padLeft:N:C` | Preenche a esquerda com `C` ate `N` caracteres | `Number \| padLeft:6:0` |
+| `decimal:N` | Formata como decimal com `N` casas | `Values.ServicesAmount \| decimal:2` |
+| `nullable:V` | Usa valor `V` como fallback se nulo | `Provider.SpecialTaxRegime \| nullable:0` |
+| `maxLength:N` | Trunca em `N` caracteres | `Service.Description \| maxLength:100` |
+
+Na conversao para regras tipadas, os pipes sao traduzidos para campos do `ProviderRule`:
+- `format:` → campo `format`
+- `padLeft:` → campos `padLeft` e `padChar`
+- `digitsOnly` → campo `digitsOnly: true`
+- `decimal:` → campo `format: "FN"`
+- `nullable:` → tipo `Default` com `fallbackValue`
+
+---
+
+## Personalizacao via API
+
+O suporte pode customizar regras usando os endpoints da API sem alterar codigo:
+
+### Fluxo tipico de personalizacao
+
+1. **Consultar regras auto-geradas:**
+   ```bash
+   curl http://localhost:5000/api/v1/providers/{id}/rules
+   ```
+
+2. **Consultar campos disponiveis como source:**
+   ```bash
+   curl http://localhost:5000/api/v1/rules/sources
+   ```
+
+3. **Consultar campos disponiveis como target no schema:**
+   ```bash
+   curl http://localhost:5000/api/v1/rules/targets/{providerName}
+   ```
+
+4. **Adicionar regras manuais para campos pendentes:**
+   ```bash
+   curl -X POST http://localhost:5000/api/v1/providers/{id}/rules \
+     -H "Content-Type: application/json" \
+     -d '[
+       { "type": "Binding", "target": "CodigoObra", "sourceType": "constant", "constantValue": "000" },
+       { "type": "Formatting", "target": "InscricaoMunicipal", "digitsOnly": true, "padLeft": 15, "padChar": "0" }
+     ]'
+   ```
+
+5. **Re-validar:**
+   ```bash
+   curl -X POST http://localhost:5000/api/v1/providers/{id}/validate
+   ```
+
+---
+
+## Exemplo Completo: base-rules.json do Nacional
+
+O provider `nacional` usa um formato legado (`base-rules.json`) com secoes separadas para bindings, formatting, enums, conditionals e documentChoice. O formato atual (`rules.json`) usa a lista tipada de `ProviderRule`, que e o padrao para todos os novos providers.
+
+Estrutura do `base-rules.json` do nacional (resumido):
+
+```json
+{
+  "provider": "nacional",
+  "version": "1.01",
+  "constants": {
+    "dpsVersion": "1.01",
+    "appVersion": "V_1.00.02",
+    "dateFormat": "yyyy-MM-dd",
+    "dateTimeFormat": "yyyy-MM-ddTHH:mm:sszzz"
+  },
+  "defaults": {
+    "tpAmb": 2,
+    "tpEmit": 1,
+    "opSimpNac": 1,
+    "regEspTrib": 0
+  },
+  "enums": {
+    "tribISSQN": { "WithinCity": "1", "Immune": "2", "Export": "3", "Free": "4" },
+    "opSimpNac": { "MicroempreendedorIndividual": "2", "SimplesNacional": "3", "_default": "1" }
+  },
+  "formatting": {
+    "cTribNac": { "padLeft": 6, "padChar": "0", "digitsOnly": true, "maxLength": 6 },
+    "CNPJ": { "padLeft": 14, "padChar": "0" },
+    "CPF": { "padLeft": 11, "padChar": "0" }
+  },
+  "bindings": {
+    "infDPS.@Id": "BuildId",
+    "infDPS.tpAmb": "Environment",
+    "infDPS.dhEmi": "IssuedOn | format:yyyy-MM-ddTHH:mm:sszzz",
+    "infDPS.cLocEmi": "Provider.MunicipalityCode",
+    "infDPS.prest.CNPJ": "Provider.Cnpj | padLeft:14:0",
+    "infDPS.serv.cServ.cTribNac": "Service.FederalServiceCode | digitsOnly | padLeft:6:0",
+    "infDPS.serv.cServ.xDescServ": "Service.Description",
+    "infDPS.valores.vServPrest.vServ": "Values.ServicesAmount | decimal:2",
+    "infDPS.valores.trib.tribMun.tribISSQN": "Values.TaxationType | enum:tribISSQN"
+  }
+}
+```
+
+Para novos providers criados via API, o formato equivalente em regras tipadas seria:
+
+```json
+[
+  { "type": "Binding", "target": "infDPS.@Id", "source": "BuildId" },
+  { "type": "Binding", "target": "infDPS.tpAmb", "source": "Environment" },
+  { "type": "Binding", "target": "infDPS.dhEmi", "source": "IssuedOn", "format": "yyyy-MM-ddTHH:mm:sszzz" },
+  { "type": "Binding", "target": "infDPS.cLocEmi", "source": "Provider.MunicipalityCode" },
+  { "type": "Binding", "target": "infDPS.prest.CNPJ", "source": "Provider.Cnpj", "padLeft": 14, "padChar": "0" },
+  { "type": "Binding", "target": "infDPS.serv.cServ.cTribNac", "source": "Service.FederalServiceCode", "digitsOnly": true, "padLeft": 6, "padChar": "0" },
+  { "type": "Binding", "target": "infDPS.serv.cServ.xDescServ", "source": "Service.Description" },
+  { "type": "Binding", "target": "infDPS.valores.vServPrest.vServ", "source": "Values.ServicesAmount", "format": "F2" },
+  { "type": "EnumMapping", "target": "infDPS.valores.trib.tribMun.tribISSQN", "source": "Values.TaxationType", "mappings": { "WithinCity": "1", "Immune": "2", "Export": "3", "Free": "4" }, "defaultMapping": "1" },
+  { "type": "Formatting", "target": "cTribNac", "digitsOnly": true, "padLeft": 6, "padChar": "0", "maxLength": 6 },
+  { "type": "Formatting", "target": "CNPJ", "padLeft": 14, "padChar": "0" },
+  { "type": "Formatting", "target": "CPF", "padLeft": 11, "padChar": "0" }
+]
+```

--- a/docs/08-testing-strategy.md
+++ b/docs/08-testing-strategy.md
@@ -1,0 +1,342 @@
+# Estrategia de Testes
+
+## Visao Geral
+
+O projeto possui **727 testes** distribuidos em duas suites:
+- **611 testes unitarios** — cobrem a engine de schema, serializer, auto-geracao, regras tipadas, diagnosticos e modelos de dominio.
+- **116 testes de integracao** — cobrem endpoints da API, persistencia MongoDB e fluxos E2E completos.
+
+---
+
+## Piramide de Testes
+
+```
+                    ┌──────────────┐
+                    │   Manual     │  Swagger UI / curl
+                    │   (ad hoc)   │
+                    ├──────────────┤
+                ┌───┤  Integracao  ├───┐  116 testes
+                │   │  (API + DB)  │   │  WebApplicationFactory + MongoDB
+                │   ├──────────────┤   │
+            ┌───┤   │   Unitarios  │   ├───┐  611 testes
+            │   │   │  (engine +   │   │   │  xUnit + Shouldly
+            │   │   │   dominio)   │   │   │
+            └───┴───┴──────────────┴───┴───┘
+```
+
+### Testes Unitarios (611)
+
+Cobrem componentes isolados sem dependencias externas (sem banco, sem rede, sem filesystem externo).
+
+**Principais areas cobertas:**
+- Analise de schema XSD (`XsdSchemaAnalyzer`)
+- Serializacao XML baseada em schema (`SchemaBasedXmlSerializer`)
+- Auto-geracao de configuracao (`ProviderConfigGenerator`)
+- Resolucao de regras tipadas (`TypedRuleResolver`)
+- Validacao de regras (`ProviderRuleValidator`)
+- Diagnosticos de validacao (`ValidationDiagnosticEnricher`)
+- Data binding (`ServiceInvoiceSchemaDataBinder`)
+- Pipeline de serializacao (`SchemaSerializationPipeline`)
+- Selecao de XSD de envio (`SendXsdSelector`)
+- Condicoes de regra (`RuleCondition`)
+- Modelo de dominio (`ManagedProvider`)
+- Servico de gestao (`ProviderManagementService`)
+- Mappers de request (`NfseRequestToDpsDocumentModelMapper`)
+- Serializer manual baseline (`NationalDpsManualSerializer`, `IbsCbsManualBuilder`)
+- Golden master / snapshot tests
+
+### Testes de Integracao (116)
+
+Cobrem fluxos completos com HTTP real (via `WebApplicationFactory`) e MongoDB (service container).
+
+**Principais areas cobertas:**
+- Endpoints de NFS-e (`NfseEndpointIntegrationTests`)
+- Endpoints de gestao de providers (`ProviderManagementEndpointTests`)
+- Fluxo E2E para 48 providers (`ProviderEndToEndFlowTests`)
+- Lifecycle completo de 7 providers (`ProviderFullLoadTests`)
+- Onboarding em massa (`ProviderOnboardingLoadTests`)
+
+### Testes Manuais
+
+Via Swagger UI (`/swagger`) ou curl direto nos endpoints da API. Uteis para validacao visual do XML gerado e testes exploratórios.
+
+---
+
+## Classes de Teste Principais
+
+### AllProvidersXsdValidationSummaryTests
+
+Valida XML gerado contra o schema XSD para todos os providers do diretorio `providers/`. Garante que o XML produzido pela engine e valido segundo o schema de cada provider.
+
+**Localizacao:** `tests/SemanaIA.ServiceInvoice.UnitTests/SchemaEngine/`
+
+### ProviderEndToEndFlowTests
+
+Testa o fluxo completo via API para 48 providers (test data providers). Para cada provider:
+1. Cria via `POST /api/v1/providers` com os XSDs
+2. Verifica status
+3. Gera XML via `POST /api/v1/nfse/xml`
+4. Valida que o XML foi gerado
+
+**Requer MongoDB** — roda no CI com service container.
+
+**Localizacao:** `tests/SemanaIA.ServiceInvoice.IntegrationsTests/ProviderEndToEndFlowTests.cs`
+
+### ProviderManagementEndpointTests
+
+Testa todos os endpoints da API de gestao de providers:
+- CRUD completo (Create, Read, Update, Delete)
+- Gestao de municipios (Add, Remove)
+- Gestao de regras (Get, Replace, Add, Remove)
+- Validacao sob demanda
+- Transicoes de status (Activate, Deactivate)
+
+**Localizacao:** `tests/SemanaIA.ServiceInvoice.IntegrationsTests/ProviderManagementEndpointTests.cs`
+
+### ValidationDiagnosticEnricherTests
+
+Testa a logica de sugestao de mapeamento para campos pendentes. Verifica que o enricher:
+- Encontra matches exatos no `CommonFieldMappingDictionary`
+- Encontra matches parciais com strip de prefixos (`tc`, `Inf`, `TC`, `Tc`)
+- Retorna "Manual mapping required" quando nao ha sugestao
+
+**Localizacao:** `tests/SemanaIA.ServiceInvoice.UnitTests/SchemaEngine/ValidationDiagnosticEnricherTests.cs`
+
+### XsdSchemaAnalyzerAttributeTests
+
+Testa a captura de atributos XSD (como `@Id`, `@versao`) pelo analisador de schema. Garante que atributos obrigatorios sao detectados e incluidos no modelo de schema.
+
+**Localizacao:** `tests/SemanaIA.ServiceInvoice.UnitTests/SchemaEngine/XsdSchemaAnalyzerAttributeTests.cs`
+
+### SchemaBasedXmlSerializerAttributeTests
+
+Testa a emissao de atributos XML pelo serializer. Garante que atributos como `@Id` e `@versao` sao emitidos corretamente no XML gerado.
+
+**Localizacao:** `tests/SemanaIA.ServiceInvoice.UnitTests/SchemaEngine/SchemaBasedXmlSerializerAttributeTests.cs`
+
+### TypedRuleResolverTests
+
+Testa a resolucao de todos os 6 tipos de regra (Binding, Default, EnumMapping, ConditionalEmission, Choice, Formatting).
+
+**Localizacao:** `tests/SemanaIA.ServiceInvoice.UnitTests/SchemaEngine/TypedRuleResolverTests.cs`
+
+### ProviderRuleValidatorTests
+
+Testa a validacao de regras tipadas: regras invalidas (sem target, source inexistente), regras validas, e deteccao de erros.
+
+**Localizacao:** `tests/SemanaIA.ServiceInvoice.UnitTests/SchemaEngine/ProviderRuleValidatorTests.cs`
+
+### RuleConditionTests
+
+Testa a avaliacao de condicoes: operadores simples, condicoes compostas (And/Or), comparacoes numericas, operador In, IsNull, HasValue.
+
+**Localizacao:** `tests/SemanaIA.ServiceInvoice.UnitTests/SchemaEngine/RuleConditionTests.cs`
+
+### Outras classes relevantes
+
+| Classe | O que testa |
+|--------|------------|
+| `SchemaBasedXmlSerializerTests` | Serializacao XML basica com schema |
+| `SchemaBasedXmlSerializerXmlStructureTests` | Estrutura XML (namespaces, hierarquia) |
+| `ServiceInvoiceSchemaDataBinderTests` | Binding de dados do dominio para schema |
+| `SendXsdSelectorTests` | Selecao inteligente do XSD de envio |
+| `SchemaSerializationPipelineTests` | Pipeline completa de serializacao |
+| `GissonlineSchemaGenerationTests` | Auto-geracao especifica para GISSOnline |
+| `OperationalStatusTests` | Calculo de status operacional |
+| `ManagedProviderTests` | Modelo de dominio ManagedProvider |
+| `ProviderManagementServiceTests` | Servico de gestao (mocks) |
+| `GoldenMasterTests` | Snapshot tests (baseline XML) |
+| `NfseRequestToDpsDocumentModelMapperTests` | Mapper request -> dominio |
+
+---
+
+## Convencao de Nomenclatura
+
+Todos os testes seguem o padrao:
+
+```
+Given_<contexto>_Should_<comportamento_esperado>
+```
+
+Exemplos reais do projeto:
+- `Given_RequiredAttribute_Should_IncludeInAttributes`
+- `Given_ValidProvider_Should_ReturnReady`
+- `Given_NullField_Should_ReturnIsNullTrue`
+- `Given_EnumMapping_Should_MapToExpectedCode`
+- `Given_MissingXsd_Should_ReturnBlocked`
+
+---
+
+## Estrutura de Teste (Arrange / Act / Assert)
+
+Todos os testes seguem o padrao AAA:
+
+```csharp
+[Fact]
+public void Given_ValidBindingRule_Should_ResolveSourceValue()
+{
+    // Arrange
+    var rule = new ProviderRule
+    {
+        Type = RuleType.Binding,
+        Target = "CNPJ",
+        Source = "Provider.Cnpj"
+    };
+    var resolver = new TypedRuleResolver([rule]);
+
+    // Act
+    var result = resolver.Resolve("CNPJ", fieldPath => "12345678000199");
+
+    // Assert
+    result.ShouldBe("12345678000199");
+}
+```
+
+---
+
+## Frameworks e Ferramentas
+
+| Framework | Uso |
+|-----------|-----|
+| **xUnit** | Framework de teste principal |
+| **Shouldly** | Assertions fluentes (`result.ShouldBe(...)`, `result.ShouldNotBeNull()`) |
+| **WebApplicationFactory** | Servidor HTTP in-process para testes de integracao |
+| **MongoDB** | Service container no CI (mongo:7 via GitHub Actions) |
+
+O projeto nao usa Moq extensivamente nos testes unitarios — a maioria dos testes trabalha com implementacoes reais dos componentes da engine, pois sao classes puras sem dependencias externas.
+
+---
+
+## CI: GitHub Actions
+
+O pipeline de CI esta definido em `.github/workflows/ci.yml`:
+
+```yaml
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    services:
+      mongodb:
+        image: mongo:7
+        ports:
+          - 27017:27017
+    env:
+      MongoDb__ConnectionString: mongodb://localhost:27017
+      MongoDb__DatabaseName: semana_ia_test
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "10.0.x"
+      - name: Restore
+        run: dotnet restore
+      - name: Build
+        run: dotnet build --no-restore
+      - name: Unit Tests
+        run: dotnet test tests/SemanaIA.ServiceInvoice.UnitTests --no-build -v normal
+      - name: Integration Tests
+        run: dotnet test tests/SemanaIA.ServiceInvoice.IntegrationsTests --no-build -v normal
+```
+
+**Pontos importantes:**
+- .NET 10 (preview/RC)
+- MongoDB 7 como service container — disponivel automaticamente para testes de integracao
+- Triggers: push em `master`, `main`, `feature/**` e pull requests
+
+---
+
+## Como Executar os Testes
+
+### Todos os testes unitarios
+
+```bash
+dotnet test tests/SemanaIA.ServiceInvoice.UnitTests/
+```
+
+### Todos os testes de integracao
+
+**Pre-requisito:** MongoDB rodando em `localhost:27017`.
+
+```bash
+# Com Docker:
+docker run -d -p 27017:27017 mongo:7
+
+# Executar testes:
+dotnet test tests/SemanaIA.ServiceInvoice.IntegrationsTests/
+```
+
+### Filtrar por classe de teste
+
+```bash
+# Apenas testes E2E de providers
+dotnet test tests/SemanaIA.ServiceInvoice.IntegrationsTests/ --filter "ProviderEndToEndFlowTests"
+
+# Apenas testes do serializer
+dotnet test tests/SemanaIA.ServiceInvoice.UnitTests/ --filter "SchemaBasedXmlSerializerTests"
+
+# Apenas testes de regras tipadas
+dotnet test tests/SemanaIA.ServiceInvoice.UnitTests/ --filter "TypedRuleResolverTests"
+
+# Apenas testes de validacao XSD
+dotnet test tests/SemanaIA.ServiceInvoice.UnitTests/ --filter "XsdSchemaAnalyzerTests"
+```
+
+### Filtrar por nome de teste
+
+```bash
+dotnet test --filter "Given_RequiredAttribute_Should_IncludeInAttributes"
+```
+
+### Executar com output detalhado
+
+```bash
+dotnet test tests/SemanaIA.ServiceInvoice.UnitTests/ -v detailed --logger "console;verbosity=detailed"
+```
+
+---
+
+## Organizacao do Codigo de Teste
+
+```
+tests/
+├── SemanaIA.ServiceInvoice.UnitTests/
+│   ├── SchemaEngine/                    # Testes da engine de schema
+│   │   ├── XsdSchemaAnalyzerTests.cs
+│   │   ├── XsdSchemaAnalyzerAttributeTests.cs
+│   │   ├── XsdSchemaAnalyzerVersionTests.cs
+│   │   ├── SchemaBasedXmlSerializerTests.cs
+│   │   ├── SchemaBasedXmlSerializerAttributeTests.cs
+│   │   ├── SchemaBasedXmlSerializerXmlStructureTests.cs
+│   │   ├── ServiceInvoiceSchemaDataBinderTests.cs
+│   │   ├── SchemaSerializationPipelineTests.cs
+│   │   ├── SendXsdSelectorTests.cs
+│   │   ├── TypedRuleResolverTests.cs
+│   │   ├── TypedRuleIntegrationTests.cs
+│   │   ├── ProviderRuleValidatorTests.cs
+│   │   ├── RuleConditionTests.cs
+│   │   ├── ValidationDiagnosticEnricherTests.cs
+│   │   ├── OperationalStatusTests.cs
+│   │   ├── GissonlineSchemaGenerationTests.cs
+│   │   ├── GenerateNacionalArtifactsTests.cs
+│   │   ├── BaselineComparisonAnalyzerTests.cs
+│   │   └── SchemaCodeGeneratorTests.cs
+│   ├── ProviderManagement/              # Testes de gestao de providers
+│   │   ├── Application/
+│   │   │   └── ProviderManagementServiceTests.cs
+│   │   └── ManagedProviderTests.cs
+│   ├── Mappers/                         # Testes de mapeamento
+│   │   └── NfseRequestToDpsDocumentModelMapperTests.cs
+│   ├── Manual/                          # Testes do serializer manual
+│   │   ├── NationalDpsManualSerializerTests.cs
+│   │   └── IbsCbsManualBuilderTests.cs
+│   └── Snapshots/                       # Testes de snapshot (golden master)
+│       └── GoldenMasterTests.cs
+│
+└── SemanaIA.ServiceInvoice.IntegrationsTests/
+    ├── NfseEndpointIntegrationTests.cs
+    ├── ProviderManagementEndpointTests.cs
+    ├── ProviderEndToEndFlowTests.cs
+    ├── ProviderFullLoadTests.cs
+    └── ProviderOnboardingLoadTests.cs
+```

--- a/docs/09-limitations-and-roadmap.md
+++ b/docs/09-limitations-and-roadmap.md
@@ -1,0 +1,173 @@
+# Limitacoes Conhecidas e Roadmap
+
+## O que Funciona Hoje
+
+### Nacional (MVP completo)
+
+- Fluxo E2E via API: `POST /api/v1/providers` → `POST /api/v1/nfse/xml`
+- **0 erros XSD** na validacao contra o schema
+- Schema `DPS > infDPS` com todos os campos obrigatorios mapeados
+- Auto-geracao de regras funcionando
+- Serializer manual (`NationalDpsManualSerializer`) como baseline com ~900 linhas e 19 metodos Build
+- Suporte a IBS/CBS (`IbsCbsManualBuilder`)
+- 611 testes unitarios + 116 testes de integracao passando
+
+### ISSNet
+
+- Cria provider via API com XSDs ABRASF
+- Resolve envelope `EnviarLoteRpsEnvio > LoteRps > ListaRps > Rps > InfRps`
+- Gera XML com conteudo mapeado
+- **Gaps rastreados:**
+  - Atributo `versao` emitido em elementos onde nao e declarado no schema
+  - Envelope `LoteRps` com conteudo incompleto em alguns cenarios
+  - Alguns campos ABRASF especificos nao mapeados automaticamente
+
+### GISSOnline
+
+- Cria provider via API com XSDs
+- Resolve envelope ABRASF
+- Gera XML com conteudo mapeado
+- **Gaps rastreados:**
+  - Atributo `versao` — mesmo problema do ISSNet
+  - Pattern constraints do XSD nao validados em tempo de geracao
+  - Envelope incompleto para cenarios avancados
+
+### Fallback Nacional
+
+- Funciona sempre: quando o codigo IBGE informado nao esta atribuido a nenhum provider, a engine usa o provider `nacional` automaticamente.
+- Resposta inclui `isFallback: true` e `fallbackReason` para rastreabilidade.
+
+### 48 Providers Onboardaveis via API
+
+- 48 test data providers podem ser criados via API usando os XSDs incluidos no repositorio.
+- Cada provider passa pela auto-geracao de regras e validacao automatica.
+- Status varia por provider: alguns ficam `Ready`, outros `Blocked` com gaps especificos.
+
+### 7 Providers Base
+
+Os 7 providers no diretorio `providers/` representam os padroes mais comuns:
+- `nacional` — padrao nacional DPS (NFSe Nacional)
+- `abrasf` — padrao ABRASF generico
+- `gissonline` — GISSOnline (variante ABRASF)
+- `issnet` — ISSNet (variante ABRASF)
+- `paulistana` — Nota Paulistana (requer assinatura digital)
+- `simpliss` — Simpliss (variante ABRASF)
+- `webiss` — WebISS (variante ABRASF)
+
+---
+
+## Limitacoes Conhecidas
+
+### 1. Enum-to-code usa constantes em vez de mapeamento dinamico
+
+**Onde:** `CommonFieldMappingDictionary` mapeia campos tributarios como `tribISSQN`, `opSimpNac`, `tpRetISSQN` para valores constantes (`const:1`).
+
+**Impacto:** todos os providers recebem o mesmo codigo tributario fixo, independente do regime real do prestador. Por exemplo:
+- `opSimpNac = const:1` significa "Normal" para todos, mesmo que o prestador seja MEI ou Simples Nacional.
+- `tribISSQN = const:1` significa "Tributado no municipio" para todos.
+
+**Mitigacao atual:** o suporte pode criar regras `EnumMapping` manualmente via API para sobrescrever as constantes.
+
+**Solucao necessaria:** auto-geracao deveria produzir regras `EnumMapping` com mapeamentos completos baseados nos valores do enum `TaxationType`, `TaxRegime`, etc.
+
+### 2. Envelope ABRASF incompleto para alguns providers
+
+**Onde:** `ProviderConfigGenerator.DetectEnvelopePattern` e `WalkEnvelopeChildForWrapperBindings`.
+
+**Impacto:** alguns providers ABRASF tem estruturas de envelope que a engine nao detecta completamente:
+- `LoteRps` com sub-elementos nao mapeados (ex: `CpfCnpj > Cnpj` do prestador)
+- `ListaRps` vazio quando o data container nao e encontrado no caminho esperado
+- Elementos opcionais do envelope ignorados
+
+**Mitigacao atual:** o suporte pode adicionar `wrapperBindings` manualmente editando as regras do provider.
+
+### 3. Atributo `versao` em raizes ABRASF
+
+**Onde:** `AddRequiredAttributeRules` e `AddEnvelopeAttributeBindings` em `ProviderConfigGenerator`.
+
+**Impacto:** a engine emite `versao="2.03"` em elementos onde o schema XSD nao declara esse atributo. Isso gera erros XSD do tipo "The 'versao' attribute is not declared."
+
+**Mitigacao atual:** nos providers afetados, a regra de `@versao` pode ser removida manualmente via `DELETE /api/v1/providers/{id}/rules/{index}`.
+
+### 4. Pattern constraints nao validados em tempo de geracao
+
+**Onde:** `InferFormattingRule` em `ProviderConfigGenerator`.
+
+**Impacto:** apenas patterns do tipo `[0-9]{N}` (digitos fixos) sao traduzidos em regras de formatacao. Patterns mais complexos (ex: `[0-9]{7,14}`, `[A-Z]{2}[0-9]{4}`) sao ignorados, podendo gerar valores que nao atendem as restricoes do XSD.
+
+**Exemplo:** um campo com pattern `[0-9]{7}` gera corretamente `padLeft: 7, digitsOnly: true`. Mas `[0-9]{1,15}` nao gera nenhuma regra.
+
+### 5. GenericReusableFields: heuristica pode ser imprecisa
+
+**Onde:** `WalkSchemaTree` em `ProviderConfigGenerator`, que usa `CommonFieldMappingDictionary` para mapeamento automatico.
+
+**Impacto:**
+- **Muito ampla:** campos com nomes genericos (ex: `Numero`, `Valor`) podem ser mapeados incorretamente. `Numero` pode significar tanto o numero do RPS quanto o numero de um documento auxiliar.
+- **Muito restrita:** campos com nomes especificos do municipio (ex: `CodigoVerificacao`, `OutrasInformacoes`) podem nao ter mapeamento automatico.
+
+**Mitigacao:** revisao manual das regras geradas via `GET /api/v1/providers/{id}/rules`.
+
+### 6. Sample data nem sempre e valido para providers nao-nacionais
+
+**Onde:** `ProviderSampleDocumentGenerator`.
+
+**Impacto:** o gerador de dados de amostra cria um `DpsDocument` generico para testar a serializacao. Para providers com restricoes especificas (ex: tamanho fixo de campos, codigos municipais obrigatorios), os dados de amostra podem nao passar na validacao XSD.
+
+**Consequencia:** a etapa `XsdValidation` pode falhar mesmo quando as regras estao corretas — o problema e nos dados de teste, nao nas regras.
+
+### 7. Paulistana requer assinatura digital
+
+**Onde:** o provider `paulistana` exige XML assinado digitalmente para envio.
+
+**Impacto:** a engine gera o XML sem assinatura. A integracao com certificado digital nao esta implementada.
+
+---
+
+## Roadmap
+
+### Curto Prazo
+
+| Item | Descricao | Impacto |
+|------|-----------|---------|
+| Envelope ABRASF completo | Corrigir `DetectEnvelopePattern` para cobrir todos os cenarios de envelope ABRASF (LoteRps com sub-elementos, identificacao do prestador no envelope) | Desbloqueia ISSNet, WebISS, Simpliss |
+| Mapeamento dinamico de enum | `ProviderConfigGenerator` deve gerar regras `EnumMapping` em vez de `const:1` para campos tributarios | Elimina a necessidade de ajuste manual para opSimpNac, tribISSQN |
+| Correcao do atributo versao | Nao emitir `@versao` quando o schema nao declara o atributo | Elimina erros XSD em providers ABRASF |
+| Melhoria do sample data | `ProviderSampleDocumentGenerator` deve respeitar restricoes XSD (tamanho, pattern) | Reduz falsos negativos na validacao |
+
+### Medio Prazo
+
+| Item | Descricao | Impacto |
+|------|-----------|---------|
+| Expandir MVP para 10+ providers | Validar e corrigir os 10 providers mais utilizados alem dos 3 atuais | Cobertura real de mercado |
+| Sample data inteligente | Gerar dados de amostra a partir de restricoes XSD (minLength, maxLength, pattern, enumeration) | Validacao automatica mais confiavel |
+| Patterns complexos | Suportar mais patterns XSD na auto-geracao de regras de formatacao | Menos ajustes manuais |
+| Diagnostico enriquecido | Expandir `ValidationDiagnosticEnricher` com sugestoes mais precisas e contextuais | Suporte resolve problemas mais rapido |
+| Testes de contrato | Adicionar testes de contrato para os endpoints da API | Previne quebras de API |
+
+### Longo Prazo
+
+| Item | Descricao | Impacto |
+|------|-----------|---------|
+| UI administrativo | Interface web para gestao de providers, regras e monitoramento | Suporte nao precisa usar curl |
+| Hot-reload de providers | Atualizar regras e XSDs sem restart da aplicacao | Zero downtime em mudancas |
+| Deploy em producao | Pipeline de deploy, autenticacao, rate limiting, logging estruturado | Pronto para uso real |
+| Assinatura digital | Integrar com certificado digital A1/A3 para providers que exigem XML assinado (Paulistana) | Desbloqueia Paulistana |
+| Mutation testing | Adicionar mutation testing para medir qualidade real dos testes | Confianca na cobertura |
+| Cache de schema | Cache de schemas compilados para melhorar performance em alta carga | Reducao de latencia |
+
+---
+
+## Metricas Atuais
+
+| Metrica | Valor |
+|---------|-------|
+| Testes unitarios | 611 |
+| Testes de integracao | 116 |
+| Total de testes | 727 |
+| Providers base | 7 |
+| Test data providers | 48 |
+| Providers MVP (0 XSD errors) | 1 (nacional) |
+| Providers MVP (com gaps rastreados) | 2 (ISSNet, GISSOnline) |
+| Mapeamentos no CommonFieldMappingDictionary | 119 entradas |
+| Tipos de regra | 6 (Binding, Default, EnumMapping, ConditionalEmission, Choice, Formatting) |
+| Etapas de validacao | 4 (XsdSelection, SchemaAnalysis, XmlSerialization, XsdValidation) |

--- a/openspec/changes/.archived-create-product-readme-and-support-wiki/.openspec.yaml
+++ b/openspec/changes/.archived-create-product-readme-and-support-wiki/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-23

--- a/openspec/changes/.archived-create-product-readme-and-support-wiki/design.md
+++ b/openspec/changes/.archived-create-product-readme-and-support-wiki/design.md
@@ -1,0 +1,39 @@
+## Context
+
+34 commits de evolução, do serializer manual até engine schema-driven com MVP fechado para 3 providers. Sem documentação consolidada.
+
+## Goals / Non-Goals
+
+**Goals:**
+- README robusto com visão do produto, status, como rodar
+- Wiki com evolução técnica, jornada IA, guia suporte, arquitetura
+- Material útil para apresentação >60min
+- Conteúdo concreto baseado no projeto real (não genérico)
+
+**Non-Goals:**
+- Novas features técnicas
+- Documentação auto-gerada de API (Swagger já existe)
+
+## Decisions
+
+### 1. Estrutura de documentação
+```
+README.md                          — Porta de entrada
+docs/
+  01-product-overview.md           — O que é, para que serve
+  02-evolution-journey.md          — Do manual ao engine (com commits)
+  03-ai-journey.md                 — Jornada IA completa (10 temas)
+  04-architecture.md               — Pipeline, componentes, fluxo
+  05-provider-management-api.md    — Endpoints, exemplos curl
+  06-support-onboarding-guide.md   — Como o suporte onboarda providers
+  07-rules-and-configuration.md    — Modelo de regras, dicionário, profiles
+  08-testing-strategy.md           — Testes unitários, E2E, integration
+  09-limitations-and-roadmap.md    — Gaps conhecidos, próximos passos
+```
+
+### 2. Conteúdo baseado em dados reais
+- Commits reais do git log
+- Providers reais da pasta providers/
+- Endpoints reais do Swagger
+- Testes reais com contagens
+- Erros XSD reais dos diagnósticos

--- a/openspec/changes/.archived-create-product-readme-and-support-wiki/proposal.md
+++ b/openspec/changes/.archived-create-product-readme-and-support-wiki/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+O MVP técnico está fechado: 3 providers (Nacional, ISSNet, GISSOnline) geram XML válido via API, com 727 testes passando. O projeto evoluiu de um serializer manual (commit #1) até uma engine schema-driven com 34 commits, 50 providers de teste, e gestão via API/MongoDB. Mas não existe documentação consolidada — nem README, nem wiki, nem material para suporte ou apresentação.
+
+## What Changes
+
+- **README.md**: Visão completa do produto, arquitetura, como rodar, status dos providers
+- **Wiki** (`docs/`): Documentação estruturada em múltiplas páginas:
+  - Evolução do produto (manual → engine → multi-provider → API)
+  - Jornada de IA (Terminal, IDE, Docker, Assistente, Agentes, Skills, MCP, Tools, Commands, Scheduling)
+  - Guia de suporte (onboarding, regras, validação, troubleshooting)
+  - Arquitetura técnica (pipeline, schemas, serializer, resolver)
+  - API reference (endpoints, exemplos)
+  - Limitações e próximos passos
+
+## Capabilities
+
+### New Capabilities
+- `product-documentation`: README e wiki estruturada cobrindo produto, evolução, IA, suporte e arquitetura
+
+## Impact
+
+- **README.md**: Criado do zero
+- **docs/**: Novo diretório com 8-10 páginas markdown
+- **Zero impacto em código** — apenas documentação

--- a/openspec/changes/.archived-create-product-readme-and-support-wiki/specs/product-documentation/spec.md
+++ b/openspec/changes/.archived-create-product-readme-and-support-wiki/specs/product-documentation/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: Product README
+
+O projeto MUST ter um README.md na raiz com: descrição do produto, status atual dos providers, arquitetura em alto nível, como rodar, link para wiki.
+
+#### Scenario: README exists and is complete
+- **WHEN** o desenvolvedor acessa o repositório
+- **THEN** encontra README.md com visão clara do produto e links para documentação detalhada
+
+### Requirement: Structured wiki documentation
+
+O projeto MUST ter documentação em `docs/` cobrindo: evolução do produto, jornada de IA, guia de suporte, arquitetura, API, regras, testes, limitações.
+
+#### Scenario: Wiki covers all required topics
+- **WHEN** o time acessa docs/
+- **THEN** encontra páginas para cada tema obrigatório com conteúdo concreto do projeto

--- a/openspec/changes/.archived-create-product-readme-and-support-wiki/tasks.md
+++ b/openspec/changes/.archived-create-product-readme-and-support-wiki/tasks.md
@@ -1,0 +1,27 @@
+## 1. README.md
+
+- [ ] 1.1 Criar README.md com: nome do produto, descrição, status MVP, providers suportados, como rodar, stack, links para docs
+
+## 2. Wiki — Produto e Evolução
+
+- [ ] 2.1 Criar docs/01-product-overview.md — O que é, problema que resolve, quem usa
+- [ ] 2.2 Criar docs/02-evolution-journey.md — Timeline do manual ao engine com commits reais (#1 ao #32)
+
+## 3. Wiki — Jornada IA
+
+- [ ] 3.1 Criar docs/03-ai-journey.md — Cobrindo os 10 temas: Terminal/IDE, Docker, Assistente, Agente único, Multi agentes, Skills, MCP/LSP, Tools/Plugins, Commands, Scheduling
+
+## 4. Wiki — Arquitetura e API
+
+- [ ] 4.1 Criar docs/04-architecture.md — Pipeline, componentes, fluxo de dados
+- [ ] 4.2 Criar docs/05-provider-management-api.md — Endpoints com exemplos curl
+
+## 5. Wiki — Suporte e Operação
+
+- [ ] 5.1 Criar docs/06-support-onboarding-guide.md — Passo a passo para suporte onboardar provider
+- [ ] 5.2 Criar docs/07-rules-and-configuration.md — Modelo de regras, dicionário, profiles
+
+## 6. Wiki — Testes e Roadmap
+
+- [ ] 6.1 Criar docs/08-testing-strategy.md — Estratégia de testes, contagens, E2E
+- [ ] 6.2 Criar docs/09-limitations-and-roadmap.md — Gaps conhecidos, próximos passos

--- a/providers/onboarding-report.md
+++ b/providers/onboarding-report.md
@@ -1,6 +1,6 @@
 # Provider Onboarding Report
 
-Generated: 2026-03-23 15:42:22 UTC
+Generated: 2026-03-23 15:58:00 UTC
 
 ## Provider Status Overview
 


### PR DESCRIPTION
- README.md with project overview, MVP status, quick start, architecture
- docs/01-product-overview.md: what is NFSe, what the engine solves
- docs/02-evolution-journey.md: 6 phases, 34 commits timeline
- docs/03-ai-journey.md: 10 AI themes (Terminal, Docker, Assistant, Agent, Multi-agents, Skills, MCP, Tools, Commands, Scheduling)
- docs/04-architecture.md: pipeline, components, diagrams
- docs/05-provider-management-api.md: 16+ endpoints with curl examples
- docs/06-support-onboarding-guide.md: step-by-step for support team
- docs/07-rules-and-configuration.md: rule types, dictionary, profiles
- docs/08-testing-strategy.md: 727 tests, pyramid, how to run
- docs/09-limitations-and-roadmap.md: known gaps, next steps
- Claude agents and skills for documentation generation