### PR TITLE
docs: add product wiki with 19 structured pages and updated README (#34)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,78 @@
-# spec-mcp-poc
+# SemanaIA — NFSe Schema-Driven Engine
 
-POC para geração de XML de NFS-e a partir de:
-- contrato OpenAPI/YAML
-- schemas XSD
-- regras de negócio já existentes no serializer legado
-- fluxo com OpenSpec + MCP + LSP + OpenCode + Claude Code
+![.NET 10](https://img.shields.io/badge/.NET-10-512BD4)
+![MongoDB](https://img.shields.io/badge/MongoDB-7-47A248)
+![Tests](https://img.shields.io/badge/tests-727%20passing-brightgreen)
+![MVP](https://img.shields.io/badge/status-MVP-blue)
 
-## Objetivo
-Demonstrar uma abordagem guiada por especificação para evoluir o serializer atual para uma arquitetura mais testável e legível:
+## O que é
 
-request -> mapper -> modelo canônico -> builders XML -> XML final
+O SemanaIA é um motor de geração de XML de NFS-e (Nota Fiscal de Serviços Eletrônica) orientado por schema XSD. Em vez de manter serializadores manuais para cada município, a engine analisa os XSDs dos providers em runtime, aplica regras tipadas e produz XML válido automaticamente. Isso elimina a necessidade de código específico por prefeitura e permite onboarding de novos providers sem intervenção de desenvolvedor.
 
-## Escopo inicial
-Primeira iteração limitada a:
-- infDPS
-- prest
-- toma
-- serv
-- valores
+O projeto foi construído inteiramente com assistência de IA (Claude Code com Opus 4.6) ao longo de 34 commits, passando por 6 fases de evolução — do serializer manual ao MVP com API, persistência MongoDB e 727 testes automatizados. A arquitetura segue o padrão Onion com 5 camadas bem definidas.
 
-## Próximos passos
-1. Consolidar a spec da POC em `openspec/`.
-2. Evoluir o request C# a partir do YAML enviado.
-3. Implementar o modelo canônico e os builders XML.
-4. Conectar o MCP `spec-assistant` ao OpenCode e ao Claude Code.
-5. Gerar testes BDD + 3A para os primeiros critérios de aceite.
+## Quick Start
 
+### Pré-requisitos
 
-## Ajuste aplicado
+- [.NET 10 SDK](https://dotnet.microsoft.com/download)
+- [Docker](https://www.docker.com/) (para MongoDB)
 
-Esta versão inicial da POC foi ajustada para usar o **XBuilder** como tecnologia de infraestrutura para geração de XML, refletindo o framework já utilizado no projeto real. O fluxo agora é `request -> mapper -> modelo canônico -> builder XML com XBuilder -> XML final`.
+### Subir a infraestrutura
+
+```bash
+docker compose up -d
+```
+
+### Executar a API
+
+```bash
+cd src/SemanaIA.ServiceInvoice.Api
+dotnet run
+```
+
+A API estará disponível em **http://localhost:5211** e o Swagger em **http://localhost:5211/swagger**.
+
+### Executar os testes
+
+```bash
+dotnet test
+```
+
+> 611 testes unitários + 116 testes de integração = **727 testes**, todos passando.
+
+## Documentação
+
+A documentação completa do projeto está na wiki:
+
+**[Wiki — SemanaIA NFSe Engine](docs/wiki/Home.md)**
+
+## Stack
+
+| Camada | Tecnologia |
+|--------|-----------|
+| Runtime | .NET 10 / C# |
+| API | ASP.NET Core Minimal API |
+| Banco de dados | MongoDB 7 |
+| Testes | xUnit, Shouldly, Bogus, Moq |
+| Containers | Docker Compose |
+| Engine XML | XSD analysis em runtime, `XElement`-based serialization |
+| IA | Claude Code (Opus 4.6) via OpenSpec workflow |
+
+## Estrutura do Projeto
+
+```
+src/
+├── SemanaIA.ServiceInvoice.Api/            # Endpoints e configuração
+├── SemanaIA.ServiceInvoice.Application/    # Casos de uso
+├── SemanaIA.ServiceInvoice.Domain/         # Modelos de domínio
+├── SemanaIA.ServiceInvoice.Infrastructure/ # Integrações e persistência
+└── SemanaIA.ServiceInvoice.XmlGeneration/  # Engine de geração XML
+providers/                                   # XSDs, regras e configs por provider
+tests/                                       # Testes unitários e de integração
+docs/wiki/                                   # Documentação completa
+```
+
+## Licença
+
+Este projeto é de uso interno. Licença a ser definida.

--- a/docs/wiki/API-de-Gestao-de-Providers.md
+++ b/docs/wiki/API-de-Gestao-de-Providers.md
@@ -1,0 +1,316 @@
+# API de Gestao de Providers
+
+Referencia completa dos endpoints da API de NFS-e XML Engine.
+
+**Base URL:** `http://localhost:5211`
+
+---
+
+## Emissao de XML
+
+| Metodo | Endpoint | Descricao |
+|--------|----------|-----------|
+| POST | `/api/v1/nfse/xml` | Gerar XML de NFS-e a partir dos dados do documento |
+
+### POST /api/v1/nfse/xml
+
+Gera o XML de NFS-e (DPS) resolvendo automaticamente o provider pelo codigo IBGE do municipio do prestador (`location.city.code`). Se nenhum provider atender o municipio, o provider nacional e usado como fallback.
+
+**Content-Type:** `application/json`
+
+```bash
+curl -X POST http://localhost:5211/api/v1/nfse/xml \
+  -H "Content-Type: application/json" \
+  -d '{
+    "externalId": "NF-001",
+    "provider": {
+      "federalTaxNumber": 12345678000199,
+      "municipalTaxNumber": "12345"
+    },
+    "borrower": {
+      "name": "Tomador Exemplo",
+      "federalTaxNumber": 98765432000188,
+      "address": {
+        "postalCode": "01001000",
+        "street": "Rua Exemplo",
+        "number": "100",
+        "district": "Centro",
+        "city": { "code": "3550308", "name": "Sao Paulo" },
+        "state": "SP"
+      }
+    },
+    "location": {
+      "postalCode": "01001000",
+      "street": "Rua do Prestador",
+      "number": "200",
+      "district": "Centro",
+      "city": { "code": "3550308", "name": "Sao Paulo" },
+      "state": "SP"
+    },
+    "description": "Servicos de consultoria",
+    "servicesAmount": 1500.00,
+    "issuedOn": "2026-01-20T10:00:00-03:00",
+    "taxationType": "WithinCity",
+    "federalServiceCode": "17.01"
+  }'
+```
+
+**Response:** JSON com `xml`, `providerName`, `municipalityCode`, `isFallback`, `fallbackReason`, `rootElement`, `generatedBy`.
+
+---
+
+## CRUD de Providers
+
+| Metodo | Endpoint | Descricao |
+|--------|----------|-----------|
+| POST | `/api/v1/providers` | Criar provider com XSDs e municipios |
+| GET | `/api/v1/providers` | Listar todos os providers |
+| GET | `/api/v1/providers/{id}` | Obter detalhes completos de um provider |
+| PUT | `/api/v1/providers/{id}` | Atualizar provider (parcial) |
+| DELETE | `/api/v1/providers/{id}` | Excluir provider permanentemente |
+
+### POST /api/v1/providers
+
+Cadastra um novo provider com arquivos XSD. Dispara validacao automatica apos o cadastro. Se a validacao falhar, o provider fica com status `Blocked`.
+
+**Content-Type:** `multipart/form-data`
+
+| Campo | Tipo | Obrigatorio | Descricao |
+|-------|------|-------------|-----------|
+| `name` | string | Sim | Nome unico do provider (ex: `gissonline`, `paulistana`) |
+| `xsdFiles[]` | file[] | Sim | Arquivos `.xsd` do schema |
+| `municipalityCodes` | string | Nao | Codigos IBGE separados por virgula (ex: `3550308,3509502`) |
+| `primaryXsdFile` | string | Nao | Nome do XSD principal (obrigatorio quando ha mais de um XSD) |
+
+```bash
+curl -X POST http://localhost:5211/api/v1/providers \
+  -F "name=meu-provider" \
+  -F "xsdFiles[]=@servico_enviar_lote_rps_envio.xsd" \
+  -F "xsdFiles[]=@tipos_complexos.xsd" \
+  -F "municipalityCodes=3550308,3509502" \
+  -F "primaryXsdFile=servico_enviar_lote_rps_envio.xsd"
+```
+
+### GET /api/v1/providers
+
+Lista todos os providers. Aceita filtro opcional por status.
+
+| Query Param | Tipo | Descricao |
+|-------------|------|-----------|
+| `status` | string | Filtrar por status: `Draft`, `Ready`, `Blocked`, `Inactive` |
+
+```bash
+curl http://localhost:5211/api/v1/providers?status=Ready
+```
+
+### GET /api/v1/providers/{id}
+
+Retorna detalhes completos do provider incluindo XSDs, municipios, contagem de regras e historico de validacao.
+
+```bash
+curl http://localhost:5211/api/v1/providers/665f1a2b3c4d5e6f7a8b9c0d
+```
+
+### PUT /api/v1/providers/{id}
+
+Atualiza um provider existente. Todos os campos sao opcionais (atualizacao parcial). Dispara revalidacao quando XSDs sao alterados.
+
+**Content-Type:** `multipart/form-data`
+
+| Campo | Tipo | Obrigatorio | Descricao |
+|-------|------|-------------|-----------|
+| `name` | string | Nao | Novo nome do provider |
+| `xsdFiles[]` | file[] | Nao | Novos XSDs (substitui todos os existentes) |
+| `primaryXsdFile` | string | Nao | Novo XSD principal |
+| `version` | string | Nao | Nova versao |
+
+```bash
+curl -X PUT http://localhost:5211/api/v1/providers/665f1a2b3c4d5e6f7a8b9c0d \
+  -F "version=2.0" \
+  -F "xsdFiles[]=@schema_v2.xsd"
+```
+
+### DELETE /api/v1/providers/{id}
+
+Exclui permanentemente um provider e todas as suas configuracoes.
+
+```bash
+curl -X DELETE http://localhost:5211/api/v1/providers/665f1a2b3c4d5e6f7a8b9c0d
+```
+
+---
+
+## Ciclo de Vida
+
+| Metodo | Endpoint | Descricao |
+|--------|----------|-----------|
+| POST | `/api/v1/providers/{id}/validate` | Executar validacao sob demanda |
+| POST | `/api/v1/providers/{id}/activate` | Ativar provider |
+| POST | `/api/v1/providers/{id}/deactivate` | Desativar provider |
+| GET | `/api/v1/providers/{id}/status` | Obter status operacional detalhado |
+
+### POST /api/v1/providers/{id}/validate
+
+Executa validacao completa: selecao de XSD, analise de schema, geracao de XML de teste e validacao contra o XSD. Atualiza o status para `Ready` ou `Blocked`.
+
+```bash
+curl -X POST http://localhost:5211/api/v1/providers/665f1a2b3c4d5e6f7a8b9c0d/validate
+```
+
+### POST /api/v1/providers/{id}/activate
+
+Ativa o provider. Executa validacao se nenhuma existir. Transiciona para `Ready` ou `Blocked`.
+
+```bash
+curl -X POST http://localhost:5211/api/v1/providers/665f1a2b3c4d5e6f7a8b9c0d/activate
+```
+
+### POST /api/v1/providers/{id}/deactivate
+
+Desativa o provider. Define status como `Inactive`. O provider deixa de ser resolvido para emissao.
+
+```bash
+curl -X POST http://localhost:5211/api/v1/providers/665f1a2b3c4d5e6f7a8b9c0d/deactivate
+```
+
+### GET /api/v1/providers/{id}/status
+
+Retorna status operacional com resultado detalhado da ultima validacao.
+
+```bash
+curl http://localhost:5211/api/v1/providers/665f1a2b3c4d5e6f7a8b9c0d/status
+```
+
+---
+
+## Municipios
+
+| Metodo | Endpoint | Descricao |
+|--------|----------|-----------|
+| POST | `/api/v1/providers/{id}/municipalities` | Adicionar municipios ao provider |
+| DELETE | `/api/v1/providers/{id}/municipalities` | Remover municipios do provider |
+
+### POST /api/v1/providers/{id}/municipalities
+
+Adiciona codigos IBGE ao provider. Cada codigo deve ser exclusivo entre todos os providers.
+
+```bash
+curl -X POST http://localhost:5211/api/v1/providers/665f1a2b3c4d5e6f7a8b9c0d/municipalities \
+  -H "Content-Type: application/json" \
+  -d '{ "codes": ["3550308", "4106902", "3304557"] }'
+```
+
+### DELETE /api/v1/providers/{id}/municipalities
+
+Remove codigos IBGE do provider.
+
+```bash
+curl -X DELETE http://localhost:5211/api/v1/providers/665f1a2b3c4d5e6f7a8b9c0d/municipalities \
+  -H "Content-Type: application/json" \
+  -d '{ "codes": ["3304557"] }'
+```
+
+---
+
+## Regras Tipadas
+
+| Metodo | Endpoint | Descricao |
+|--------|----------|-----------|
+| GET | `/api/v1/providers/{id}/rules` | Listar todas as regras do provider |
+| PUT | `/api/v1/providers/{id}/rules` | Substituir todas as regras |
+| POST | `/api/v1/providers/{id}/rules` | Adicionar regras sem remover existentes |
+| DELETE | `/api/v1/providers/{id}/rules/{index}` | Remover regra por indice (base zero) |
+
+### GET /api/v1/providers/{id}/rules
+
+Retorna a lista completa de regras tipadas configuradas para o provider.
+
+```bash
+curl http://localhost:5211/api/v1/providers/665f1a2b3c4d5e6f7a8b9c0d/rules
+```
+
+### PUT /api/v1/providers/{id}/rules
+
+Substitui todas as regras do provider pela lista informada. A lista e validada pela engine antes de ser salva.
+
+```bash
+curl -X PUT http://localhost:5211/api/v1/providers/665f1a2b3c4d5e6f7a8b9c0d/rules \
+  -H "Content-Type: application/json" \
+  -d '[
+    { "type": "Binding", "target": "infDPS.tpAmb", "source": "Environment" },
+    { "type": "Binding", "target": "infDPS.dhEmi", "source": "IssuedOn", "format": "yyyy-MM-ddTHH:mm:sszzz" }
+  ]'
+```
+
+### POST /api/v1/providers/{id}/rules
+
+Adiciona regras ao final da lista existente. O conjunto completo e validado.
+
+```bash
+curl -X POST http://localhost:5211/api/v1/providers/665f1a2b3c4d5e6f7a8b9c0d/rules \
+  -H "Content-Type: application/json" \
+  -d '[
+    { "type": "Formatting", "target": "cTribNac", "digitsOnly": true, "padLeft": 6, "padChar": "0" }
+  ]'
+```
+
+### DELETE /api/v1/providers/{id}/rules/{index}
+
+Remove uma regra por indice (base zero). Apos remocao, a lista e reindexada.
+
+```bash
+curl -X DELETE http://localhost:5211/api/v1/providers/665f1a2b3c4d5e6f7a8b9c0d/rules/3
+```
+
+---
+
+## Catalogo da DSL
+
+| Metodo | Endpoint | Descricao |
+|--------|----------|-----------|
+| GET | `/api/v1/rules/catalog` | Catalogo completo (tipos, sources, targets, operadores, acoes) |
+| GET | `/api/v1/rules/sources` | Campos do dominio disponiveis como source |
+| GET | `/api/v1/rules/targets/{providerName}` | Campos XSD do provider disponiveis como target |
+| GET | `/api/v1/rules/types` | Tipos de regra com descricao e exemplo JSON |
+| GET | `/api/v1/rules/operators` | Operadores de comparacao para condicoes |
+| GET | `/api/v1/rules/actions` | Acoes disponiveis (Emit, Skip) |
+
+### GET /api/v1/rules/sources
+
+Lista todos os campos do dominio (DpsDocument) disponiveis como `source` em regras.
+
+```bash
+curl http://localhost:5211/api/v1/rules/sources
+```
+
+### GET /api/v1/rules/targets/{providerName}
+
+Lista campos do schema XSD de um provider disponiveis como `target`.
+
+```bash
+curl http://localhost:5211/api/v1/rules/targets/nacional
+```
+
+### GET /api/v1/rules/types
+
+Lista tipos de regra com campos obrigatorios e exemplo JSON.
+
+```bash
+curl http://localhost:5211/api/v1/rules/types
+```
+
+### GET /api/v1/rules/operators
+
+Lista operadores de comparacao: `Equals`, `NotEquals`, `GreaterThan`, `LessThan`, `GreaterThanOrEqual`, `LessThanOrEqual`, `IsNull`, `HasValue`, `Contains`, `In`.
+
+```bash
+curl http://localhost:5211/api/v1/rules/operators
+```
+
+### GET /api/v1/rules/actions
+
+Lista acoes para regras condicionais: `Emit` (emitir campo) e `Skip` (omitir campo).
+
+```bash
+curl http://localhost:5211/api/v1/rules/actions
+```

--- a/docs/wiki/Arquitetura.md
+++ b/docs/wiki/Arquitetura.md
@@ -1,0 +1,133 @@
+# Arquitetura
+
+## Visão geral
+
+O SemanaIA segue a arquitetura **Onion (cebola)** com 5 camadas bem definidas. As dependências apontam sempre para dentro: camadas externas dependem das internas, nunca o contrário.
+
+```
+┌─────────────────────────────────────────────────┐
+│                    API                          │
+│  (Endpoints, Controllers, Swagger)              │
+├─────────────────────────────────────────────────┤
+│              Infrastructure                     │
+│  (MongoDB, SchemaEngineNfseXmlGenerator)        │
+├─────────────────────────────────────────────────┤
+│              XmlGeneration                      │
+│  (Engine, Analyzer, Serializer, Binder)         │
+├─────────────────────────────────────────────────┤
+│              Application                        │
+│  (GenerateNfseXmlUseCase)                       │
+├─────────────────────────────────────────────────┤
+│                Domain                           │
+│  (DpsDocument, Provider, Values, IBS/CBS)       │
+└─────────────────────────────────────────────────┘
+```
+
+## As 5 camadas
+
+### Domain (`SemanaIA.ServiceInvoice.Domain`)
+
+Modelos de domínio puros, sem dependências externas. Contém:
+- `DpsDocument` — modelo canônico que representa uma NFS-e
+- `Provider`, `Borrower`, `ServiceProvider` — entidades de domínio
+- `Values`, `IbsCbs` — objetos de valor fiscal
+- `INfseXmlGenerator` — interface que o domínio expõe para geração XML
+- `IProviderOnboardingService` — contrato de onboarding
+- `NfseXmlGenerationResult` — resultado tipado da geração
+
+### Application (`SemanaIA.ServiceInvoice.Application`)
+
+Orquestração de casos de uso. Depende apenas do Domain.
+- `GenerateNfseXmlUseCase` — recebe um request, converte para `DpsDocument`, invoca `INfseXmlGenerator`
+
+### XmlGeneration (`SemanaIA.ServiceInvoice.XmlGeneration`)
+
+Coração da engine. Componentes principais:
+
+| Componente | Responsabilidade |
+|-----------|-----------------|
+| `XsdSchemaAnalyzer` | Lê arquivos XSD e produz um `SchemaModel` canônico |
+| `SchemaModel` | Representação intermediária da estrutura do XSD |
+| `SchemaBasedXmlSerializer` | Serializa XML dinamicamente a partir de `SchemaModel` + dados |
+| `ServiceInvoiceSchemaDataBinder` | Converte `DpsDocument` em dicionário de dados para o serializer |
+| `SchemaSerializationPipeline` | Orquestra: binding → serialização → validação XSD |
+| `ProviderResolver` | Resolve qual provider usar dado um código de município |
+| `ProviderConfigGenerator` | Auto-gera configuração e regras sugeridas para novos providers |
+| `TypedRuleResolver` | Aplica regras tipadas (DSL) no pipeline de serialização |
+| `XsdValidator` | Valida o XML gerado contra o XSD original |
+| `ValidationDiagnosticEnricher` | Classifica erros XSD com recomendações acionáveis |
+| `SendXsdSelector` | Seleciona o XSD correto de envio quando o provider tem múltiplos schemas |
+| `CommonFieldMappingDictionary` | Mapeamentos padrão de campos domínio→schema |
+| `ProviderOnboardingValidator` | Executa checks de prontidão do provider |
+
+### Infrastructure (`SemanaIA.ServiceInvoice.Infrastructure`)
+
+Implementações concretas e integrações:
+- `SchemaEngineNfseXmlGenerator` — implementa `INfseXmlGenerator` usando a engine
+- `ProviderOnboardingService` — implementa `IProviderOnboardingService`
+- Repositórios MongoDB para providers e regras
+- `AddNfseInfrastructure()` — extensão de configuração de DI
+
+### Api (`SemanaIA.ServiceInvoice.Api`)
+
+Camada de entrada HTTP:
+- `POST /nfse/xml` — gera XML de NFS-e
+- `POST /api/v1/providers/onboard` — onboarda um novo provider
+- `GET /api/v1/providers` — lista providers com status
+- `GET /api/v1/providers/{name}/status` — status detalhado de um provider
+- Endpoints CRUD para regras tipadas
+- `GET /api/v1/rules/catalog` — catálogo de campos disponíveis para regras
+
+## Pipeline de geração XML
+
+```
+Request HTTP
+    │
+    ▼
+Mapper (Request → DpsDocument)
+    │
+    ▼
+ProviderResolver (código município → provider)
+    │
+    ▼
+SchemaSerializationPipeline
+    ├── SendXsdSelector (escolhe XSD de envio)
+    ├── XsdSchemaAnalyzer (XSD → SchemaModel)
+    ├── TypedRuleResolver (aplica regras tipadas)
+    ├── ServiceInvoiceSchemaDataBinder (DpsDocument → data dict)
+    ├── SchemaBasedXmlSerializer (data dict + SchemaModel → XML)
+    └── XsdValidator (XML → validação contra XSD)
+    │
+    ▼
+NfseXmlGenerationResult (XML + diagnóstico)
+```
+
+## Resolução de provider
+
+O `ProviderResolver` busca o provider em cadeia:
+
+1. **MongoDB** — providers cadastrados via API com configuração persistida
+2. **Filesystem** — pasta `providers/{name}/` com XSD e regras em arquivo
+3. **Fallback Nacional** — se nenhum provider for encontrado, usa o Nacional como padrão
+
+A resolução é feita pelo **código de município IBGE**. Cada provider está associado a um ou mais códigos de município.
+
+## Estrutura de um provider
+
+```
+providers/{nome}/
+├── xsd/              # Schemas XSD do provider
+│   ├── tipos.xsd
+│   └── servicos.xsd
+├── rules/            # Regras de binding e configuração
+│   └── rules.json
+└── generated/        # Artefatos auto-gerados (suggested-rules, etc.)
+    └── suggested-rules.json
+```
+
+---
+
+**Páginas relacionadas:**
+- [Fluxo End-to-End](Fluxo-End-to-End.md)
+- [Engine e Interpretação de XSD](Engine-e-Interpretacao-de-XSD.md)
+- [Validação Automática](Validacao-Automatica.md)

--- a/docs/wiki/Cadastro-de-Providers.md
+++ b/docs/wiki/Cadastro-de-Providers.md
@@ -1,0 +1,164 @@
+# Cadastro de Providers
+
+## Visao geral
+
+O cadastro de um provider e feito via API REST com upload multipart dos arquivos XSD.
+A engine analisa os schemas, gera regras automaticamente, executa validacao e persiste
+o provider no MongoDB.
+
+---
+
+## Endpoint de criacao
+
+```
+POST /api/v1/providers
+Content-Type: multipart/form-data
+```
+
+### Parametros
+
+| Campo              | Tipo            | Obrigatorio | Descricao                                                      |
+|--------------------|-----------------|-------------|----------------------------------------------------------------|
+| `name`             | string          | Sim         | Nome unico do provider (ex: `gissonline`, `paulistana`)        |
+| `xsdFiles[]`       | file[]          | Sim         | Arquivos `.xsd` do schema do provider                          |
+| `municipalityCodes`| string          | Nao         | Codigos IBGE separados por virgula (ex: `3550308,3509502`)     |
+| `primaryXsdFile`   | string          | Nao*        | Nome do XSD principal para analise                              |
+
+(*) Obrigatorio quando o provider possui mais de um XSD e a engine nao consegue
+determinar automaticamente qual e o XSD de envio.
+
+---
+
+## O que acontece no Create
+
+```
+Upload XSDs
+    |
+    v
+ManagedProvider.Create(name, xsdFiles, municipalityCodes)
+    |
+    v
+Status = Draft
+    |
+    v
+EngineProviderValidator.Validate()
+    |
+    ├── XsdSelection: SendXsdSelector identifica o XSD de envio
+    ├── SchemaAnalysis: XsdSchemaAnalyzer.Analyze() interpreta o schema
+    ├── ConfigGeneration: ProviderConfigGenerator gera profile e rules
+    ├── XmlSerialization: SchemaBasedXmlSerializer gera XML de teste
+    └── XsdValidation: XsdValidator valida o XML contra o XSD
+    |
+    v
+Validation passed? --> MarkReady() / Block(reason)
+    |
+    v
+Save no MongoDB (XSD files como byte[], rules como JSON, validation history)
+```
+
+---
+
+## Auto-geracao de regras
+
+O `ProviderConfigGenerator.GenerateFromXsdFiles` e chamado durante a validacao
+quando o provider nao possui `rulesJson` preexistente:
+
+1. **Selecao do XSD**: Usa `SendXsdSelector` para encontrar o XSD de envio
+2. **Analise do schema**: `XsdSchemaAnalyzer.Analyze` produz o `SchemaDocument`
+3. **Deteccao de envelope**: Identifica patterns ABRASF (`EnviarLoteRpsEnvio > LoteRps > ListaRps > Rps > InfRps`)
+4. **WalkSchemaTree**: Percorre a arvore do schema, consultando o `CommonFieldMappingDictionary`
+5. **Geracao de rules**: Converte bindings e formatting em `List<ProviderRule>` tipadas
+6. **Deteccao de atributos**: Adiciona rules para atributos obrigatorios (`Id`, `versao`)
+
+### Profile gerado
+
+O profile salvo contem:
+
+| Campo                  | Exemplo                                           | Descricao                                      |
+|------------------------|---------------------------------------------------|-------------------------------------------------|
+| `rootComplexTypeName`  | `_anon_EnviarLoteRpsEnvio`                        | Tipo raiz do schema                            |
+| `rootElementName`      | `EnviarLoteRpsEnvio`                              | Elemento raiz do XML                           |
+| `bindingPathPrefix`    | `LoteRps.ListaRps.Rps.InfDeclaracaoPrestacaoServico` | Caminho ate o container de dados (ABRASF)  |
+| `wrapperBindings`      | `{"LoteRps.NumeroLote": "const:1", ...}`          | Bindings do envelope (fora do data container)  |
+| `rules`                | Lista de `ProviderRule`                           | Regras tipadas auto-geradas                    |
+| `version`              | `"2.04"`                                          | Versao extraida do atributo `versao` do XSD    |
+
+---
+
+## Exemplos com curl
+
+### Provider nacional (schema DPS)
+
+```bash
+curl -X POST http://localhost:5211/api/v1/providers \
+  -F "name=nacional" \
+  -F "xsdFiles=@DPS_v1.00.xsd" \
+  -F "xsdFiles=@tiposBasico_v1.00.xsd" \
+  -F "xsdFiles=@tiposDPS_v1.00.xsd" \
+  -F "xsdFiles=@xmldsig-core-schema20020212.xsd" \
+  -F "municipalityCodes=3550308"
+```
+
+### Provider ISSNet (ABRASF com multiplos XSDs)
+
+```bash
+curl -X POST http://localhost:5211/api/v1/providers \
+  -F "name=issnet" \
+  -F "xsdFiles=@servico_enviar_lote_rps_envio.xsd" \
+  -F "xsdFiles=@tipos_v03.xsd" \
+  -F "xsdFiles=@tiposSimples_v03.xsd" \
+  -F "xsdFiles=@tiposComplexos_v03.xsd" \
+  -F "municipalityCodes=3509502,3304557" \
+  -F "primaryXsdFile=servico_enviar_lote_rps_envio.xsd"
+```
+
+---
+
+## Erros possiveis
+
+| Codigo HTTP | Tipo      | Causa                                                              |
+|-------------|-----------|--------------------------------------------------------------------|
+| 409         | Conflict  | Ja existe provider com o mesmo `name`                              |
+| 409         | Conflict  | Um dos `municipalityCodes` ja pertence a outro provider            |
+| 400         | Validation| Nenhum arquivo XSD enviado                                        |
+| 400         | Validation| Nome do provider vazio                                            |
+| 201         | Created   | Provider criado; status pode ser `Ready` ou `Blocked`              |
+
+### Exemplo de resposta com Blocked
+
+```json
+{
+  "id": "a1b2c3d4e5f6",
+  "name": "custom-provider",
+  "version": "1.01",
+  "status": "Blocked",
+  "blockReason": "Schema analysis failed: The 'X' element is not declared.",
+  "xsdFileNames": ["schema.xsd"],
+  "municipalityCodes": ["3550308"],
+  "hasRulesConfig": false,
+  "typedRuleCount": 0,
+  "validationCount": 1,
+  "createdAt": "2026-03-23T14:00:00Z",
+  "updatedAt": "2026-03-23T14:00:00Z"
+}
+```
+
+---
+
+## Atualizacao de provider
+
+```
+PUT /api/v1/providers/{id}
+Content-Type: multipart/form-data
+```
+
+Parametros opcionais: `name`, `xsdFiles[]`, `primaryXsdFile`, `version`.
+Quando XSDs sao atualizados, a engine re-executa a validacao automaticamente.
+
+---
+
+## Links relacionados
+
+- [Regras de Provider](Regras-de-Provider.md)
+- [Validacao Automatica](Validacao-Automatica.md)
+- [Engine e Interpretacao de XSD](Engine-e-Interpretacao-de-XSD.md)

--- a/docs/wiki/Engine-e-Interpretacao-de-XSD.md
+++ b/docs/wiki/Engine-e-Interpretacao-de-XSD.md
@@ -1,0 +1,161 @@
+# Engine e Interpretacao de XSD
+
+## Visao geral
+
+O motor de geracao de XML da NFSe opera a partir de schemas XSD reais dos providers.
+Em vez de usar mapeamentos hardcoded, a engine le o XSD, constroi um modelo intermediario
+(`SchemaDocument`) e usa esse modelo para serializar XML dinamicamente.
+
+O fluxo principal e:
+
+```
+XSD files  -->  XsdSchemaAnalyzer  -->  SchemaDocument  -->  SchemaBasedXmlSerializer  -->  XML
+```
+
+---
+
+## XsdSchemaAnalyzer
+
+A classe `XsdSchemaAnalyzer` e o ponto de entrada para interpretacao de schemas.
+Ela recebe o caminho de um arquivo `.xsd`, carrega todos os XSDs do mesmo diretorio
+em um `XmlSchemaSet`, compila o schema set e produz um `SchemaDocument`.
+
+**Responsabilidades:**
+
+- Carregar e compilar todos os arquivos `*.xsd` do diretorio do provider
+- Identificar o `TargetNamespace` principal (ignorando `xmldsig#`)
+- Extrair o `RootElementName` do primeiro elemento global
+- Analisar todos os `ComplexType` globais e inline
+- Extrair restrictions (pattern, minLength, maxLength, enumerations, totalDigits)
+- Detectar o atributo `versao` no elemento raiz
+- Construir o `NamespaceMap` com prefixos declarados ou gerados (`ns1`, `ns2`, ...)
+- Extrair `SchemaAttribute` de cada ComplexType (ignorando atributos de infraestrutura como `xmlns`, `xsi:`, `xml:`)
+
+---
+
+## SchemaModel
+
+O modelo intermediario e composto por records imutaveis:
+
+### SchemaDocument
+
+| Propriedade          | Tipo                              | Descricao                                         |
+|----------------------|-----------------------------------|----------------------------------------------------|
+| TargetNamespace      | `string`                          | Namespace principal do schema                      |
+| RootElementName      | `string`                          | Nome do elemento raiz (ex: `DPS`, `EnviarLoteRpsEnvio`) |
+| ComplexTypes         | `List<SchemaComplexType>`         | Todos os tipos complexos encontrados               |
+| RootInlineType       | `SchemaComplexType?`              | Tipo inline do elemento raiz, quando anonimo       |
+| NamespaceMap         | `Dictionary<string, string>?`     | Mapa prefixo -> URI de namespace                   |
+| RootVersionAttribute | `string?`                         | Valor fixo/default do atributo `versao` na raiz    |
+
+### SchemaComplexType
+
+| Propriedade | Tipo                       | Descricao                              |
+|-------------|----------------------------|----------------------------------------|
+| Name        | `string`                   | Nome do tipo (ou `_anon_ElementName`)  |
+| Elements    | `List<SchemaElement>`      | Elementos filhos                       |
+| Annotation  | `string?`                  | Documentacao do XSD                    |
+| Namespace   | `string?`                  | Namespace onde o tipo foi definido     |
+| Attributes  | `List<SchemaAttribute>?`   | Atributos XML do tipo complexo         |
+
+### SchemaElement
+
+| Propriedade | Tipo                           | Descricao                                  |
+|-------------|--------------------------------|--------------------------------------------|
+| Name        | `string`                       | Nome do elemento                           |
+| TypeName    | `string`                       | Nome do tipo referenciado                  |
+| IsRequired  | `bool`                         | `MinOccurs > 0` e nao e choice             |
+| MinOccurs   | `int`                          | Ocorrencia minima                          |
+| MaxOccurs   | `int`                          | Ocorrencia maxima (`-1` = unbounded)       |
+| IsChoice    | `bool`                         | Pertence a um grupo `xs:choice`            |
+| ChoiceGroup | `string?`                      | Identificador do grupo (ex: `choice_1`)    |
+| Restriction | `SchemaSimpleTypeRestriction?` | Restricoes do tipo simples                 |
+| InlineType  | `SchemaComplexType?`           | Tipo complexo anonimo inline               |
+
+### SchemaAttribute
+
+| Propriedade | Tipo     | Descricao                    |
+|-------------|----------|------------------------------|
+| Name        | `string` | Nome do atributo             |
+| TypeName    | `string` | Tipo do atributo             |
+| IsRequired  | `bool`   | `use="required"` no schema   |
+
+### SchemaSimpleTypeRestriction
+
+Captura facets de `xs:restriction`: `Pattern`, `MinLength`, `MaxLength`, `Enumerations` e `BaseType`.
+
+---
+
+## Tipos inline e o prefixo `_anon_`
+
+Quando um elemento raiz ou filho possui um tipo complexo anonimo (sem `name` no XSD),
+o analyzer gera um nome sintetico com o prefixo `_anon_` seguido do nome do elemento.
+
+Exemplo: o elemento `<DPS>` com tipo inline produz `_anon_DPS`.
+Isso permite que o serializer encontre o tipo pelo nome no `typeMap`.
+
+---
+
+## Multi-namespace e NamespaceMap
+
+Providers como o nacional possuem multiplos namespaces no mesmo schema set.
+O `BuildNamespaceMap` percorre todos os schemas compilados e monta um dicionario
+`prefix -> namespaceUri`:
+
+- Usa o prefixo declarado no XSD quando disponivel
+- Gera prefixos `ns1`, `ns2`, ... quando nao ha prefixo declarado
+- Ignora `xmldsig#` e namespaces vazios
+
+O serializer adiciona as declaracoes `xmlns:prefix` no elemento raiz e
+usa o namespace do tipo (nao do elemento) para emitir conteudo filho.
+
+---
+
+## SendXsdSelector
+
+Providers frequentemente possuem multiplos arquivos XSD (envio, retorno, tipos, cancelamento, etc.).
+O `SendXsdSelector` identifica qual e o XSD de envio usando heuristicas:
+
+**Prioridades de selecao:**
+
+| Prioridade | Patterns                                                                |
+|------------|-------------------------------------------------------------------------|
+| 1 (Exata)  | `servico_enviar`, `enviar`, `envio_lote`                               |
+| 2 (Forte)  | `RecepcionarLoteRps`, `GerarNfse`, `EnviarLoteRps`, `DPS_`, `Pedido`  |
+| 3 (Fallback)| `schema_nfse`, `nfse_`                                                |
+
+**Patterns de exclusao:** `resposta`, `retorno`, `consulta`, `cancelar`, `tipos_`, `cabecalho`,
+`TiposNFe`, `CompNfse`, `ConsultarNfse`, `SubstituirNfse`, entre outros.
+
+**Override:** Quando o `ProviderProfile.PrimaryXsdFile` esta definido, o selector usa
+diretamente esse arquivo, sem aplicar heuristicas.
+
+**Resultado:** `XsdSelectionResult` com `SelectedFile`, `IsAmbiguous`, `Candidates` e `Reason`.
+
+---
+
+## Como o serializer usa o modelo
+
+O `SchemaBasedXmlSerializer` recebe o `SchemaDocument`, um dicionario de dados
+(`Dictionary<string, object?>`) e um `IProviderRuleResolver`, e produz XML:
+
+1. **Localiza o root type** no `typeMap` pelo `rootComplexTypeName` (com fallback para `RootInlineType`)
+2. **Cria o elemento raiz** com o namespace e adiciona declaracoes de namespace adicionais
+3. **Emite o atributo `versao`** no root, se o tipo raiz o declara
+4. **`BuildComplexTypeContent`**: itera cada `SchemaElement` do tipo:
+   - Se e `choice`, delega para `EmitChoiceGroup` que seleciona o branch com dados
+   - Caso contrario, chama `EmitElement`
+5. **`EmitElement`**: decide entre elemento complexo e simples:
+   - **Complexo**: cria `XElement`, emite atributos via `EmitAttributes`, e recursa via `BuildComplexTypeContent`
+   - **Simples**: resolve valor do dicionario de dados, aplica `ApplyFormatting` (digitsOnly, padLeft, maxLength)
+   - Se nao ha valor, tenta `resolver.ResolveDefault`; se obrigatorio e sem default, registra erro
+6. **Elementos opcionais com apenas campos genericos** (`GenericReusableFields` como CNPJ, CEP, xNome)
+   sao suprimidos para evitar emitir containers vazios de significado
+
+---
+
+## Links relacionados
+
+- [Arquitetura](Arquitetura.md)
+- [Validacao Automatica](Validacao-Automatica.md)
+- [Regras de Provider](Regras-de-Provider.md)

--- a/docs/wiki/Evolucao-da-Solucao.md
+++ b/docs/wiki/Evolucao-da-Solucao.md
@@ -1,0 +1,132 @@
+# Evolução da Solução
+
+O projeto foi construído em 6 fases ao longo de 34 commits, inteiramente com assistência de IA. Cada fase adicionou uma camada de capacidade sobre a anterior, sem reescritas.
+
+---
+
+## Fase 1: Baseline Manual (commits #1 a #9)
+
+**Objetivo:** Criar um serializer manual funcional como ponto de partida.
+
+**O que foi construído:**
+- Configuração inicial do projeto com IA para refatoração (#1)
+- Specs e contratos YAML/OpenAPI (#2–#4)
+- Serializer manual nacional (`NationalDpsManualSerializer`) com ~900 linhas e 19 métodos de build (#5)
+- Implementação completa de IBS/CBS com sub-blocos avançados (#7–#8)
+- Integração de mapper, endpoint e testes (#8–#9)
+
+**Decisões-chave:**
+- Usar `XBuilder` como tecnologia de infraestrutura para geração XML
+- Manter o serializer manual como baseline/oracle para validação futura
+- Modelo canônico `DpsDocument` como representação única do domínio
+
+**Métricas:** 74% de cobertura XSD (92% campos obrigatórios), golden master XML como referência.
+
+---
+
+## Fase 2: Schema Engine (commits #10 a #18)
+
+**Objetivo:** Criar uma engine capaz de analisar XSDs e gerar XML em runtime, sem código manual por provider.
+
+**O que foi construído:**
+- `XsdSchemaAnalyzer` para leitura de XSD e produção de `SchemaModel` (#10–#11)
+- Geração de artefatos por provider e comparação com baseline manual (#12)
+- Prova de conceito com schemas ABRASF e GISSOnline (#13–#14)
+- Análise multiagente com MCP/LSP (#15)
+- `SchemaBasedXmlSerializer` para serialização runtime com `XElement` (#16)
+- `ServiceInvoiceSchemaDataBinder` para binding domínio→schema (#17)
+- Suporte a tipos inline anônimos, multi-namespace e path bindings multinível (#18)
+
+**Decisões-chave:**
+- Usar `XElement` (não XBuilder) no serializer runtime para nomes dinâmicos de elementos
+- Schema como fonte de verdade; regras externas complementam o que o XSD não expressa
+- Estrutura `providers/{name}/xsd/` + `providers/{name}/rules/` por provider
+
+**Métricas:** 4 providers com XML válido contra XSD (Nacional, ABRASF, GISSOnline, ISSNet). Suporte a choice, sequence, inline types, multi-namespace.
+
+---
+
+## Fase 3: Runtime Serializer (commits #19 a #22)
+
+**Objetivo:** Fazer o serializer runtime produzir XML completo a partir do modelo de domínio.
+
+**O que foi construído:**
+- Binding de `ServiceInvoice` para o serializer runtime (#19)
+- Suporte a tipos inline anônimos no runtime (#20)
+- Multi-namespace com elementos emitidos no namespace correto por tipo (#21)
+- Path bindings multinível para providers como ISSNet (#22)
+
+**Decisões-chave:**
+- Pipeline orquestrado: binding → serialização → validação XSD
+- Bindings configuráveis por provider via JSON
+- Dados de teste equivalentes a documentos reais do MongoDB
+
+**Métricas:** Pipeline completo funcionando para Nacional e ISSNet com validação XSD PASS.
+
+---
+
+## Fase 4: Provider Onboarding (commits #23 a #27)
+
+**Objetivo:** Permitir que novos providers sejam onboarded sem intervenção de desenvolvedor.
+
+**O que foi construído:**
+- `ProviderResolver` com resolução por código de município IBGE (#23)
+- `ProviderOnboardingValidator` com checks automáticos (#23)
+- `ProviderConfigGenerator` para auto-geração de configuração (#24)
+- `OperationalStatus` (SupportReady, SupportConfigOnly, NeedsEngineering) (#24)
+- `SendXsdSelector` para seleção inteligente de XSD de envio (#26)
+- 6 correções de onboarding para cobertura expandida (#27)
+
+**Decisões-chave:**
+- Provider resolve por município (código IBGE), não por nome
+- Auto-geração de `suggested-rules.json` para que o suporte ajuste sem código
+- Load test com 48 providers reais validou a abordagem
+
+**Métricas:** 48 providers testados em suite automatizada, 5/7 providers base totalmente operacionais, endpoint `POST /providers/onboard` funcional.
+
+---
+
+## Fase 5: API e Gestão (commits #28 a #29)
+
+**Objetivo:** Expor a engine via API REST com persistência e gestão de providers.
+
+**O que foi construído:**
+- API de gestão de providers com persistência MongoDB (#28)
+- Endpoints CRUD para providers e configurações (#28)
+- DSL de regras tipadas com auto-geração a partir do schema (#29)
+- Endpoints CRUD para regras e catálogo de campos disponíveis (#29)
+
+**Decisões-chave:**
+- MongoDB como store principal de providers e regras
+- Resolução em cadeia: MongoDB → Filesystem → Fallback Nacional
+- `TypedRuleResolver` para aplicação de regras tipadas no pipeline
+
+**Métricas:** API completa em http://localhost:5211 com Swagger, CRUD de providers e regras funcional.
+
+---
+
+## Fase 6: Fechamento do MVP (commits #30 a #32)
+
+**Objetivo:** Resolver os gaps restantes para que os 3 providers MVP (Nacional, ISSNet, GISSOnline) passem na validação XSD.
+
+**O que foi construído:**
+- Deep autogen com geração de regras aprofundada (#30)
+- Validação XSD com escopo por provider e diagnóstico enriquecido (#30)
+- `ValidationDiagnosticEnricher` para classificação automática de erros (#30)
+- Suporte a `xs:attribute` e detecção de envelope ABRASF (#31)
+- Correções de enum-to-code mappings, formato de data e campos ABRASF (#32)
+
+**Decisões-chave:**
+- Diagnóstico deve ser acionável: cada erro XSD é classificado e tem recomendação
+- Atributos XML (`xs:attribute`) são cidadãos de primeira classe na engine
+- MVP fechado com Nacional PASS (0 erros) e ISSNet/GISSOnline com gaps rastreados
+
+**Métricas:** 727 testes passando (611 unit + 116 integration), Nacional com 0 erros XSD, 7 providers no repositório.
+
+---
+
+**Páginas relacionadas:**
+- [Visão Geral do Produto](Visao-Geral-do-Produto.md)
+- [Arquitetura](Arquitetura.md)
+- [Providers Suportados](Providers-Suportados.md)
+- [Roadmap do Produto](Roadmap-do-Produto.md)

--- a/docs/wiki/Exemplos-de-Regras.md
+++ b/docs/wiki/Exemplos-de-Regras.md
@@ -1,0 +1,248 @@
+# Exemplos de Regras Tipadas
+
+Exemplos praticos de cada tipo de regra da DSL, mostrando o JSON da regra e o efeito no XML gerado.
+
+As regras sao configuradas via `PUT /api/v1/providers/{id}/rules` ou `POST /api/v1/providers/{id}/rules`.
+
+---
+
+## a) Binding simples — tpAmb
+
+Vincula o campo `tpAmb` do XML ao campo `Environment` do dominio.
+
+### Regra JSON
+
+```json
+{
+  "type": "Binding",
+  "target": "infDPS.tpAmb",
+  "source": "Environment"
+}
+```
+
+### Efeito no XML
+
+```xml
+<tpAmb>2</tpAmb>
+```
+
+> O valor `2` corresponde ao ambiente de homologacao. O campo `Environment` do dominio e resolvido automaticamente pela engine.
+
+---
+
+## b) Binding com formato — dhEmi
+
+Vincula o campo `dhEmi` ao campo `IssuedOn` do dominio, aplicando formatacao de data/hora com timezone.
+
+### Regra JSON
+
+```json
+{
+  "type": "Binding",
+  "target": "infDPS.dhEmi",
+  "source": "IssuedOn",
+  "format": "yyyy-MM-ddTHH:mm:sszzz"
+}
+```
+
+### Efeito no XML
+
+```xml
+<dhEmi>2026-01-20T10:00:00-03:00</dhEmi>
+```
+
+> O campo `format` aceita qualquer formato valido de DateTime do .NET. O formato `zzz` gera o offset UTC (ex: `-03:00`).
+
+---
+
+## c) Binding com constante — verAplic
+
+Emite um valor fixo no XML usando `sourceType: "constant"` e `constantValue`.
+
+### Regra JSON
+
+```json
+{
+  "type": "Binding",
+  "target": "infDPS.verAplic",
+  "sourceType": "constant",
+  "constantValue": "V_1.00.02"
+}
+```
+
+### Efeito no XML
+
+```xml
+<verAplic>V_1.00.02</verAplic>
+```
+
+> Constantes sao usadas para campos que possuem valor fixo independente dos dados de entrada (versao do aplicativo, codigo fixo do provider, etc.).
+
+---
+
+## d) @Id com BuildId — infDPS.@Id
+
+Gera o atributo `Id` do elemento `infDPS` usando a funcao especial `BuildId`, que compoe o identificador conforme o padrao nacional.
+
+### Regra JSON
+
+```json
+{
+  "type": "Binding",
+  "target": "infDPS.@Id",
+  "source": "BuildId"
+}
+```
+
+### Efeito no XML
+
+```xml
+<infDPS Id="DPS3550308212345678000199000000000010000000000001">
+```
+
+> O `BuildId` e uma funcao interna da engine que concatena: prefixo `DPS` + codigo IBGE + CNPJ + serie + numero, conforme a especificacao nacional. O target usa `@` para indicar que e um atributo XML e nao um elemento filho.
+
+---
+
+## e) Formatting — cTribNac
+
+Aplica transformacoes de formatacao: remove caracteres nao numericos e preenche com zeros a esquerda.
+
+### Regra JSON
+
+```json
+{
+  "type": "Formatting",
+  "target": "cTribNac",
+  "digitsOnly": true,
+  "padLeft": 6,
+  "padChar": "0",
+  "maxLength": 6
+}
+```
+
+### Entrada e saida
+
+| Valor de entrada | Apos `digitsOnly` | Apos `padLeft:6:0` | XML gerado |
+|------------------|-------------------|---------------------|------------|
+| `01.01` | `0101` | `000101` | `<cTribNac>000101</cTribNac>` |
+| `17.01` | `1701` | `001701` | `<cTribNac>001701</cTribNac>` |
+| `1` | `1` | `000001` | `<cTribNac>000001</cTribNac>` |
+
+### Campos de Formatting disponiveis
+
+| Campo | Tipo | Descricao |
+|-------|------|-----------|
+| `digitsOnly` | bool | Remove todos os caracteres nao numericos |
+| `padLeft` | int | Preenche com `padChar` a esquerda ate o tamanho indicado |
+| `padChar` | string | Caractere de preenchimento (default: `"0"`) |
+| `maxLength` | int | Trunca o valor apos formatacao |
+| `trim` | bool | Remove espacos em branco |
+
+---
+
+## f) Wrapper binding ABRASF — LoteRps.NumeroLote
+
+Para providers que usam o padrao ABRASF, as regras podem configurar elementos de envelope como `LoteRps`.
+
+### Regra JSON
+
+```json
+{
+  "type": "Binding",
+  "target": "LoteRps.NumeroLote",
+  "sourceType": "constant",
+  "constantValue": "1"
+}
+```
+
+### Efeito no XML
+
+```xml
+<LoteRps>
+  <NumeroLote>1</NumeroLote>
+  <!-- demais elementos do lote -->
+</LoteRps>
+```
+
+> Wrappers ABRASF como `LoteRps`, `InfRps`, `IdentificacaoRps` sao targets validos quando o schema XSD do provider os define.
+
+---
+
+## Outros exemplos uteis
+
+### Default com fallback
+
+```json
+{
+  "type": "Default",
+  "target": "infDPS.tpRetISSQN",
+  "source": "Values.RetentionType",
+  "fallbackValue": "1"
+}
+```
+
+Usa o valor de `RetentionType` do dominio; se nulo, emite `1`.
+
+### EnumMapping
+
+```json
+{
+  "type": "EnumMapping",
+  "target": "infDPS.tribISSQN",
+  "source": "Values.TaxationType",
+  "mappings": {
+    "WithinCity": "1",
+    "OutsideCity": "2",
+    "Immune": "3",
+    "Free": "4"
+  },
+  "defaultMapping": "1"
+}
+```
+
+Converte o enum `TaxationType` para os codigos numericos esperados pelo provider.
+
+### ConditionalEmission
+
+```json
+{
+  "type": "ConditionalEmission",
+  "target": "infDPS.pAliq",
+  "source": "Values.IssRate",
+  "action": "Emit",
+  "condition": {
+    "field": "Values.IssRate",
+    "operator": "GreaterThan",
+    "value": "0"
+  }
+}
+```
+
+Emite `pAliq` somente quando a aliquota de ISS e maior que zero.
+
+### Choice — CNPJ ou CPF
+
+```json
+{
+  "type": "Choice",
+  "target": "infDPS.prest",
+  "choiceField": "Provider.PersonType",
+  "options": {
+    "LegalEntity": {
+      "element": "CNPJ",
+      "source": "Provider.Cnpj",
+      "padLeft": 14,
+      "padChar": "0"
+    },
+    "Individual": {
+      "element": "CPF",
+      "source": "Provider.Cpf",
+      "padLeft": 11,
+      "padChar": "0"
+    }
+  }
+}
+```
+
+Seleciona `<CNPJ>` ou `<CPF>` conforme o tipo de pessoa do prestador.

--- a/docs/wiki/Exemplos-de-Requests-e-Responses.md
+++ b/docs/wiki/Exemplos-de-Requests-e-Responses.md
@@ -1,0 +1,273 @@
+# Exemplos de Requests e Responses
+
+Exemplos reais com payloads completos para os principais endpoints da API.
+
+**Base URL:** `http://localhost:5211`
+
+---
+
+## a) POST /api/v1/nfse/xml — Exemplo minimo
+
+Request com os campos obrigatorios: `provider`, `borrower`, `location` e dados do servico.
+
+### Request
+
+```bash
+curl -X POST http://localhost:5211/api/v1/nfse/xml \
+  -H "Content-Type: application/json" \
+  -d '{
+    "externalId": "NF-2026-001",
+    "provider": {
+      "federalTaxNumber": 12345678000199,
+      "municipalTaxNumber": "98765"
+    },
+    "borrower": {
+      "name": "Empresa Tomadora Ltda",
+      "federalTaxNumber": 98765432000188,
+      "address": {
+        "postalCode": "01310100",
+        "street": "Av Paulista",
+        "number": "1000",
+        "district": "Bela Vista",
+        "city": { "code": "3550308", "name": "Sao Paulo" },
+        "state": "SP"
+      }
+    },
+    "location": {
+      "postalCode": "01310100",
+      "street": "Av Paulista",
+      "number": "500",
+      "district": "Bela Vista",
+      "city": { "code": "3550308", "name": "Sao Paulo" },
+      "state": "SP"
+    },
+    "description": "Desenvolvimento de software sob demanda",
+    "servicesAmount": 5000.00,
+    "issuedOn": "2026-01-20T10:00:00-03:00",
+    "taxationType": "WithinCity",
+    "federalServiceCode": "01.01"
+  }'
+```
+
+### Response
+
+```json
+{
+  "externalId": "NF-2026-001",
+  "xml": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><DPS xmlns=\"http://www.sped.fazenda.gov.br/nfse\"><infDPS Id=\"DPS3550308123456780001990000000001\"><tpAmb>2</tpAmb><dhEmi>2026-01-20T10:00:00-03:00</dhEmi><verAplic>V_1.00.02</verAplic>...</infDPS></DPS>",
+  "rootElement": "DPS",
+  "generatedBy": "SchemaEngine",
+  "providerName": "nacional",
+  "municipalityCode": "3550308",
+  "isFallback": false,
+  "fallbackReason": null
+}
+```
+
+> **Nota:** O campo `xml` foi truncado para legibilidade. O XML real contem todos os elementos conforme as regras do provider resolvido.
+
+---
+
+## b) POST /api/v1/providers — Criar provider com 4 XSDs
+
+Exemplo de criacao de um provider nacional com multiplos arquivos XSD e municipios atribuidos.
+
+### Request
+
+```bash
+curl -X POST http://localhost:5211/api/v1/providers \
+  -F "name=issnet-goiania" \
+  -F "xsdFiles[]=@servico_enviar_lote_rps_envio.xsd" \
+  -F "xsdFiles[]=@tipos_complexos_v1.xsd" \
+  -F "xsdFiles[]=@tipos_simples_v1.xsd" \
+  -F "xsdFiles[]=@cabecalho_v1.xsd" \
+  -F "municipalityCodes=5208707" \
+  -F "primaryXsdFile=servico_enviar_lote_rps_envio.xsd"
+```
+
+### Response (201 Created)
+
+```json
+{
+  "id": "665f1a2b3c4d5e6f7a8b9c0d",
+  "name": "issnet-goiania",
+  "version": "1.0",
+  "status": "Ready",
+  "blockReason": null,
+  "xsdFileNames": [
+    "servico_enviar_lote_rps_envio.xsd",
+    "tipos_complexos_v1.xsd",
+    "tipos_simples_v1.xsd",
+    "cabecalho_v1.xsd"
+  ],
+  "municipalityCodes": ["5208707"],
+  "hasRulesConfig": true,
+  "typedRuleCount": 18,
+  "primaryXsdFile": "servico_enviar_lote_rps_envio.xsd",
+  "validationCount": 1,
+  "createdAt": "2026-01-20T14:30:00-03:00",
+  "updatedAt": "2026-01-20T14:30:00-03:00"
+}
+```
+
+> **Nota:** O `status` sera `Ready` quando a validacao automatica passar. Se falhar, sera `Blocked` com o campo `blockReason` preenchido.
+
+---
+
+## c) Response de validacao com pendingFields
+
+Quando a validacao detecta campos ausentes no schema, retorna sugestoes de mapeamento com diferentes niveis de confianca.
+
+### Request
+
+```bash
+curl -X POST http://localhost:5211/api/v1/providers/665f1a2b3c4d5e6f7a8b9c0d/validate
+```
+
+### Response (200 OK — Blocked)
+
+```json
+{
+  "passed": false,
+  "checks": [
+    {
+      "name": "XsdSelection",
+      "passed": true,
+      "detail": "Selected: servico_enviar_lote_rps_envio.xsd"
+    },
+    {
+      "name": "SchemaAnalysis",
+      "passed": true,
+      "detail": "Analyzed 4 complex types, 22 elements"
+    },
+    {
+      "name": "XmlSerialization",
+      "passed": false,
+      "detail": "3 required fields missing in generated XML"
+    },
+    {
+      "name": "XsdValidation",
+      "passed": false,
+      "detail": "XML failed validation against schema: element 'Numero' is required"
+    }
+  ],
+  "blockReason": "XML gerado nao passou na validacao contra o schema",
+  "timestamp": "2026-01-20T14:35:00-03:00",
+  "pendingFields": [
+    {
+      "fieldPath": "InfRps.Numero",
+      "isRequired": true,
+      "suggestedSource": "Number",
+      "confidence": "Exact",
+      "reason": "Nome identico ao campo do dominio"
+    },
+    {
+      "fieldPath": "InfRps.Serie",
+      "isRequired": true,
+      "suggestedSource": "RpsSerialNumber",
+      "confidence": "Partial",
+      "reason": "Nome parcialmente similar: Serie ~ SerialNumber"
+    },
+    {
+      "fieldPath": "InfRps.DataEmissao",
+      "isRequired": true,
+      "suggestedSource": null,
+      "confidence": "None",
+      "reason": "Nenhuma correspondencia encontrada no dominio"
+    }
+  ]
+}
+```
+
+### Niveis de confianca (`confidence`)
+
+| Nivel | Significado | Acao recomendada |
+|-------|-------------|------------------|
+| `Exact` | Correspondencia exata com campo do dominio | Aceitar sugestao diretamente |
+| `Partial` | Nome parcialmente similar | Revisar antes de aceitar |
+| `None` | Sem correspondencia encontrada | Requer mapeamento manual (binding com constante ou campo customizado) |
+
+---
+
+## d) Response de POST /nfse/xml com fallback
+
+Quando o municipio informado nao esta atribuido a nenhum provider, a engine usa o provider nacional como fallback.
+
+### Request
+
+```bash
+curl -X POST http://localhost:5211/api/v1/nfse/xml \
+  -H "Content-Type: application/json" \
+  -d '{
+    "externalId": "NF-2026-002",
+    "provider": {
+      "federalTaxNumber": 11222333000144
+    },
+    "borrower": {
+      "name": "Tomador Teste",
+      "federalTaxNumber": 55666777000155,
+      "address": {
+        "postalCode": "69900000",
+        "street": "Rua Principal",
+        "number": "10",
+        "district": "Centro",
+        "city": { "code": "1200401", "name": "Rio Branco" },
+        "state": "AC"
+      }
+    },
+    "location": {
+      "postalCode": "69900000",
+      "street": "Rua Exemplo",
+      "number": "50",
+      "district": "Centro",
+      "city": { "code": "1200401", "name": "Rio Branco" },
+      "state": "AC"
+    },
+    "description": "Servico de manutencao",
+    "servicesAmount": 800.00,
+    "issuedOn": "2026-02-15T09:00:00-05:00",
+    "taxationType": "WithinCity",
+    "federalServiceCode": "14.01"
+  }'
+```
+
+### Response (200 OK — Fallback)
+
+```json
+{
+  "externalId": "NF-2026-002",
+  "xml": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><DPS xmlns=\"http://www.sped.fazenda.gov.br/nfse\"><infDPS Id=\"DPS1200401112223330001440000000001\"><tpAmb>2</tpAmb><dhEmi>2026-02-15T09:00:00-05:00</dhEmi>...</infDPS></DPS>",
+  "rootElement": "DPS",
+  "generatedBy": "SchemaEngine",
+  "providerName": "nacional",
+  "municipalityCode": "1200401",
+  "isFallback": true,
+  "fallbackReason": "Nenhum provider encontrado para o municipio 1200401"
+}
+```
+
+> **Nota:** Quando `isFallback` e `true`, significa que o municipio nao foi atribuido a nenhum provider especifico. Para usar um provider customizado, atribua o municipio via `POST /api/v1/providers/{id}/municipalities`.
+
+---
+
+## Campos opcionais do request de NFS-e
+
+O request de geracao de XML aceita diversos campos opcionais alem dos obrigatorios:
+
+| Campo | Tipo | Descricao |
+|-------|------|-----------|
+| `cityServiceCode` | string | Codigo de servico municipal |
+| `cnaeCode` | string | Codigo CNAE |
+| `issRate` | decimal | Aliquota do ISS |
+| `issTaxAmount` | decimal | Valor do ISS |
+| `issAmountWithheld` | decimal | ISS retido |
+| `retentionType` | string | `NotWithheld`, `WithheldByBuyer`, `WithheldByIntermediary` |
+| `deductionsAmount` | decimal | Valor de deducoes |
+| `discountUnconditionedAmount` | decimal | Desconto incondicionado |
+| `discountConditionedAmount` | decimal | Desconto condicionado |
+| `additionalInformation` | string | Informacoes complementares |
+| `rpsNumber` | long | Numero do RPS |
+| `rpsSerialNumber` | string | Serie do RPS |
+| `nbsCode` | string | Codigo NBS |
+| `intermediary` | object | Dados do intermediario |
+| `ibsCbs` | object | Grupo IBS/CBS |

--- a/docs/wiki/Fluxo-End-to-End.md
+++ b/docs/wiki/Fluxo-End-to-End.md
@@ -1,0 +1,163 @@
+# Fluxo End-to-End
+
+Este documento descreve o fluxo completo de geração de XML de NFS-e, desde o request HTTP até a resposta com o XML validado.
+
+## Endpoint
+
+```
+POST /nfse/xml
+Content-Type: application/json
+```
+
+## Diagrama do fluxo
+
+```
+Cliente HTTP
+    │
+    │  POST /nfse/xml { provider, borrower, service, values, ... }
+    ▼
+┌──────────────────┐
+│  API Controller   │
+│  (deserializa     │
+│   request JSON)   │
+└────────┬─────────┘
+         │
+         ▼
+┌──────────────────┐
+│  Mapper           │
+│  (Request →       │
+│   DpsDocument)    │
+└────────┬─────────┘
+         │
+         ▼
+┌──────────────────┐
+│ ProviderResolver  │  ← código município IBGE
+│ (MongoDB →        │  ← filesystem fallback
+│  Filesystem →     │  ← fallback Nacional
+│  Nacional)        │
+└────────┬─────────┘
+         │
+         ▼
+┌──────────────────────────────────────────────────┐
+│          SchemaSerializationPipeline              │
+│                                                  │
+│  1. SendXsdSelector                              │
+│     └─ Seleciona o XSD de envio correto          │
+│                                                  │
+│  2. XsdSchemaAnalyzer                            │
+│     └─ Analisa XSD → SchemaModel                 │
+│        (elementos, tipos, sequences, choices,    │
+│         inline types, atributos, namespaces)     │
+│                                                  │
+│  3. TypedRuleResolver                            │
+│     └─ Carrega e aplica regras tipadas           │
+│        (field mappings, value transforms,        │
+│         conditional emit, fixed values)          │
+│                                                  │
+│  4. ServiceInvoiceSchemaDataBinder               │
+│     └─ DpsDocument → dicionário de dados         │
+│        (mapeia campos do domínio para paths      │
+│         do schema usando CommonFieldMapping      │
+│         + regras do provider)                    │
+│                                                  │
+│  5. SchemaBasedXmlSerializer                     │
+│     └─ SchemaModel + dados → XML (XElement)      │
+│        (resolve choices, sequences, namespaces,  │
+│         tipos inline, atributos, enums)          │
+│                                                  │
+│  6. XsdValidator                                 │
+│     └─ XML gerado → validação contra XSD         │
+│        original do provider                      │
+│                                                  │
+│  7. ValidationDiagnosticEnricher (se houver erro)│
+│     └─ Classifica erros: ConfigurationGap,       │
+│        EngineGap, InputError, SchemaError         │
+│     └─ Gera recomendações acionáveis             │
+└────────┬─────────────────────────────────────────┘
+         │
+         ▼
+┌──────────────────┐
+│ NfseXmlGeneration │
+│ Result            │
+│ ├─ Xml (string)   │
+│ ├─ IsValid (bool) │
+│ ├─ Errors []      │
+│ └─ Diagnostics [] │
+└────────┬─────────┘
+         │
+         ▼
+┌──────────────────┐
+│  Response HTTP    │
+│  200 OK + XML     │
+│  ou 422 + erros   │
+└──────────────────┘
+```
+
+## Passo a passo detalhado
+
+### 1. Request recebido
+
+O cliente envia um JSON com os dados da NFS-e: provider (ou código do município), prestador, tomador, serviço, valores, impostos (IBS/CBS), etc.
+
+### 2. Mapper
+
+O request é convertido para `DpsDocument`, o modelo canônico do domínio. Todos os campos são normalizados e validados nesse ponto.
+
+### 3. Resolução de provider
+
+O `ProviderResolver` identifica qual provider atende o município informado. A busca segue a cadeia: MongoDB → Filesystem → Fallback Nacional.
+
+### 4. Seleção de XSD
+
+O `SendXsdSelector` identifica qual dos XSDs do provider é o schema de envio (não o de resposta ou de tipos auxiliares). Isso é necessário porque muitos providers fornecem múltiplos arquivos XSD.
+
+### 5. Análise do schema
+
+O `XsdSchemaAnalyzer` lê o XSD selecionado e constrói um `SchemaModel` com toda a estrutura: elementos, tipos complexos, sequences, choices, inline types anônimos, atributos e namespaces.
+
+### 6. Aplicação de regras
+
+O `TypedRuleResolver` carrega as regras tipadas do provider e as aplica. Regras podem definir mapeamentos de campo, transformações de valor, emissão condicional e valores fixos.
+
+### 7. Data binding
+
+O `ServiceInvoiceSchemaDataBinder` converte o `DpsDocument` em um dicionário chave-valor onde as chaves são paths do schema (ex.: `infDPS/prest/CNPJ`). Usa o `CommonFieldMappingDictionary` como base e sobrescreve com mapeamentos específicos do provider.
+
+### 8. Serialização XML
+
+O `SchemaBasedXmlSerializer` percorre o `SchemaModel` e, para cada elemento, busca o valor no dicionário de dados. Gera `XElement` dinâmicos respeitando a estrutura, namespaces e choices do XSD.
+
+### 9. Validação XSD
+
+O `XsdValidator` valida o XML gerado contra o XSD original do provider. Qualquer erro estrutural é capturado.
+
+### 10. Diagnóstico (se houver erros)
+
+O `ValidationDiagnosticEnricher` classifica cada erro XSD em categorias acionáveis:
+
+| Classificação | Significado | Ação |
+|--------------|-------------|------|
+| `ConfigurationGap` | Falta configuração de regras ou bindings | Suporte ajusta rules.json |
+| `EngineGap` | Limitação da engine atual | Desenvolvimento necessário |
+| `InputError` | Dados de entrada inválidos ou ausentes | Cliente corrige o request |
+| `SchemaError` | XSD com problema ou incompatibilidade | Investigar schema do provider |
+
+## O que acontece quando dá erro
+
+| Etapa | Tipo de erro | Comportamento |
+|-------|-------------|---------------|
+| Mapper | Campo obrigatório ausente | Retorna 400 Bad Request |
+| ProviderResolver | Provider não encontrado | Usa fallback Nacional |
+| SendXsdSelector | Nenhum XSD de envio encontrado | Retorna erro com diagnóstico |
+| XsdSchemaAnalyzer | XSD inválido ou corrompido | Retorna erro com detalhes do parse |
+| DataBinder | Campo sem mapeamento | Elemento omitido no XML (pode causar erro XSD) |
+| Serializer | Tipo não suportado | Registra gap e continua |
+| XsdValidator | XML inválido | Retorna 200 com `IsValid=false` e lista de erros classificados |
+
+---
+
+**Páginas relacionadas:**
+- [Arquitetura](Arquitetura.md)
+- [Engine e Interpretação de XSD](Engine-e-Interpretacao-de-XSD.md)
+- [Validação Automática](Validacao-Automatica.md)
+- [Status e Classificação de Gaps](Status-e-Classificacao-de-Gaps.md)

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,0 +1,33 @@
+# Wiki — SemanaIA NFSe Engine
+
+Documentação completa do motor de geração de XML de NFS-e orientado por schema XSD.
+
+---
+
+## Produto
+- [Visão Geral do Produto](Visao-Geral-do-Produto.md)
+- [Evolução da Solução](Evolucao-da-Solucao.md)
+- [Providers Suportados](Providers-Suportados.md)
+- [Roadmap do Produto](Roadmap-do-Produto.md)
+
+## Arquitetura e Engine
+- [Arquitetura](Arquitetura.md)
+- [Fluxo End-to-End](Fluxo-End-to-End.md)
+- [Engine e Interpretação de XSD](Engine-e-Interpretacao-de-XSD.md)
+- [Validação Automática](Validacao-Automatica.md)
+- [Status e Classificação de Gaps](Status-e-Classificacao-de-Gaps.md)
+
+## Gestão de Providers
+- [Cadastro de Providers](Cadastro-de-Providers.md)
+- [Regras de Provider](Regras-de-Provider.md)
+- [API de Gestão de Providers](API-de-Gestao-de-Providers.md)
+- [Exemplos de Requests e Responses](Exemplos-de-Requests-e-Responses.md)
+- [Exemplos de Regras](Exemplos-de-Regras.md)
+
+## Suporte
+- [Onboarding de Provider pelo Suporte](Onboarding-de-Provider-pelo-Suporte.md)
+
+## IA e Apresentação
+- [Jornada de IA no Projeto](Jornada-de-IA-no-Projeto.md)
+- [Lições Aprendidas](Licoes-Aprendidas.md)
+- [Material para Apresentação](Material-para-Apresentacao.md)

--- a/docs/wiki/Jornada-de-IA-no-Projeto.md
+++ b/docs/wiki/Jornada-de-IA-no-Projeto.md
@@ -1,0 +1,521 @@
+# Jornada de IA no Projeto NFSe
+
+> 34 commits, 727 testes, 48 providers, 3 MVPs.
+> Construído com Claude Code CLI + Cursor IDE.
+> Orquestração multi-agente com spec-agent, implementation-agent, unit-test-agent, xml-test-agent e review-agent.
+
+---
+
+## Índice
+
+1. [Terminal / IDE](#1-terminal--ide)
+2. [Docker](#2-docker)
+3. [Assistente (Par Programmer)](#3-assistente-par-programmer)
+4. [Agente Único](#4-agente-único)
+5. [Multi Agentes](#5-multi-agentes)
+6. [Agent Skills](#6-agent-skills)
+7. [MCP / LSP](#7-mcp--lsp)
+8. [Tools / Plugins](#8-tools--plugins)
+9. [Commands](#9-commands)
+10. [Scheduling](#10-scheduling)
+
+---
+
+## 1. Terminal / IDE
+
+### O que é
+
+Claude Code CLI é uma interface de terminal que permite interagir com modelos de linguagem diretamente do prompt de comando. Cursor IDE complementa como editor com completions inteligentes e integração nativa com IA. Juntos, formam o ambiente de desenvolvimento principal do projeto.
+
+### Como foi usado
+
+O Claude Code CLI foi a interface principal para todas as decisões de arquitetura, geração de código e execução de tarefas complexas. Cursor IDE atuou como complemento para navegação de código, completions rápidas e edições pontuais.
+
+O fluxo típico era:
+
+1. Abrir o terminal no diretório do projeto
+2. Descrever a tarefa desejada em linguagem natural
+3. Claude Code gera código, testes e configurações
+4. Cursor IDE refina detalhes e fornece completions contextuais
+
+### Exemplo concreto: SchemaSerializationPipeline (#19)
+
+O componente `SchemaSerializationPipeline` nasceu de um prompt direto no Claude Code CLI:
+
+```
+"Criar um pipeline de serialização que leia XSD em runtime,
+resolva tipos complexos e gere XML válido para qualquer provider"
+```
+
+O resultado foi a classe `SchemaSerializationPipeline.cs` no namespace `SemanaIA.ServiceInvoice.XmlGeneration.SchemaEngine`, que orquestra todo o fluxo de serialização runtime. O PR #19 (`feat(engine): bind serviceinvoice to runtime schema serializer`) conectou essa pipeline ao domínio do ServiceInvoice.
+
+A diferença entre ter o CLI no terminal versus usar apenas chat web é brutal: o contexto do projeto inteiro está disponível, o agente pode ler arquivos, executar testes e validar o resultado sem sair do fluxo.
+
+### Cursor IDE como complemento
+
+Cursor brilhou em cenários de micro-edição: renomear variáveis, completar signatures de métodos, navegar entre referências. O completion contextual entendia o padrão do projeto (por exemplo, sugerir `Shouldly` assertions em testes) porque tinha acesso ao código circundante.
+
+---
+
+## 2. Docker
+
+### O que é
+
+Docker permite executar serviços em containers isolados. No projeto, o `docker-compose.yml` configura um MongoDB local para persistência de providers e testes de integração.
+
+### Como foi usado
+
+O MongoDB sobe via `docker-compose up -d` e serve como backend para a API de providers. Os testes de integração usam `WebApplicationFactory` com MongoDB real — não mocks. Isso garante que serialization, persistência e validação XSD funcionem de ponta a ponta.
+
+```yaml
+# docker-compose.yml — MongoDB para testes e desenvolvimento
+services:
+  mongodb:
+    image: mongo:7
+    ports:
+      - "27017:27017"
+```
+
+### Exemplo concreto: Provider Management API (#28)
+
+No PR #28 (`feat(api): add provider management API with MongoDB persistence`), a API de gerenciamento de providers foi criada com persistência em MongoDB. Os testes de integração usam `WebApplicationFactory<Program>` que conecta ao MongoDB real rodando no Docker:
+
+```csharp
+// IntegrationTests com MongoDB real
+public class ProviderApiTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    // POST /providers com 4 XSDs → MongoDB → validação
+}
+```
+
+Esse approach evita a fragilidade de mocks de banco. Se o MongoDB muda comportamento, o teste pega. Se a serialização quebra na ida ou volta, o teste pega. A IA sugeriu esse approach depois de avaliar que mocks de `IMongoCollection<T>` seriam frágeis e não validariam o pipeline real.
+
+### CI com MongoDB
+
+O GitHub Actions CI (`ci.yml`) também sobe MongoDB como service container, garantindo que os mesmos testes de integração rodam no pipeline automatizado.
+
+---
+
+## 3. Assistente (Par Programmer)
+
+### O que é
+
+Neste modo, a IA atua como um colega de trabalho — discutindo decisões, avaliando trade-offs e propondo alternativas. Não executa autonomamente; contribui para a decisão humana.
+
+### Como foi usado
+
+As decisões arquiteturais mais importantes do projeto nasceram de sessões de pair programming com a IA:
+
+**Decisão 1: Runtime vs Build-time**
+
+O projeto começou com geração build-time (PRs #16 e #17). A IA foi instrumental ao avaliar os trade-offs:
+
+- Build-time gera código C# estático a partir de XSD → precisa recompilar para cada provider
+- Runtime lê XSD em tempo de execução → adicionar provider é configuração, não código
+
+A decisão de migrar para runtime (#18) veio de uma sessão onde discutimos escalabilidade: "Se temos 48 providers e cada um pode ter atualizações de schema, recompilar não escala."
+
+**Decisão 2: Resolução por município**
+
+O sistema de NFSe brasileiro é municipalizado — cada cidade pode usar um provider diferente. A resolução por código IBGE do município (#23) nasceu de uma conversa onde a IA mapeou o problema:
+
+```
+Humano: "Como resolver qual provider usar?"
+IA: "O vinculo natural é município → provider.
+     O código IBGE é único e estável."
+```
+
+**Decisão 3: CommonFieldMappingDictionary**
+
+O `CommonFieldMappingDictionary.cs` é um dicionário que mapeia campos do domínio para paths XSD. Nasceu de uma sessão onde a IA identificou que os mesmos 40+ campos apareciam em quase todos os providers com paths levemente diferentes:
+
+```
+"Se 80% dos campos são comuns com variações de path,
+ um dicionário base com override por provider elimina
+ 80% do trabalho de onboarding."
+```
+
+Esse componente (`src/SemanaIA.ServiceInvoice.XmlGeneration/SchemaEngine/CommonFieldMappingDictionary.cs`) se tornou a base do auto-generation de configurações.
+
+### O valor do par
+
+A IA como par programmer não substitui decisão humana. Ela acelera a análise de trade-offs, traz referências de padrões e identifica duplicações antes que virem dívida técnica. O humano mantém a palavra final.
+
+---
+
+## 4. Agente Único
+
+### O que é
+
+O agente único é a IA operando de forma autônoma para completar uma tarefa end-to-end: ler contexto, planejar, implementar, testar e validar. Diferente do assistente, aqui a IA executa sem parar para pedir confirmação em cada etapa.
+
+### Como foi usado
+
+Tarefas bem delimitadas eram delegadas ao agente único. O escopo precisa ser claro, o critério de sucesso precisa ser mensurável (testes passando, XSD válido).
+
+### Exemplo concreto: Multi-namespace (#21)
+
+O PR #21 (`feat(engine): add multi-namespace support to runtime serializer`) é o exemplo canônico de agente único em ação. O problema: providers como ABRASF usam múltiplos namespaces XML (ex: `tc:` para tipos comuns, `nfse:` para nota fiscal). O serializer original só lidava com um namespace.
+
+Em uma única sessão, o agente:
+
+1. **Leu** os XSDs de providers multi-namespace para entender a estrutura
+2. **Analisou** o `RuntimeSchemaSerializer` existente e identificou onde a limitação estava
+3. **Modificou** o analyzer para extrair e preservar namespace bindings de cada schema importado
+4. **Modificou** o serializer para emitir prefixos de namespace corretos baseado no tipo do elemento
+5. **Criou** testes unitários cobrindo cenários de 1, 2 e 3 namespaces
+6. **Executou** a suíte completa e validou que nenhum teste existente quebrou
+
+Tudo isso em uma sessão contínua, sem intervenção humana entre etapas. O commit `53bb079` mostra o diff completo.
+
+### Quando funciona vs quando não funciona
+
+Agente único funciona quando:
+- O escopo é bem definido ("adicionar suporte a X")
+- O critério de sucesso é objetivo ("testes passando")
+- Não há ambiguidade de negócio
+
+Não funciona quando:
+- Há trade-offs de arquitetura que precisam de decisão humana
+- A tarefa envolve múltiplas camadas com riscos de conflito
+- O escopo é vago ("melhorar performance")
+
+---
+
+## 5. Multi Agentes
+
+### O que é
+
+Orquestração multi-agente é o uso coordenado de agentes especializados, cada um responsável por uma etapa do processo. No projeto, 5 agentes trabalham em sequência:
+
+| Agente | Responsabilidade |
+|--------|-----------------|
+| **spec-agent** | Analisa requisitos, define contratos, propõe design |
+| **implementation-agent** | Implementa código seguindo SOLID e Clean Code |
+| **unit-test-agent** | Cria testes xUnit + Shouldly com nomenclatura `Given_Should` |
+| **xml-test-agent** | Testa serialização XML com validação XSD |
+| **review-agent** | Revisa código, verifica aderência a padrões, valida coesão |
+
+### Como foi usado
+
+Para mudanças complexas que tocam múltiplas camadas, o orquestrador aciona agentes em sequência. Cada agente recebe o output do anterior como contexto.
+
+### Exemplo concreto: Typed Rule DSL (#29)
+
+O PR #29 (`feat(engine): add typed rule DSL with auto-generation, CRUD endpoints, and catalog API`) é a referência de orquestração multi-agente. O problema: providers precisavam de regras específicas (formatação de data, mapeamento de enum, campos opcionais) e essas regras estavam hardcoded.
+
+**Fase 1 — spec-agent:**
+Analisou os 48 providers e identificou 7 categorias de regras recorrentes. Propôs a DSL tipada com `TypedRuleResolver` como resolvedor central.
+
+**Fase 2 — implementation-agent:**
+Implementou `TypedRuleResolver.cs` no namespace `SchemaEngine`, os endpoints CRUD para gerenciar regras por provider, e o catalog API que lista regras disponíveis.
+
+**Fase 3 — unit-test-agent:**
+Criou `TypedRuleResolverTests.cs` e `TypedRuleIntegrationTests.cs` cobrindo:
+- Resolução de regras por provider
+- Fallback para regras default
+- Override de regras específicas
+- Validação de tipos incompatíveis
+
+**Fase 4 — xml-test-agent:**
+Validou que regras aplicadas (ex: formato de data `yyyy-MM-dd` vs `dd/MM/yyyy`) geravam XML válido contra o XSD do provider.
+
+**Fase 5 — review-agent:**
+Revisou a coesão: regras no lugar certo? Nomeação orientada ao domínio? Sem acoplamento desnecessário?
+
+### O resultado
+
+O `TypedRuleResolver` permite que suporte técnico ajuste regras de provider sem envolver desenvolvimento. É configuração, não código. Isso é transformador para operação em escala.
+
+### Fluxo visual
+
+```
+spec-agent → implementation-agent → unit-test-agent → xml-test-agent → review-agent
+    ↓              ↓                      ↓                 ↓              ↓
+  design       código SOLID          testes Given_Should   XSD válido    aprovação
+```
+
+---
+
+## 6. Agent Skills
+
+### O que é
+
+Agent Skills são capacidades especializadas registradas no sistema de agentes. Funcionam como "receitas" que agentes podem invocar para tarefas padronizadas. No projeto, skills como `/opsx:propose` e `/opsx:apply-orchestrate` encapsulam fluxos complexos.
+
+### Como foi usado
+
+O `CLAUDE.md` na raiz do projeto define as regras que todos os agentes devem seguir:
+
+```markdown
+## Comandos de aplicação
+- Usar `/opsx-apply` para mudanças simples, localizadas e de baixo impacto.
+- Usar `/opsx-apply-orchestrated` para mudanças relevantes, com múltiplas etapas.
+```
+
+Isso garante consistência entre agentes. Quando o spec-agent propõe uma mudança e o implementation-agent executa, ambos seguem as mesmas convenções de SOLID, Clean Code, e nomenclatura.
+
+### Skills registradas
+
+| Skill | Propósito |
+|-------|-----------|
+| `/opsx:propose` | Propor mudança com análise de impacto antes de implementar |
+| `/opsx:apply` | Aplicar mudança simples e localizada |
+| `/opsx:apply-orchestrate` | Aplicar mudança complexa com pipeline multi-agente |
+
+### Exemplo concreto: Consistência de padrões
+
+O `CLAUDE.md` estabelece regras como:
+
+- "Não criar `UseCase` por padrão"
+- "Evitar classes genéricas como `Helper`, `Utils`, `Manager`"
+- "Preferir classes especializadas com nomes orientados ao domínio"
+
+Quando o implementation-agent criou o `TypedRuleResolver` (#29), o nome foi orientado ao domínio. Sem o `CLAUDE.md`, poderia ter sido `RuleManager`, `RuleHelper` ou `RuleProcessor` — nomes genéricos que o review-agent rejeitaria.
+
+### O impacto
+
+Skills transformam conhecimento tácito em processo explícito. Qualquer agente novo que entre no projeto lê o `CLAUDE.md` e sabe exatamente como operar. Isso é escalabilidade de processo, não só de código.
+
+---
+
+## 7. MCP / LSP
+
+### O que é
+
+**MCP (Model Context Protocol)** é um protocolo que permite conectar servidores de contexto aos agentes de IA. **LSP (Language Server Protocol)** fornece análise semântica de código. Juntos, ampliam o conhecimento disponível para os agentes.
+
+### Como foi usado
+
+O projeto configura três fontes de contexto MCP:
+
+| Servidor MCP | Propósito |
+|-------------|-----------|
+| `mcp-spec-server` (local) | Serve specs do projeto, schemas XSD, e regras de provider |
+| `microsoft-docs` | Documentação oficial de `XmlSchemaSet`, `XmlSerializer`, `System.Xml` |
+| `context7` | Documentação atualizada de xUnit, Shouldly, e outras libs |
+
+### mcp-spec-server local
+
+O diretório `ia/mcp-spec-server/` contém um servidor MCP TypeScript que expõe:
+
+- Schemas XSD dos 48 providers
+- Specs de serialização
+- Regras de mapeamento de campos
+
+Quando um agente precisa entender "como o provider GissOnline mapeia campos de serviço", consulta o mcp-spec-server em vez de ler arquivos manualmente.
+
+### microsoft-docs para XmlSchemaSet
+
+A decisão de usar `XmlSchemaSet` para validação runtime veio de consulta ao MCP microsoft-docs:
+
+```
+Consulta: "XmlSchemaSet validate XML against multiple XSD with imports"
+Resultado: Documentação oficial com exemplos de Add(), Compile(), Validate()
+```
+
+Isso foi crítico no PR #30 (`feat(engine): add deep autogen, scoped XSD validation`) onde a validação XSD precisava lidar com schemas que importam outros schemas.
+
+### context7 para xUnit
+
+O agente de testes consulta `context7` para padrões atualizados de xUnit e Shouldly. Exemplo: confirmar que `Should.Throw<T>` é a forma idiomática versus `Assert.Throws<T>` no contexto Shouldly.
+
+### LSP no fluxo
+
+O PR #11 (`feat(mcp/lsp): add MCP and LSP configuration`) configurou a integração LSP para fornecer:
+- Diagnósticos de compilação em tempo real
+- Navegação de referências para os agentes
+- Type information para decisões de implementação
+
+---
+
+## 8. Tools / Plugins
+
+### O que é
+
+Tools e plugins são integrações externas que os agentes podem invocar durante o trabalho. Vão além do código: interagem com GitHub, buscam documentação web, criam PRs.
+
+### Como foi usado
+
+| Ferramenta | Uso no projeto |
+|-----------|---------------|
+| **GitHub CLI (`gh`)** | Criar PRs, listar issues, verificar status de CI |
+| **Firecrawl** | Crawl de documentação de providers (portais de prefeitura) |
+| **dotnet CLI** | Build, test, run |
+| **git** | Commits, branches, diffs |
+
+### GitHub CLI para PRs
+
+Todos os 29+ PRs foram criados via `gh pr create`. O agente gera título, corpo com summary e test plan, e submete:
+
+```bash
+gh pr create --title "feat(engine): add typed rule DSL" --body "## Summary
+- Add TypedRuleResolver for configurable provider rules
+- Add CRUD endpoints for rule management
+- Add catalog API for available rules
+
+## Test plan
+- [x] TypedRuleResolverTests (unit)
+- [x] TypedRuleIntegrationTests (integration)
+- [x] XSD validation with rules applied"
+```
+
+### Firecrawl para docs de providers
+
+Alguns providers têm documentação dispersa em portais de prefeitura. Firecrawl foi usado para extrair especificações de XML, campos obrigatórios e regras de negócio diretamente dessas páginas. Esse conteúdo alimentou o mcp-spec-server.
+
+### Exemplo concreto: PRs automatizados
+
+O fluxo típico de PR:
+
+1. Agente implementa a mudança
+2. Executa `dotnet test` para validar
+3. Cria branch com nome descritivo
+4. Faz commit com mensagem padronizada
+5. Abre PR via `gh pr create`
+6. CI roda automaticamente
+
+Do commit `74a383a` (simulação sem IA) ao commit `416bed9` (docs completas), todos os PRs seguiram esse fluxo automatizado.
+
+---
+
+## 9. Commands
+
+### O que é
+
+Commands são invocações diretas que o desenvolvedor faz para acionar comportamentos específicos dos agentes. São a interface de comunicação entre humano e sistema de IA.
+
+### Como foi usado
+
+Três commands principais governam o fluxo de trabalho:
+
+### `/opsx:propose` — Antes de mudar
+
+Usado antes de qualquer mudança relevante. O agente analisa o estado atual, propõe a abordagem e estima impacto:
+
+```
+/opsx:propose "Adicionar suporte a xs:attribute no serializer"
+
+Resposta do agente:
+- Escopo: RuntimeSchemaAnalyzer + RuntimeSchemaSerializer
+- Arquivos impactados: 4
+- Testes novos necessários: ~12
+- Risco: Médio (pode afetar providers que usam attributes)
+- Recomendação: Implementar com feature flag
+```
+
+Isso foi usado no PR #31 (`feat(engine): add xs:attribute support, ABRASF envelope detection`).
+
+### `/opsx:apply-orchestrate` — Implementação completa
+
+Para mudanças que exigem múltiplas etapas e agentes:
+
+```
+/opsx:apply-orchestrate "Implementar typed rule DSL com CRUD e catalog"
+
+Aciona: spec-agent → implementation-agent → unit-test-agent
+        → xml-test-agent → review-agent
+```
+
+O PR #29 é o resultado direto desse command.
+
+### `/commit` — Commits padronizados
+
+Commits seguem conventional commits com escopo:
+
+```
+feat(engine): add typed rule DSL with auto-generation, CRUD endpoints, and catalog API
+fix(engine): resolve enum-to-code mappings, date format, and ABRASF field gaps
+chore: remove runtime-generated files from tracking and update .gitignore
+```
+
+O agente gera a mensagem baseada no diff, mantendo consistência de formato ao longo dos 34 commits.
+
+### Fluxo completo
+
+```
+1. /opsx:propose → entender impacto
+2. /opsx:apply-orchestrate → implementar com multi-agente
+3. /commit → registrar mudança
+4. gh pr create → submeter para review
+```
+
+---
+
+## 10. Scheduling
+
+### O que é
+
+Scheduling refere-se à execução assíncrona e paralela de tarefas: rodar processos em background, isolar workspaces com worktrees, e automatizar CI/CD.
+
+### Como foi usado
+
+| Mecanismo | Propósito |
+|-----------|-----------|
+| `run_in_background` | Executar `dotnet test` enquanto o agente continua trabalhando |
+| `isolation:worktree` | Isolar experimentos sem afetar a branch principal |
+| **GitHub Actions CI** | Pipeline automatizado com MongoDB service container |
+
+### run_in_background
+
+Quando o agente precisa rodar a suíte completa de 727 testes mas não quer bloquear o fluxo:
+
+```
+run_in_background: dotnet test --no-build
+# Agente continua implementando enquanto testes rodam
+# Notificação quando completa
+```
+
+Isso foi particularmente útil durante o PR #27 (`feat(engine): implement 6 provider onboarding fixes`) onde 6 providers foram ajustados em sequência. Entre cada ajuste, os testes do provider anterior rodavam em background.
+
+### isolation:worktree
+
+Git worktrees permitem ter múltiplas working copies do repositório. Usado para:
+
+- Testar abordagens alternativas sem contaminar a branch de trabalho
+- Rodar testes de uma versão enquanto implementa outra
+- Comparar output XML entre versões
+
+Exemplo: durante a decisão runtime vs build-time, um worktree rodava a versão build-time (#17) enquanto outro tinha o protótipo runtime (#18). A comparação lado a lado foi decisiva.
+
+### GitHub Actions CI
+
+O `ci.yml` configura o pipeline:
+
+```yaml
+services:
+  mongodb:
+    image: mongo:7
+    ports:
+      - 27017:27017
+
+steps:
+  - uses: actions/checkout@v4
+  - uses: actions/setup-dotnet@v4
+  - run: dotnet test
+```
+
+Cada PR dispara o CI automaticamente. Commits como `1cb8fd2` ("ci: add detailed console logger to integration tests for failure diagnosis") e `687d170` ("fix(test): create generated subdirectories before writing artifacts in CI") mostram o refinamento iterativo do pipeline.
+
+### O valor do scheduling
+
+Sem execução assíncrona, cada ciclo de `dotnet test` (727 testes) bloquearia o agente por minutos. Com `run_in_background`, o throughput do desenvolvimento aumenta significativamente — o agente trabalha enquanto a validação acontece em paralelo.
+
+---
+
+## Resumo da Jornada
+
+| Fase | Ferramenta | Impacto |
+|------|-----------|---------|
+| Início | Terminal + Cursor | Ambiente produtivo desde o dia 1 |
+| Infraestrutura | Docker + MongoDB | Testes E2E reais, sem mocks frágeis |
+| Decisões | Assistente (par) | Runtime > build-time, resolução por município |
+| Implementação simples | Agente único | Multi-namespace em 1 sessão |
+| Implementação complexa | Multi agentes | Typed Rule DSL com 5 agentes coordenados |
+| Consistência | Agent Skills + CLAUDE.md | Padrões mantidos em 34 commits |
+| Conhecimento externo | MCP / LSP | XmlSchemaSet, xUnit, specs de providers |
+| Automação | Tools / Plugins | PRs, docs, CI |
+| Fluxo de trabalho | Commands | Propose → Implement → Commit → PR |
+| Performance | Scheduling | Background tests, worktrees, CI paralelo |
+
+De `74a383a` (simulação sem IA) a `416bed9` (documentação completa), cada tema contribuiu para multiplicar a capacidade de entrega. O projeto não seria viável em uma semana sem essa combinação de ferramentas e práticas de IA.

--- a/docs/wiki/Licoes-Aprendidas.md
+++ b/docs/wiki/Licoes-Aprendidas.md
@@ -1,0 +1,119 @@
+# Lições Aprendidas
+
+> Projeto NFSe: 34 commits, 727 testes, 48 providers, 3 MVPs.
+> Uma semana de desenvolvimento intensivo com IA. Aqui está o que ficou.
+
+---
+
+## O que funcionou
+
+### Runtime serialization > build-time
+
+A decisão de migrar de geração build-time (PRs #16, #17) para serialização runtime (#18) foi a mais impactante do projeto. Build-time gerava classes C# estáticas a partir de XSD — cada provider novo exigia recompilação e deploy. Runtime lê XSD em tempo de execução: adicionar um provider é configuração, não código.
+
+Resultado: escalou de 3 providers para 48 sem alterar uma linha do engine. O `SchemaSerializationPipeline` processa qualquer XSD válido sem saber de antemão qual provider vai receber.
+
+### Typed Rules DSL configurável
+
+O `TypedRuleResolver` (#29) permite que suporte técnico ajuste regras por provider (formato de data, mapeamento de enum, campos opcionais) sem envolver desenvolvimento. É a diferença entre "abre um ticket para dev" e "configura direto no painel".
+
+Sete categorias de regras cobrem 95% dos ajustes necessários entre providers. O catálogo expõe via API quais regras estão disponíveis e quais estão ativas por provider.
+
+### CommonFieldMappingDictionary como base para auto-gen
+
+O dicionário de campos comuns (`CommonFieldMappingDictionary.cs`) identificou que ~80% dos campos são compartilhados entre providers com variações de path. Isso viabilizou o auto-generation de configurações no PR #24 (`feat(engine): add support-friendly provider onboarding with auto-config generation`).
+
+Onboarding de provider novo: upload 4 XSDs, auto-gen gera 80% da config, suporte ajusta os 20% restantes.
+
+### Multi-agent para mudanças complexas
+
+Orquestração com 5 agentes especializados (spec → impl → test → xml-test → review) garantiu que mudanças complexas como o Typed Rule DSL (#29) saíssem completas: código, testes, validação XSD e revisão de padrões — tudo em um ciclo.
+
+O `CLAUDE.md` como contrato entre agentes foi essencial. Sem ele, cada agente tomava decisões inconsistentes de nomeação e estrutura.
+
+### E2E com WebApplicationFactory + MongoDB real
+
+Testes de integração com `WebApplicationFactory` conectando a MongoDB real (via Docker) pegam problemas que unit tests e mocks nunca pegariam. Serialização, persistência, validação XSD e resposta HTTP — tudo validado no mesmo teste.
+
+O investimento em CI com MongoDB service container (`ci.yml`) pagou-se na primeira vez que um teste de integração pegou um bug de serialização que 200 unit tests não viram.
+
+---
+
+## O que não funcionou
+
+### IsDataNode heurística quebrando entre providers
+
+A heurística `IsDataNode` tentava identificar automaticamente quais nós do XSD são "dados" versus "estrutura/envelope". Funcionava para ABRASF puro, mas providers com schemas customizados tinham nós ambíguos. Um nó que é envelope no provider A pode ser dado no provider B.
+
+O PR #31 (`feat(engine): add xs:attribute support, ABRASF envelope detection`) teve que refatorar essa lógica para detecção específica de envelope ABRASF em vez de heurística genérica.
+
+**Lição:** heurísticas genéricas para domínios municipalizados são armadilhas. Cada provider tem suas idiossincrasias.
+
+### Enum-to-code não é 1:1 com enums C#
+
+O mapeamento de enums C# para códigos XML parecia simples: `SimNao.Sim → "1"`, `SimNao.Nao → "2"`. Mas a realidade dos providers é mais complexa. O campo `opSimpNac` (Optante Simples Nacional) em alguns providers aceita `"1"/"2"`, em outros `"S"/"N"`, e em outros `"true"/"false"`.
+
+O PR #32 (`fix(engine): resolve enum-to-code mappings, date format, and ABRASF field gaps`) corrigiu isso, mas o trabalho reativo foi maior do que seria um design preventivo.
+
+**Lição:** enums de domínio fiscal brasileiro nunca são simples. Mapear cedo e por provider.
+
+### GenericReusableFields skip frágil
+
+A tentativa de criar uma lista genérica de campos reutilizáveis que o serializer poderia "pular" (skip) quando já processados foi frágil. A ordem de processamento dos campos variava entre providers, e o skip às vezes pulava campos que precisavam ser emitidos.
+
+**Lição:** "genérico" e "48 providers municipais" não combinam. Preferir explícito sobre implícito.
+
+### Agentes paralelos conflitando em mesmo arquivo
+
+Durante experimentos com execução paralela de agentes, dois agentes tentaram modificar o mesmo arquivo simultaneamente. O resultado foi conflito de merge que precisou de resolução manual.
+
+**Lição:** multi-agente funciona em sequência para o mesmo escopo. Paralelismo só quando os escopos são disjuntos (arquivos diferentes, módulos diferentes).
+
+---
+
+## O que faria diferente
+
+### Enum mapping rules desde o início
+
+Em vez de assumir que enums C# mapeiam diretamente para códigos XML, teria criado o `TypedRuleResolver` com regras de mapeamento de enum desde o PR #18 (runtime serializer). O retrabalho dos PRs #29 e #32 poderia ter sido evitado.
+
+### Separar envelope detection por padrão
+
+Em vez de heurística genérica (`IsDataNode`), teria definido uma estratégia de detecção de envelope por padrão ABRASF desde o início. Cada padrão (ABRASF 2.04, ABRASF 1.0, proprietário) tem uma estrutura de envelope previsível que pode ser detectada por assinatura de namespace.
+
+### Investir em sample data com XSD restrictions
+
+Os testes validavam estrutura XML contra XSD, mas não geravam sample data que respeitasse restrictions (`xs:minLength`, `xs:maxLength`, `xs:pattern`, `xs:enumeration`). Ter um gerador de dados de teste baseado em XSD restrictions teria pego bugs de formato antes de chegar em produção.
+
+---
+
+## Métricas finais
+
+| Métrica | Valor |
+|---------|-------|
+| Commits totais | 34 |
+| Testes (unit + integration) | 727 |
+| MVPs entregues | 3 |
+| Providers testáveis | 48 |
+| Erros XSD no padrão nacional | 0 |
+| PRs criados | 33 |
+| Agentes especializados | 5 |
+| Skills registradas | 3 |
+| Servidores MCP | 3 |
+| Dias de desenvolvimento | ~7 |
+
+### O que os números não contam
+
+Os 727 testes não foram escritos manualmente. A combinação de unit-test-agent + xml-test-agent com padrões definidos no `CLAUDE.md` (xUnit, Shouldly, `Given_Should`) gerou a maioria. O humano revisou e ajustou.
+
+Os 48 providers testáveis são resultado direto da decisão runtime. Com build-time, teríamos no máximo 10 — o custo por provider seria proibitivo.
+
+Os 0 erros XSD no padrão nacional são resultado do investimento em validação XSD integrada aos testes. Cada teste de serialização valida contra o schema real. Se o XML não é válido, o teste falha.
+
+---
+
+## Conclusão
+
+A maior lição é sobre **quando ser genérico e quando ser específico**. Em domínios como NFSe, onde cada município pode ter regras próprias, abstrações genéricas falham mais do que ajudam. O equilíbrio está em: **base comum + configuração específica por provider**. O `CommonFieldMappingDictionary` + `TypedRuleResolver` materializa exatamente esse equilíbrio.
+
+A segunda lição é sobre **IA como multiplicador, não substituto**. A IA gerou 80% do código e dos testes, mas as decisões arquiteturais (runtime vs build-time, resolução por município, regras configuráveis) foram humanas, informadas por conversas com a IA. O humano decide, a IA executa e valida.

--- a/docs/wiki/Material-para-Apresentacao.md
+++ b/docs/wiki/Material-para-Apresentacao.md
@@ -1,0 +1,186 @@
+# Material para Apresentação
+
+> Roteiro para apresentação de 60+ minutos.
+> Projeto NFSe: 34 commits, 727 testes, 48 providers, 3 MVPs.
+> Construído com Claude Code CLI + Cursor IDE em ~1 semana.
+
+---
+
+## Estrutura da Apresentação (60+ min)
+
+### Bloco 1: O Problema (0-10 min)
+
+**Objetivo:** Estabelecer contexto e dor do cliente.
+
+- O que é NFSe (Nota Fiscal de Serviço Eletrônica)
+- O problema da municipalização: cada cidade escolhe seu provider, seu schema XSD, suas regras
+- Escala do problema: milhares de municípios, dezenas de providers, schemas que mudam sem aviso
+- Custo atual: cada provider novo exige semanas de desenvolvimento manual
+- Pergunta retórica: "E se um provider novo fosse configuração em vez de código?"
+
+**Slide sugerido:** Mapa do Brasil com pontos coloridos por provider, mostrando a fragmentação.
+
+### Bloco 2: Evolução do Projeto (10-20 min)
+
+**Objetivo:** Mostrar a jornada técnica em 6 fases via git log.
+
+| Fase | Commits | Descrição |
+|------|---------|-----------|
+| 1. Simulação sem IA | `74a383a` | Baseline manual para comparação |
+| 2. Specs e estrutura | #1 a #5 | Definição de specs, YAML, primeiras serializações |
+| 3. Serializer manual | #6 a #12 | IBSCBS completo manual, baseline de qualidade |
+| 4. Engine de geração | #13 a #17 | Build-time: XSD → código C# gerado |
+| 5. Runtime serializer | #18 a #26 | Runtime: XSD lido em execução, escalou para 48 providers |
+| 6. API e regras | #27 a #33 | Provider API, Typed Rules DSL, MVP completo |
+
+**Narrativa:** Mostrar o `git log --oneline` real. Cada fase representa uma decisão arquitetural. A transição build-time → runtime (fase 4 → 5) é o ponto de inflexão.
+
+**Slide sugerido:** Timeline horizontal com as 6 fases e os marcos de cada uma.
+
+### Bloco 3: Jornada de IA — 10 Temas (20-35 min)
+
+**Objetivo:** Percorrer os 10 temas da jornada com exemplos reais.
+
+Para cada tema, apresentar em 1-2 minutos:
+
+1. **Terminal / IDE** — Claude Code CLI + Cursor. Demo rápido: "assim que abro o terminal..."
+2. **Docker** — MongoDB via docker-compose. "Testes de integração com banco real, não mocks"
+3. **Assistente** — Decisões arquiteturais nasceram de conversa. Runtime vs build-time como exemplo
+4. **Agente único** — Multi-namespace (#21) em 1 sessão autônoma. Mostrar o diff
+5. **Multi agentes** — 5 especializados no Typed Rule DSL (#29). Mostrar o fluxo spec→impl→test→xml-test→review
+6. **Agent Skills** — CLAUDE.md como contrato. `/opsx:propose` e `/opsx:apply-orchestrate`
+7. **MCP / LSP** — mcp-spec-server local, microsoft-docs, context7
+8. **Tools / Plugins** — GitHub CLI para PRs, Firecrawl para docs
+9. **Commands** — `/opsx:propose` antes de mudar, `/opsx:apply-orchestrate` para implementar
+10. **Scheduling** — run_in_background, worktrees, CI com MongoDB
+
+**Demo ao vivo recomendada:** Executar `/opsx:propose "Adicionar novo campo ao ServiceInvoice"` no terminal e mostrar a resposta do agente analisando impacto em tempo real.
+
+**Slide sugerido:** Grid 2x5 com ícone e título de cada tema. Destaque visual no tema sendo apresentado.
+
+### Bloco 4: Demo ao Vivo (35-45 min)
+
+**Objetivo:** Demonstrar o sistema funcionando end-to-end.
+
+#### Demo 1: POST /providers com 4 XSDs (~3 min)
+
+```bash
+curl -X POST http://localhost:5000/api/providers \
+  -H "Content-Type: application/json" \
+  -d '{ "name": "GissOnline", "xsds": [...] }'
+```
+
+Mostrar: provider criado, XSDs validados, configuração auto-gerada.
+
+#### Demo 2: POST /nfse/xml → XML válido (~3 min)
+
+```bash
+curl -X POST http://localhost:5000/api/nfse/xml \
+  -H "Content-Type: application/json" \
+  -d '{ "provider": "GissOnline", "serviceInvoice": {...} }'
+```
+
+Mostrar: XML gerado, validado contra XSD, pronto para envio.
+
+#### Demo 3: Swagger UI (~2 min)
+
+Abrir `http://localhost:5000/swagger` no navegador. Navegar pelos endpoints:
+- Providers CRUD
+- Geração de XML
+- Catálogo de regras
+- Validação XSD
+
+#### Demo 4: dotnet test — 727 passando (~1 min)
+
+```bash
+dotnet test --verbosity minimal
+```
+
+Mostrar o número total de testes passando. Destacar que a maioria foi gerada por agentes de IA.
+
+#### Demo 5: /opsx:propose em tempo real (~3 min)
+
+Executar no terminal do Claude Code CLI:
+
+```
+/opsx:propose "Adicionar suporte ao provider XYZ da cidade ABC"
+```
+
+Mostrar a resposta do agente: análise de impacto, arquivos afetados, testes necessários, estimativa de esforço.
+
+**Dica de apresentação:** Ter o Docker rodando e a API levantada antes do bloco de demo. Testar tudo 30 min antes da apresentação.
+
+### Bloco 5: Arquitetura e Decisões (45-55 min)
+
+**Objetivo:** Aprofundar nas decisões técnicas para a audiência mais sênior.
+
+**Decisões-chave para discutir:**
+
+1. **Runtime vs Build-time** — Por que ler XSD em runtime escala melhor que gerar código
+2. **Resolução por município** — Código IBGE como chave natural para vincular município → provider
+3. **CommonFieldMappingDictionary** — 80% dos campos são comuns, 20% são override por provider
+4. **TypedRuleResolver** — Regras configuráveis sem recompilação
+5. **WebApplicationFactory + MongoDB** — Testes E2E sem mocks, com banco real
+
+**Diagrama sugerido:** Fluxo `ServiceInvoice → SchemaSerializationPipeline → XSD Runtime → XML → Validação XSD`.
+
+### Bloco 6: Lições e Roadmap (55-60 min)
+
+**Objetivo:** Fechar com transparência sobre erros e visão de futuro.
+
+**O que funcionou:** Runtime serialization, typed rules, multi-agent, E2E real.
+
+**O que não funcionou:** IsDataNode heurística, enum-to-code 1:1, GenericReusableFields skip.
+
+**O que faria diferente:** Enum mapping rules desde o início, envelope detection por padrão, sample data com XSD restrictions.
+
+**Roadmap:**
+- Próximo: Mais providers em produção, regras de negócio por município
+- Médio prazo: Portal de suporte para onboarding self-service
+- Longo prazo: Federação de schemas, versionamento automático de providers
+
+---
+
+## Perguntas Frequentes Preparadas
+
+### "A IA não gera código com bugs?"
+
+Gera. Por isso existem 727 testes. O unit-test-agent e o xml-test-agent validam cada mudança. O review-agent verifica aderência a padrões. Bugs existem, mas são pegos antes de sair do ciclo de desenvolvimento.
+
+### "Como garantir que o XML está correto para a prefeitura?"
+
+Validação XSD integrada. Cada teste de serialização valida o XML gerado contra o schema XSD real do provider. Zero erros XSD no padrão nacional (ABRASF). Providers proprietários são validados individualmente.
+
+### "Quanto tempo para adicionar um provider novo?"
+
+Com auto-generation: upload dos 4 XSDs, auto-gen cria 80% da configuração. Suporte ajusta os 20% restantes. Estimativa: horas, não semanas.
+
+### "E se o provider mudar o schema?"
+
+Upload do novo XSD, re-validação automática, ajuste de regras se necessário. Como é runtime, não precisa recompilar ou fazer deploy de código novo para mudanças de schema.
+
+### "Os agentes de IA podem rodar em produção?"
+
+Os agentes são ferramentas de desenvolvimento, não componentes de produção. O código que eles geram roda em produção. Os agentes ficam no ciclo de desenvolvimento.
+
+### "Qual o custo de tokens/API para usar IA assim?"
+
+O custo é significativo para sessões longas de multi-agente, mas o ROI é claro: uma semana de trabalho produziu o que levaria meses sem IA. O investimento em tokens é uma fração do custo de desenvolvedores adicionais.
+
+### "Como replicar esse setup em outro projeto?"
+
+Três componentes essenciais: (1) CLAUDE.md com regras do projeto, (2) Agent skills com fluxos padronizados, (3) MCP servers com contexto do domínio. O setup é transferível para qualquer projeto .NET com domínio bem definido.
+
+---
+
+## Checklist Pré-Apresentação
+
+- [ ] Docker rodando com MongoDB (`docker-compose up -d`)
+- [ ] API levantada (`dotnet run`)
+- [ ] Swagger acessível no navegador
+- [ ] Claude Code CLI aberto no terminal
+- [ ] Slides com as 6 fases visíveis
+- [ ] `dotnet test` executado previamente (cache de build)
+- [ ] Provider de demo já cadastrado para as demos 1 e 2
+- [ ] Backup: screenshots das demos caso a rede falhe
+- [ ] Cronômetro visível para controle de tempo

--- a/docs/wiki/Onboarding-de-Provider-pelo-Suporte.md
+++ b/docs/wiki/Onboarding-de-Provider-pelo-Suporte.md
@@ -1,0 +1,307 @@
+# Onboarding de Provider pelo Suporte
+
+Guia passo a passo para cadastrar e ativar um novo provider de NFS-e pela API.
+
+**Base URL:** `http://localhost:5211`
+
+---
+
+## Pre-requisitos
+
+Antes de iniciar o onboarding, certifique-se de ter:
+
+1. **Arquivos XSD** do schema do provider (obtidos junto ao municipio ou fornecedor do sistema de NFS-e)
+2. **Codigo IBGE** do(s) municipio(s) atendidos pelo provider (7 digitos, ex: `3550308` = Sao Paulo)
+3. **Acesso a API** rodando em `http://localhost:5211`
+4. **Ferramenta HTTP** como `curl`, Postman ou similar
+
+---
+
+## Passo 1: Coletar os arquivos XSD
+
+Obtenha todos os arquivos XSD necessarios junto ao municipio ou fornecedor. E fundamental incluir **todos** os arquivos referenciados por `xs:include` e `xs:import` no XSD principal.
+
+### Arquivos tipicos de um provider ABRASF
+
+| Arquivo | Descricao |
+|---------|-----------|
+| `servico_enviar_lote_rps_envio.xsd` | Schema principal de envio |
+| `tipos_complexos_v1.xsd` | Definicoes de tipos complexos |
+| `tipos_simples_v1.xsd` | Definicoes de tipos simples (restricoes, enums) |
+| `cabecalho_v1.xsd` | Cabecalho do lote |
+
+### Verificacao rapida
+
+Abra o XSD principal e procure por linhas como:
+
+```xml
+<xs:include schemaLocation="tipos_complexos_v1.xsd"/>
+<xs:import schemaLocation="tipos_simples_v1.xsd"/>
+```
+
+Cada arquivo referenciado deve ser enviado junto no upload. Se faltar algum, a validacao falhara com erro de tipo nao declarado.
+
+---
+
+## Passo 2: Cadastrar o provider
+
+Envie todos os XSDs via `multipart/form-data`. Quando houver mais de um arquivo, informe o `primaryXsdFile`.
+
+```bash
+curl -X POST http://localhost:5211/api/v1/providers \
+  -F "name=issnet-goiania" \
+  -F "xsdFiles[]=@servico_enviar_lote_rps_envio.xsd" \
+  -F "xsdFiles[]=@tipos_complexos_v1.xsd" \
+  -F "xsdFiles[]=@tipos_simples_v1.xsd" \
+  -F "xsdFiles[]=@cabecalho_v1.xsd" \
+  -F "municipalityCodes=5208707" \
+  -F "primaryXsdFile=servico_enviar_lote_rps_envio.xsd"
+```
+
+> **Dica:** O `name` deve ser unico entre todos os providers. Use um nome descritivo como `issnet-goiania`, `gissonline-bh`, `paulistana`.
+
+---
+
+## Passo 3: Verificar o response
+
+A API retorna o provider criado com o resultado da validacao automatica.
+
+### Cenario 1: Status `Ready`
+
+```json
+{
+  "id": "665f1a2b3c4d5e6f7a8b9c0d",
+  "name": "issnet-goiania",
+  "status": "Ready",
+  "blockReason": null,
+  "hasRulesConfig": true,
+  "typedRuleCount": 18,
+  "validationCount": 1
+}
+```
+
+O provider esta pronto para uso. A engine analisou o schema, gerou as regras automaticamente e validou o XML contra o XSD.
+
+### Cenario 2: Status `Blocked`
+
+```json
+{
+  "id": "665f1a2b3c4d5e6f7a8b9c0d",
+  "name": "issnet-goiania",
+  "status": "Blocked",
+  "blockReason": "XML gerado nao passou na validacao contra o schema",
+  "hasRulesConfig": true,
+  "typedRuleCount": 12,
+  "validationCount": 1
+}
+```
+
+O provider precisa de ajustes. Siga para o Passo 4.
+
+---
+
+## Passo 4: Se Blocked — Diagnosticar o problema
+
+Execute a validacao para obter detalhes completos, incluindo `pendingFields`:
+
+```bash
+curl -X POST http://localhost:5211/api/v1/providers/665f1a2b3c4d5e6f7a8b9c0d/validate
+```
+
+### Analisar o response de validacao
+
+```json
+{
+  "passed": false,
+  "checks": [
+    { "name": "XsdSelection", "passed": true, "detail": "Selected: servico_enviar_lote_rps_envio.xsd" },
+    { "name": "SchemaAnalysis", "passed": true, "detail": "Analyzed 4 complex types, 22 elements" },
+    { "name": "XmlSerialization", "passed": false, "detail": "3 required fields missing" },
+    { "name": "XsdValidation", "passed": false, "detail": "element 'Numero' is required" }
+  ],
+  "blockReason": "XML gerado nao passou na validacao contra o schema",
+  "pendingFields": [
+    {
+      "fieldPath": "InfRps.Numero",
+      "isRequired": true,
+      "suggestedSource": "Number",
+      "confidence": "Exact",
+      "reason": "Nome identico ao campo do dominio"
+    },
+    {
+      "fieldPath": "InfRps.Serie",
+      "isRequired": true,
+      "suggestedSource": "RpsSerialNumber",
+      "confidence": "Partial",
+      "reason": "Nome parcialmente similar: Serie ~ SerialNumber"
+    }
+  ]
+}
+```
+
+### Acoes por nivel de confianca
+
+| Confianca | Acao |
+|-----------|------|
+| **Exact** | Aceitar a sugestao — adicionar regra de binding com o `suggestedSource` indicado |
+| **Partial** | Verificar se o mapeamento faz sentido antes de aceitar |
+| **None** | Criar manualmente: pode ser uma constante, um enum mapping ou campo customizado |
+
+### Adicionar as regras faltantes
+
+```bash
+curl -X POST http://localhost:5211/api/v1/providers/665f1a2b3c4d5e6f7a8b9c0d/rules \
+  -H "Content-Type: application/json" \
+  -d '[
+    { "type": "Binding", "target": "InfRps.Numero", "source": "Number" },
+    { "type": "Binding", "target": "InfRps.Serie", "source": "RpsSerialNumber" }
+  ]'
+```
+
+---
+
+## Passo 5: Revalidar
+
+Apos ajustar as regras, execute a validacao novamente:
+
+```bash
+curl -X POST http://localhost:5211/api/v1/providers/665f1a2b3c4d5e6f7a8b9c0d/validate
+```
+
+Repita os passos 4 e 5 ate que o `status` transite para `Ready` e `passed` seja `true`.
+
+---
+
+## Passo 6: Testar a geracao de XML
+
+Com o provider `Ready`, teste a geracao de XML usando o codigo IBGE do municipio atribuido:
+
+```bash
+curl -X POST http://localhost:5211/api/v1/nfse/xml \
+  -H "Content-Type: application/json" \
+  -d '{
+    "externalId": "TESTE-001",
+    "provider": {
+      "federalTaxNumber": 12345678000199,
+      "municipalTaxNumber": "98765"
+    },
+    "borrower": {
+      "name": "Tomador Teste",
+      "federalTaxNumber": 98765432000188,
+      "address": {
+        "postalCode": "74000000",
+        "street": "Rua Teste",
+        "number": "1",
+        "district": "Centro",
+        "city": { "code": "5208707", "name": "Goiania" },
+        "state": "GO"
+      }
+    },
+    "location": {
+      "postalCode": "74000000",
+      "street": "Rua Prestador",
+      "number": "100",
+      "district": "Centro",
+      "city": { "code": "5208707", "name": "Goiania" },
+      "state": "GO"
+    },
+    "description": "Servico de teste",
+    "servicesAmount": 100.00,
+    "issuedOn": "2026-01-20T10:00:00-03:00",
+    "taxationType": "WithinCity",
+    "federalServiceCode": "01.01"
+  }'
+```
+
+### Verificar o response
+
+- `providerName` deve ser o nome do provider criado (ex: `issnet-goiania`), e nao `nacional`
+- `isFallback` deve ser `false`
+- `xml` deve conter o XML completo conforme o schema do provider
+
+Se `isFallback` for `true`, o municipio nao esta atribuido. Adicione-o:
+
+```bash
+curl -X POST http://localhost:5211/api/v1/providers/665f1a2b3c4d5e6f7a8b9c0d/municipalities \
+  -H "Content-Type: application/json" \
+  -d '{ "codes": ["5208707"] }'
+```
+
+---
+
+## Passo 7: Monitorar o provider
+
+Consulte o status a qualquer momento:
+
+```bash
+curl http://localhost:5211/api/v1/providers/665f1a2b3c4d5e6f7a8b9c0d/status
+```
+
+Liste todos os providers ativos:
+
+```bash
+curl http://localhost:5211/api/v1/providers?status=Ready
+```
+
+---
+
+## Troubleshooting
+
+### "Type not declared" na validacao
+
+**Causa:** Falta um arquivo XSD auxiliar referenciado pelo XSD principal (tipos complexos, tipos simples, etc.).
+
+**Solucao:** Abra o XSD principal, identifique todos os `xs:include` e `xs:import`, e reenvie o provider com todos os arquivos:
+
+```bash
+curl -X PUT http://localhost:5211/api/v1/providers/665f1a2b3c4d5e6f7a8b9c0d \
+  -F "xsdFiles[]=@servico_enviar_lote_rps_envio.xsd" \
+  -F "xsdFiles[]=@tipos_complexos_v1.xsd" \
+  -F "xsdFiles[]=@tipos_simples_v1.xsd" \
+  -F "primaryXsdFile=servico_enviar_lote_rps_envio.xsd"
+```
+
+### "Schema analysis failed"
+
+**Causa:** O arquivo XSD esta corrompido, possui encoding invalido ou sintaxe XML malformada.
+
+**Solucao:** Valide o XSD em um editor XML antes de enviar. Verifique se o encoding e UTF-8 e se o XML e bem-formado.
+
+### Status `Blocked` apos criacao
+
+**Causa:** A validacao automatica detectou problemas. O campo `blockReason` indica a causa.
+
+**Solucao:**
+1. Execute `POST /validate` para obter detalhes completos
+2. Verifique os `checks` para identificar qual etapa falhou
+3. Analise os `pendingFields` para saber quais campos faltam
+4. Adicione regras via `POST /rules` conforme as sugestoes
+
+### Fallback para provider nacional
+
+**Causa:** O codigo IBGE do municipio informado no request nao esta atribuido a nenhum provider.
+
+**Solucao:** Atribua o municipio ao provider correto via `POST /providers/{id}/municipalities`.
+
+### XML vazio ou incompleto
+
+**Causa:** O provider nao possui regras configuradas ou as regras nao cobrem os campos obrigatorios.
+
+**Solucao:**
+1. Verifique as regras: `GET /providers/{id}/rules`
+2. Se `typedRuleCount` for `0`, as regras precisam ser configuradas
+3. Consulte os targets disponiveis: `GET /rules/targets/{providerName}`
+4. Consulte os sources disponiveis: `GET /rules/sources`
+5. Adicione as regras necessarias via `POST /rules` ou `PUT /rules`
+
+---
+
+## Quando acionar o time de desenvolvimento
+
+Escale para o time de dev nas seguintes situacoes:
+
+- **Schema com features nao suportadas:** XSD com `xs:choice` aninhados complexos, `xs:any`, `xs:group` com recursao ou heranca por extensao
+- **Enum mapping customizado:** Quando o provider usa codigos proprietarios que nao correspondem a nenhum enum do dominio e requerem mapeamento manual extenso
+- **Envelope ABRASF complexo:** Providers ABRASF com estrutura de envelope nao convencional (cabecalhos customizados, namespaces multiplos, assinatura digital embutida)
+- **Erros internos da engine:** Status 500 ou erros nao documentados durante validacao ou geracao de XML
+- **Performance:** Provider com schema muito grande (acima de 50 complex types) causando lentidao na validacao

--- a/docs/wiki/Providers-Suportados.md
+++ b/docs/wiki/Providers-Suportados.md
@@ -1,0 +1,84 @@
+# Providers Suportados
+
+## Tabela de providers
+
+| Provider | Padrão | Namespace | Status Operacional | Onboarding | XSD Válido | Observações |
+|----------|--------|-----------|-------------------|------------|------------|-------------|
+| **Nacional** | DPS Nacional | Single | SupportReady | Fully Onboarded | PASS | MVP principal. 0 erros XSD. Schema root: `TCDPS/DPS`. |
+| **ISSNet** | ISSNet DPS | Single | SupportReady | Fully Onboarded | PASS | MVP. Schema root: `EnviarLoteDpsEnvio` (inline). Path bindings multinível via binder. |
+| **GISSOnline** | ABRASF-based | Multi | NeedsEngineering | Schema Only | PASS | MVP com gaps rastreados. Multi-namespace. Falta configuração de regras tipadas. |
+| **ABRASF** | ABRASF 2.04 | Single | NeedsEngineering | Schema Only | PASS | Padrão base. Falta configuração de regras tipadas. Detecção de envelope implementada. |
+| **Paulistana** | SP Municipal | Multi | SupportReady | Fully Onboarded | FAIL | Schema root: `PedidoEnvioLoteRPS` (inline). XSD validation falha — requer campo Assinatura digital. |
+| **Simpliss** | ABRASF-based | Single | SupportReady | Fully Onboarded | FAIL | Baseado em ABRASF. XSD validation falha por diferenças no schema derivado. |
+| **WebISS** | ABRASF-based | — | SupportReady | Fully Onboarded | — | Totalmente onboarded. Sem geração de artefatos comparativos. |
+
+## Significado dos status
+
+### OperationalStatus
+
+| Status | Significado |
+|--------|------------|
+| **SupportReady** | Provider totalmente operacional. Suporte pode usar sem intervenção de desenvolvedor. |
+| **NeedsEngineering** | Provider carregável mas com gaps que exigem desenvolvimento na engine ou configuração avançada. |
+
+### Onboarding Status
+
+| Status | Significado |
+|--------|------------|
+| **Fully Onboarded** | Todos os 5 checks passaram: SchemaLoadable, AnalysisOk, BindingsPresent, RuntimeProducible, XsdValid. |
+| **Schema Only** | Schema carregável e analisável, mas sem bindings/regras configuradas. Precisa de configuração. |
+
+### XSD Válido
+
+| Resultado | Significado |
+|-----------|------------|
+| **PASS** | XML gerado pela engine valida contra o XSD do provider sem erros. |
+| **FAIL** | XML gerado contém erros de validação XSD. Gaps estão rastreados. |
+
+## Gaps conhecidos por provider
+
+### ABRASF
+| Check | Tipo de gap | Detalhe |
+|-------|------------|---------|
+| BindingsPresent | ConfigurationGap | Nenhuma regra tipada configurada. |
+| RuntimeProducible | EngineGap | Ignorado: bindings não disponíveis. |
+
+**Ação:** Configurar regras em `providers/abrasf/rules/rules.json` ou usar `ProviderConfigGenerator` para auto-gerar.
+
+### GISSOnline
+| Check | Tipo de gap | Detalhe |
+|-------|------------|---------|
+| BindingsPresent | ConfigurationGap | Nenhuma regra tipada configurada. |
+| RuntimeProducible | EngineGap | Ignorado: bindings não disponíveis. |
+
+**Ação:** Configurar regras em `providers/gissonline/rules/rules.json` ou usar `ProviderConfigGenerator` para auto-gerar.
+
+### Paulistana
+| Check | Tipo de gap | Detalhe |
+|-------|------------|---------|
+| XsdValid | FAIL | Requer campo `Assinatura` com hash digital que não é gerado pela engine. |
+
+**Ação:** Implementar geração de hash de assinatura digital para o schema SP.
+
+### Simpliss
+| Check | Tipo de gap | Detalhe |
+|-------|------------|---------|
+| XsdValid | FAIL | Diferenças no schema derivado do ABRASF causam erros de validação. |
+
+**Ação:** Investigar divergências entre o XSD Simpliss e o ABRASF padrão.
+
+## Providers MVP
+
+Os 3 providers definidos como MVP são:
+
+1. **Nacional** — PASS completo, 0 erros XSD
+2. **ISSNet** — PASS completo com path bindings multinível
+3. **GISSOnline** — Schema analisável, gaps de configuração rastreados
+
+---
+
+**Páginas relacionadas:**
+- [Visão Geral do Produto](Visao-Geral-do-Produto.md)
+- [Cadastro de Providers](Cadastro-de-Providers.md)
+- [Status e Classificação de Gaps](Status-e-Classificacao-de-Gaps.md)
+- [Onboarding de Provider pelo Suporte](Onboarding-de-Provider-pelo-Suporte.md)

--- a/docs/wiki/Regras-de-Provider.md
+++ b/docs/wiki/Regras-de-Provider.md
@@ -1,0 +1,303 @@
+# Regras de Provider
+
+## Visao geral
+
+Rules sao instrucoes tipadas que mapeiam campos do schema XSD para propriedades do dominio
+(`DpsDocument`). Cada provider possui uma lista de `ProviderRule` que o `TypedRuleResolver`
+interpreta em runtime para popular o dicionario de dados usado pelo serializer.
+
+As rules substituem mapeamentos hardcoded e permitem que cada provider tenha configuracao
+independente sem necessidade de codigo novo.
+
+---
+
+## Os 6 tipos de rules
+
+### 1. Binding
+
+Mapeia um campo do XSD para uma propriedade do dominio ou valor constante.
+
+```json
+{
+  "type": "Binding",
+  "target": "infDPS.dhEmi",
+  "source": "IssuedOn",
+  "format": "yyyy-MM-ddTHH:mm:sszzz"
+}
+```
+
+```json
+{
+  "type": "Binding",
+  "target": "infDPS.verAplic",
+  "sourceType": "constant",
+  "constantValue": "V_1.00.02"
+}
+```
+
+O `target` e o caminho do elemento no schema. O `source` e o caminho da propriedade
+no `DpsDocument`. Quando `sourceType` e `"constant"`, usa `constantValue` diretamente.
+
+O `format` e aplicado via `ApplyBindingFormatting`: suporta `DateTimeOffset`, `DateOnly`,
+`DateTime` e `decimal`.
+
+---
+
+### 2. Default
+
+Fornece um valor padrao quando a propriedade do dominio e nula ou zero.
+
+```json
+{
+  "type": "Default",
+  "target": "tpAmb",
+  "source": "Environment",
+  "fallbackValue": "2"
+}
+```
+
+O resolver tenta obter o valor de `source`. Se for nulo ou `"0"`, usa `fallbackValue`.
+Quando `source` nao e informado, usa sempre o `fallbackValue`.
+
+---
+
+### 3. EnumMapping
+
+Converte valores de enum do dominio para codigos esperados pelo schema XSD.
+
+```json
+{
+  "type": "EnumMapping",
+  "target": "tribISSQN",
+  "source": "Values.TaxationType",
+  "mappings": {
+    "WithinCity": "1",
+    "Immune": "2",
+    "Export": "3",
+    "Free": "4"
+  },
+  "defaultMapping": "1"
+}
+```
+
+O `TypedRuleResolver` resolve o valor do enum (pelo nome, via `ResolveWithEnumName`),
+busca no dicionario `mappings` e retorna o codigo correspondente. Se nao encontrar,
+usa `defaultMapping`.
+
+---
+
+### 4. ConditionalEmission
+
+Emite ou suprime um campo com base em uma condicao avaliada em runtime.
+
+```json
+{
+  "type": "ConditionalEmission",
+  "target": "infDPS.cNBS",
+  "source": "Service.NbsCode",
+  "condition": {
+    "field": "Service.NbsCode",
+    "operator": "HasValue"
+  },
+  "action": "Emit"
+}
+```
+
+```json
+{
+  "type": "ConditionalEmission",
+  "target": "infDPS.especial",
+  "source": "Service.SpecialCode",
+  "condition": {
+    "logicalOperator": "And",
+    "conditions": [
+      { "field": "Service.SpecialCode", "operator": "HasValue" },
+      { "field": "Values.TaxationType", "operator": "NotEquals", "value": "Export" }
+    ]
+  },
+  "action": "Emit"
+}
+```
+
+**Operadores suportados:** `Equals`, `NotEquals`, `GreaterThan`, `LessThan`,
+`GreaterThanOrEqual`, `LessThanOrEqual`, `IsNull`, `HasValue`, `Contains`, `In`.
+
+**Operadores logicos:** `And`, `Or` (composicao recursiva de condicoes).
+
+**Acoes:** `Emit` (emite se condicao verdadeira), `Skip` (emite se condicao falsa).
+
+---
+
+### 5. Choice
+
+Seleciona dinamicamente qual elemento emitir dentro de um grupo `xs:choice` do schema.
+
+```json
+{
+  "type": "Choice",
+  "target": "infDPS.CpfCnpj",
+  "choiceField": "Borrower.PersonType",
+  "options": {
+    "Legal": {
+      "element": "CNPJ",
+      "source": "Borrower.FederalTaxNumber",
+      "padLeft": 14,
+      "padChar": "0"
+    },
+    "Natural": {
+      "element": "CPF",
+      "source": "Borrower.FederalTaxNumber",
+      "padLeft": 11,
+      "padChar": "0"
+    }
+  }
+}
+```
+
+O `choiceField` e a propriedade discriminadora. O valor e usado como chave no `options`
+para determinar qual `ChoiceOption` aplicar. Cada opcao define o `element` a emitir,
+o `source` do valor, e opcionalmente `padLeft`/`padChar`.
+
+---
+
+### 6. Formatting
+
+Aplica transformacoes de texto ao valor de um campo durante a serializacao.
+
+```json
+{
+  "type": "Formatting",
+  "target": "CNPJ",
+  "digitsOnly": true,
+  "padLeft": 14,
+  "padChar": "0",
+  "maxLength": 14
+}
+```
+
+As transformacoes sao aplicadas na ordem: `digitsOnly` -> `removeChars` -> `trim` -> `padLeft` -> `maxLength`.
+
+---
+
+## Pipes de formatacao
+
+As rules de Binding e Default suportam pipes inline nos campos `format`, `digitsOnly`,
+`padLeft`, `maxLength` e `trim` diretamente na `ProviderRule`.
+
+| Pipe         | Propriedade na rule | Exemplo                     | Resultado              |
+|--------------|---------------------|-----------------------------|------------------------|
+| `format`     | `format`            | `"yyyy-MM-dd"`              | `2026-03-23`           |
+| `digitsOnly` | `digitsOnly: true`  | `"12.345.678/0001-90"`      | `"12345678000190"`     |
+| `padLeft`    | `padLeft` + `padChar`| `padLeft: 14, padChar: "0"`| `"00012345678901"`     |
+| `maxLength`  | `maxLength`         | `maxLength: 7`              | Trunca para 7 chars    |
+| `trim`       | `trim: true`        | `"  valor  "`               | `"valor"`              |
+
+O `SchemaBasedXmlSerializer.ApplyFormatting` aplica as mesmas transformacoes
+via `FormattingRule` retornada pelo `TypedRuleResolver.ResolveFormatting`.
+
+---
+
+## CommonFieldMappingDictionary
+
+Dicionario central que mapeia nomes de campos XSD para propriedades do dominio.
+Usado pela auto-geracao de regras e pelo `ValidationDiagnosticEnricher`.
+
+### Campos principais
+
+| Campo XSD              | Propriedade do dominio            | Categoria              |
+|------------------------|-----------------------------------|------------------------|
+| `CNPJ`                | `Provider.Cnpj`                   | Identificacao          |
+| `CPF`                 | `Borrower.FederalTaxNumber`       | Identificacao          |
+| `IM`                  | `Provider.MunicipalTaxNumber`     | Identificacao          |
+| `InscricaoMunicipal`  | `Provider.MunicipalTaxNumber`     | Identificacao          |
+| `cTribNac`            | `Service.FederalServiceCode`      | Servico                |
+| `CodigoServico`       | `Service.FederalServiceCode`      | Servico                |
+| `ItemListaServico`    | `Service.FederalServiceCode`      | Servico                |
+| `cTribMun`            | `CityServiceCode`                 | Servico                |
+| `xDescServ`           | `Service.Description`             | Servico                |
+| `Discriminacao`       | `Service.Description`             | Servico                |
+| `vServ`               | `Values.ServicesAmount`           | Valores                |
+| `ValorServicos`       | `Values.ServicesAmount`           | Valores                |
+| `Aliquota`            | `Values.IssRate`                  | Valores                |
+| `dhEmi`               | `IssuedOn \| format:yyyy-MM-ddTHH:mm:sszzz` | Documento    |
+| `DataEmissao`         | `IssuedOn \| format:yyyy-MM-dd`   | Documento              |
+| `dCompet`             | `CompetenceDate \| format:yyyy-MM-dd` | Documento          |
+| `nDPS`                | `Number`                          | Documento              |
+| `serie`               | `Series`                          | Documento              |
+| `tpAmb`               | `Environment`                     | Documento              |
+| `opSimpNac`           | `const:1`                         | Tributacao             |
+| `tribISSQN`           | `const:1`                         | Tributacao             |
+| `tpRetISSQN`          | `const:1`                         | Tributacao             |
+| `xNome`               | `Borrower.Name`                   | Tomador                |
+| `xEmail`              | `Borrower.Email`                  | Tomador                |
+| `cLocEmi`             | `Provider.MunicipalityCode`       | Localizacao            |
+| `CodigoMunicipio`     | `Provider.MunicipalityCode`       | Localizacao            |
+| `cMunFG`              | `Service.MunicipalityCode`        | Localizacao            |
+| `NumeroRps`           | `Number`                          | RPS (ABRASF)           |
+| `SerieRps`            | `Series`                          | RPS (ABRASF)           |
+| `MunicipioIncidencia` | `Service.MunicipalityCode`        | RPS (ABRASF)           |
+| `CodigoCnae`          | `Service.CnaeCode`               | RPS (ABRASF)           |
+
+O dicionario completo esta em `CommonFieldMappingDictionary.Mappings` com mais de 80 entradas
+cobrindo campos nacionais e ABRASF.
+
+---
+
+## Como a auto-geracao funciona
+
+O `ProviderConfigGenerator` gera rules automaticamente a partir do schema:
+
+### Processo
+
+1. **Selecao do XSD**: `SendXsdSelector` identifica o XSD de envio
+2. **Analise**: `XsdSchemaAnalyzer.Analyze` produz o `SchemaDocument`
+3. **Deteccao de envelope**: Busca pattern ABRASF (`EnviarLoteRpsEnvio`, `RecepcionarLoteRps`, etc.)
+4. **FindDataContainerPath**: Navega a arvore ate encontrar um "data node" (tipo com 3+ filhos simples)
+5. **WalkSchemaTree**: Percorre cada elemento do tipo container de dados:
+   - Se o campo existe no `CommonFieldMappingDictionary`, gera `Binding`
+   - Se e obrigatorio e nao mapeado, marca como `TODO: manual mapping required`
+   - Se tem `Restriction` com `pattern` ou `maxLength`, gera `Formatting`
+6. **Conversao para typed rules**: `GenerateTypedRules` converte os bindings em `ProviderRule`
+7. **Atributos obrigatorios**: `AddRequiredAttributeRules` gera rules para `Id` e `versao`
+8. **Wrapper bindings**: Campos do envelope sao tratados separadamente (`NumeroLote`, `CNPJ`, `versao`, etc.)
+
+### Envelope detection
+
+Para providers ABRASF, a engine detecta automaticamente a estrutura de envelope:
+
+```
+EnviarLoteRpsEnvio
+  └── LoteRps (envelope child)
+        ├── @versao (wrapper binding)
+        ├── NumeroLote (wrapper binding)
+        ├── CpfCnpj > CNPJ (wrapper binding)
+        └── ListaRps > Rps > InfDeclaracaoPrestacaoServico (data container)
+              ├── vServ -> Values.ServicesAmount (rule)
+              ├── Discriminacao -> Service.Description (rule)
+              └── ...
+```
+
+O `bindingPathPrefix` resultante e algo como `LoteRps.ListaRps.Rps.InfDeclaracaoPrestacaoServico`,
+e os `wrapperBindings` contem os campos do envelope.
+
+---
+
+## Gerenciamento de rules via API
+
+| Endpoint                              | Metodo | Descricao                                    |
+|---------------------------------------|--------|----------------------------------------------|
+| `GET /api/v1/providers/{id}/rules`    | GET    | Listar todas as rules do provider             |
+| `PUT /api/v1/providers/{id}/rules`    | PUT    | Substituir todas as rules                     |
+| `POST /api/v1/providers/{id}/rules`   | POST   | Adicionar rules sem remover as existentes     |
+| `DELETE /api/v1/providers/{id}/rules/{index}` | DELETE | Remover rule por indice (base zero)  |
+
+Apos qualquer alteracao nas rules, a engine re-executa a validacao automaticamente.
+
+---
+
+## Links relacionados
+
+- [Exemplos de Regras](Exemplos-de-Regras.md)
+- [Engine e Interpretacao de XSD](Engine-e-Interpretacao-de-XSD.md)
+- [Cadastro de Providers](Cadastro-de-Providers.md)
+- [Validacao Automatica](Validacao-Automatica.md)

--- a/docs/wiki/Roadmap-do-Produto.md
+++ b/docs/wiki/Roadmap-do-Produto.md
@@ -1,0 +1,103 @@
+# Roadmap do Produto
+
+## Estado atual
+
+O MVP está concluído com 7 providers configurados, 5 totalmente operacionais, 727 testes passando e API REST funcional com persistência MongoDB. A engine analisa XSDs em runtime e gera XML válido contra o schema.
+
+---
+
+## Curto prazo (Production Ready)
+
+Itens necessários para colocar a engine em produção real.
+
+### Prioridade P0 — Bloqueadores
+
+| Item | Tipo | Descrição |
+|------|------|-----------|
+| Envelope ABRASF | DEV | Corrigir envelope de envio para providers baseados em ABRASF (afeta GISSOnline, Simpliss) |
+| Mapeamento dinâmico de enums | DEV | Mapear enumerações XSD para códigos de domínio automaticamente |
+| Campo Assinatura (Paulistana) | DEV | Implementar geração de hash de assinatura digital para o schema SP |
+| Certificado digital no pipeline | DEV+INFRA | Integrar certificado A1/A3 para assinatura XML obrigatória em produção |
+| Error handling com correlation ID | DEV | Padronizar respostas de erro com rastreabilidade |
+
+### Prioridade P1 — Essenciais
+
+| Item | Tipo | Descrição |
+|------|------|-----------|
+| Logging estruturado | DEV+INFRA | Serilog/OpenTelemetry por provider, request e operação |
+| Health check endpoint | DEV | `/health` com status de providers disponíveis |
+| CI/CD pipeline | INFRA | GitHub Actions: build, test, deploy em staging |
+| Inferência de conditionals | DEV | Auto-gerar regras `emitWhen` a partir de elementos opcionais e choices do XSD |
+| Inferência de enums | DEV | Detectar e mapear enumerações XSD automaticamente |
+
+### Prioridade P2 — Qualidade
+
+| Item | Tipo | Descrição |
+|------|------|-----------|
+| Swagger/OpenAPI atualizado | DEV | Documentar todos os endpoints com exemplos |
+| Rate limiting | INFRA | Limitar requests por API key/tenant |
+| Substituir serializer manual (Nacional) | DEV | Quando engine cobrir 100%, remover fallback manual |
+| Testes de contrato | DEV | Validar que a API não quebra consumidores existentes |
+
+---
+
+## Médio prazo (Scale Ready)
+
+Itens para escalar a plataforma para uso corporativo.
+
+| Item | Descrição |
+|------|-----------|
+| 10+ providers operacionais | Onboardar providers dos principais municípios brasileiros |
+| Smart sample data | Geração inteligente de dados de teste a partir do schema |
+| Cache de schema analysis | Evitar re-análise de XSD a cada request (invalidação por hash) |
+| Suporte a lote | Serializar múltiplos DPS por lote (hoje é 1:1) |
+| SLA por provider | Retry policy, circuit breaker e fallback chain |
+| Dashboard de monitoramento | Grafana/Prometheus: requests/s, erros, latência por provider |
+
+---
+
+## Longo prazo (Enterprise Ready)
+
+Itens para uma plataforma enterprise multitenancy.
+
+| Item | Descrição |
+|------|-----------|
+| UI admin para providers | Interface web para upload de XSD, configuração de regras e visualização de status |
+| Hot-reload de configuração | Alterar regras de provider sem reiniciar a aplicação |
+| Deploy em produção | Kubernetes, auto-scaling, alta disponibilidade |
+| Multi-tenancy | Isolamento de providers e configuração por tenant |
+| Audit trail | Log imutável de todo XML gerado com metadados |
+| Versionamento de config | Histórico de regras com rollback |
+| API key management | Autenticação e autorização por tenant |
+| Webhook de eventos | Notificar sistemas externos quando XML é gerado ou provider muda |
+| Frontend de onboarding self-service | UI para que o suporte onboarde providers sem CLI |
+
+---
+
+## Riscos e dependências
+
+| Risco | Impacto | Mitigação |
+|-------|---------|-----------|
+| Certificado digital A1/A3 tem complexidade de integração | Bloqueia produção real | Começar com certificado de teste, integrar lib existente |
+| Providers com XSD conflitante (8/48 no load test) | Limita onboarding automático | Seleção inteligente de XSD já implementada, ajustar heurísticas |
+| Multi-tenancy exige redesign de storage | Bloqueia enterprise | Planejar abstração de storage desde o início |
+| Schema cache pode ficar stale | XML com schema desatualizado | Invalidação por hash do arquivo XSD |
+
+## Marcos
+
+| Marco | Fase | Evidência |
+|-------|------|-----------|
+| Primeira NFS-e gerada em staging | Curto prazo | XML válido contra XSD em ambiente não-local |
+| Provider onboarded por suporte em produção | Curto prazo | `POST /providers/onboard` → XML sem intervenção de dev |
+| Engine substitui serializer manual (Nacional) | Curto prazo | Fallback removido, 100% via engine |
+| 10+ providers ativos | Médio prazo | Escala comprovada |
+| Primeiro tenant enterprise | Longo prazo | Multi-tenancy funcional com isolamento |
+| 50+ providers em produção | Longo prazo | Plataforma consolidada |
+
+---
+
+**Páginas relacionadas:**
+- [Visão Geral do Produto](Visao-Geral-do-Produto.md)
+- [Evolução da Solução](Evolucao-da-Solucao.md)
+- [Providers Suportados](Providers-Suportados.md)
+- [Status e Classificação de Gaps](Status-e-Classificacao-de-Gaps.md)

--- a/docs/wiki/Status-e-Classificacao-de-Gaps.md
+++ b/docs/wiki/Status-e-Classificacao-de-Gaps.md
@@ -1,0 +1,117 @@
+# Status e Classificacao de Gaps
+
+## Visao geral
+
+Cada provider gerenciado possui um status que reflete o resultado da validacao automatica.
+O status determina se o provider esta apto para uso em producao.
+
+---
+
+## Ciclo de vida dos status
+
+```
+                      validacao OK
+  Draft  ────────────────────────────>  Ready
+    |                                     |
+    |     validacao falhou                |  POST /deactivate
+    └──────────────────>  Blocked         └──────> Inactive
+                            |                        |
+                            |  revalidacao OK        |  POST /activate
+                            └───────> Ready  <───────┘
+```
+
+### Descricao dos status
+
+| Status     | Significado                                                          |
+|------------|----------------------------------------------------------------------|
+| `Draft`    | Recem-criado, aguardando resultado da primeira validacao              |
+| `Ready`    | Validacao passou; provider apto para gerar XML de NFS-e              |
+| `Blocked`  | Validacao falhou; `blockReason` contem o motivo                      |
+| `Inactive` | Desativado manualmente via `POST /providers/{id}/deactivate`         |
+
+### Transicoes
+
+- **Draft -> Ready**: validacao automatica passa no `Create`
+- **Draft -> Blocked**: validacao automatica falha no `Create`
+- **Blocked -> Ready**: revalidacao via `POST /providers/{id}/validate` passa
+- **Ready -> Inactive**: desativacao manual
+- **Inactive -> Ready**: ativacao via `POST /providers/{id}/activate` (com validacao)
+- **Qualquer -> Blocked**: validacao falha em qualquer momento
+
+---
+
+## O que causa Blocked
+
+| Causa                         | Check que falha     | Exemplo de blockReason                                    |
+|-------------------------------|--------------------|------------------------------------------------------------|
+| Nenhum XSD de envio encontrado | XsdSelection       | `No suitable send XSD found: all files matched exclusion patterns` |
+| Schema nao compila            | SchemaAnalysis     | `Schema analysis failed: The 'X' element is not declared`  |
+| Config nao gera               | ConfigGeneration   | `Config generation failed: No suitable send XSD found`     |
+| Serializacao falha totalmente | XmlSerialization   | `Serialization failed: ComplexType 'X' not found in schema`|
+
+---
+
+## Como revalidar um provider
+
+```bash
+# Revalidacao sob demanda
+curl -X POST http://localhost:5211/api/v1/providers/{id}/validate
+
+# Resposta inclui checks e pendingFields
+# Se passou: status muda para Ready
+# Se falhou: status muda para Blocked com blockReason
+```
+
+A revalidacao e util apos:
+- Atualizar os XSDs do provider (`PUT /api/v1/providers/{id}`)
+- Ajustar regras (`PUT /api/v1/providers/{id}/rules`)
+- Corrigir o `primaryXsdFile`
+
+---
+
+## Gaps conhecidos do MVP
+
+Alguns gaps sao esperados e nao impedem o uso do provider. Sao limitacoes
+conhecidas da engine ou do schema que serao tratadas em versoes futuras.
+
+| Gap                    | Descricao                                                           | Impacto                        |
+|------------------------|---------------------------------------------------------------------|--------------------------------|
+| `regTrib` / `tribMun`  | Campo de regime tributario municipal exige mapeamento enum especifico| Requer `EnumMapping` manual    |
+| `versao` (atributo)    | Atributo `versao` com valor fixo nao e validado pelo XSD em runtime | Warning no XSD validation      |
+| Envelope ABRASF         | Estrutura `LoteRps > ListaRps > Rps > InfRps` requer deteccao de envelope | Auto-gen trata, mas pode falhar em schemas nao padrao |
+| `cTribMun`             | Codigo de servico municipal varia por municipio, sem padrao nacional | Requer configuracao por provider|
+
+---
+
+## IsKnownXsdGap nos testes
+
+Os testes da suite `AllProvidersXsdValidationSummaryTests` classificam erros de
+validacao XSD em categorias conhecidas para nao tratarem como falhas reais:
+
+| Pattern de gap                  | Significado                                                 |
+|---------------------------------|--------------------------------------------------------------|
+| `versao attribute`              | Atributo versao com valor diferente do esperado pelo XSD    |
+| `incomplete content`            | Elementos opcionais ausentes nos dados de amostra           |
+| `invalid child element`         | Elemento emitido em posicao incorreta (ordem do schema)     |
+| `pattern constraint`            | Valor nao atende ao regex definido na restriction do XSD    |
+
+Esses gaps sao rastreados e reportados, mas nao bloqueiam o onboarding.
+
+---
+
+## Tabela de referencia de status por tipo de provider
+
+| Tipo de provider | Providers exemplo                     | Status tipico | Observacao                     |
+|------------------|---------------------------------------|---------------|--------------------------------|
+| Nacional (DPS)   | nacional                              | Ready         | Schema padronizado             |
+| ABRASF 2.x       | abrasf, gissonline, betha, webiss    | Ready         | Envelope detectado automaticamente |
+| ABRASF custom    | paulistana, curitiba                  | Ready/Blocked | Pode exigir `primaryXsdFile`   |
+| Proprietario     | providers com schema proprio          | Blocked       | Requer mapeamento manual       |
+
+---
+
+## Links relacionados
+
+- [Providers Suportados](Providers-Suportados.md)
+- [Validacao Automatica](Validacao-Automatica.md)
+- [Cadastro de Providers](Cadastro-de-Providers.md)

--- a/docs/wiki/Validacao-Automatica.md
+++ b/docs/wiki/Validacao-Automatica.md
@@ -1,0 +1,152 @@
+# Validacao Automatica
+
+## Visao geral
+
+A engine executa uma pipeline de 5 checks sequenciais para validar se um provider
+consegue gerar XML valido. Se qualquer check critico falhar, o provider e marcado
+como `Blocked` com o motivo da falha.
+
+---
+
+## Os 5 checks
+
+A validacao e implementada em `EngineProviderValidator` e segue esta ordem:
+
+| #  | Check             | O que verifica                                                        | Bloqueia? |
+|----|-------------------|-----------------------------------------------------------------------|-----------|
+| 1  | **XsdSelection**      | `SendXsdSelector` consegue identificar o XSD de envio               | Sim       |
+| 2  | **SchemaAnalysis**    | `XsdSchemaAnalyzer.Analyze` executa sem excecao                     | Sim       |
+| 3  | **ConfigGeneration**  | `ProviderConfigGenerator` gera profile ou profile ja existe no JSON | Sim       |
+| 4  | **XmlSerialization**  | `SchemaBasedXmlSerializer` produz XML a partir de dados de amostra  | Nao*      |
+| 5  | **XsdValidation**     | XML gerado passa na validacao contra o XSD via `XsdValidator`       | Nao*      |
+
+(*) Os checks 4 e 5 sao reportados como informativos. Se o XML foi produzido (mesmo com
+erros de campos ausentes), o check passa. Gaps de dados de amostra nao bloqueiam porque
+a validacao real acontece com dados reais de NFS-e.
+
+### Fluxo de execucao
+
+```
+XsdSelection  --(ok)--> SchemaAnalysis  --(ok)--> ConfigGeneration  --(ok)--> XmlSerialization + XsdValidation
+      |                      |                        |
+    (fail)                 (fail)                   (fail)
+      v                      v                        v
+   Blocked               Blocked                   Blocked
+```
+
+---
+
+## XsdValidator
+
+O `XsdValidator` e uma classe estatica centralizada usada pelo serializer, pelo onboarding
+validator e pelos testes. Possui duas estrategias de validacao:
+
+### Validacao scoped (send XSD)
+
+1. Tenta carregar e compilar apenas o XSD de envio selecionado
+2. Se compilar com sucesso, valida o XML contra esse schema isolado
+3. Inclui resolucao automatica de `xs:include` e `xs:import`
+
+### Fallback (todos os XSDs)
+
+1. Se o XSD de envio falhar na compilacao isolada, carrega todos os `*.xsd` do diretorio
+2. Compila o schema set completo
+3. Valida o XML contra o conjunto
+
+### Metodos principais
+
+| Metodo                   | Uso                                                    |
+|--------------------------|--------------------------------------------------------|
+| `Validate`               | Scoped com fallback; usado na serializacao              |
+| `ValidateAgainstDirectory` | Carrega todos os XSDs de um diretorio                |
+| `CompileSchemas`         | Apenas compila, sem validar XML; usado no onboarding   |
+| `ValidateXml` (extension)| Wrapper para uso em assertions de teste                |
+
+---
+
+## ValidationDiagnosticEnricher
+
+Quando a serializacao reporta erros de `InputError` (campos obrigatorios sem valor),
+o `ValidationDiagnosticEnricher` analisa cada campo e sugere mapeamentos:
+
+### Niveis de confianca
+
+| Confianca   | Significado                                              | Exemplo                               |
+|-------------|----------------------------------------------------------|----------------------------------------|
+| **Exact**   | Nome exato encontrado no `CommonFieldMappingDictionary`  | `CNPJ` -> `Provider.Cnpj`             |
+| **Partial** | Match apos remover prefixos comuns (`tc`, `Inf`, `TC`)   | `tcCNPJ` -> `Provider.Cnpj`           |
+| **None**    | Nenhuma sugestao; requer mapeamento manual               | `cRegTrib` -> `Manual mapping required`|
+
+### Processo
+
+1. Filtra apenas erros do tipo `InputError`
+2. Extrai o nome do campo (ultimo segmento do path)
+3. Busca match exato no `CommonFieldMappingDictionary`
+4. Se nao encontra, remove prefixos comuns e busca match parcial
+5. Retorna `PendingFieldDiagnostic` com `FieldPath`, `SuggestedSource`, `Confidence` e `Reason`
+
+### Formato de saida
+
+```
+[Exact] infDPS.CNPJ -> Provider.Cnpj
+[Partial] infDPS.tcCNPJ -> Provider.Cnpj
+[None] infDPS.cRegTrib (Manual mapping required)
+```
+
+---
+
+## Quando a validacao roda
+
+| Evento                              | Dispara validacao? | Detalhe                                           |
+|--------------------------------------|--------------------|----------------------------------------------------|
+| `POST /api/v1/providers`            | Sim                | Automatica apos cadastro                           |
+| `PUT /api/v1/providers/{id}`        | Sim                | Quando XSD ou regras mudam                         |
+| `POST /api/v1/providers/{id}/validate` | Sim             | Sob demanda                                        |
+| `POST /api/v1/providers/{id}/activate` | Condicional     | Valida se nao ha validacao previa                  |
+
+---
+
+## pendingFields no response da API
+
+O endpoint `POST /api/v1/providers/{id}/validate` retorna um `ValidationResponse`
+que inclui a lista `pendingFields` quando existem campos ausentes:
+
+```json
+{
+  "passed": true,
+  "checks": [
+    { "name": "XsdSelection", "passed": true, "detail": "Selected: servico_enviar_lote_rps_envio.xsd" },
+    { "name": "SchemaAnalysis", "passed": true, "detail": "Analyzed 12 complex types." },
+    { "name": "ConfigGeneration", "passed": true, "detail": "Profile loaded from rules JSON." },
+    { "name": "XsdValidation", "passed": true, "detail": "Pending fields: [Exact] Numero -> Number; [None] cRegTrib (Manual mapping required)" }
+  ],
+  "pendingFields": [
+    {
+      "fieldPath": "InfRps.Numero",
+      "isRequired": true,
+      "suggestedSource": "Number",
+      "confidence": "Exact",
+      "reason": "Exact match found for 'Numero'"
+    },
+    {
+      "fieldPath": "InfRps.cRegTrib",
+      "isRequired": true,
+      "suggestedSource": null,
+      "confidence": "None",
+      "reason": "Manual mapping required"
+    }
+  ],
+  "timestamp": "2026-03-23T14:00:00Z"
+}
+```
+
+O campo `pendingFields` permite que ferramentas de suporte identifiquem rapidamente
+quais regras precisam ser adicionadas para completar o onboarding.
+
+---
+
+## Links relacionados
+
+- [Status e Classificacao de Gaps](Status-e-Classificacao-de-Gaps.md)
+- [Engine e Interpretacao de XSD](Engine-e-Interpretacao-de-XSD.md)
+- [Cadastro de Providers](Cadastro-de-Providers.md)

--- a/docs/wiki/Visao-Geral-do-Produto.md
+++ b/docs/wiki/Visao-Geral-do-Produto.md
@@ -1,0 +1,60 @@
+# Visão Geral do Produto
+
+## O que é NFS-e
+
+A Nota Fiscal de Serviços Eletrônica (NFS-e) é o documento fiscal digital que registra a prestação de serviços no Brasil. Diferente da NF-e (mercadorias), que tem um padrão nacional único, a NFS-e varia de município para município. Cada prefeitura — ou o consórcio de software que a atende — define seu próprio formato XML, baseado em schemas XSD específicos.
+
+Na prática, isso significa que gerar NFS-e para São Paulo é completamente diferente de gerar para Belo Horizonte ou Curitiba. Os schemas XSD definem estruturas distintas, namespaces diferentes, campos obrigatórios diferentes e regras de validação próprias.
+
+## O problema
+
+A abordagem tradicional para lidar com essa diversidade é criar **serializadores manuais** para cada provider (padrão de software fiscal municipal). Cada novo município exige:
+
+- Análise manual do XSD
+- Implementação de um serializer C# específico
+- Testes manuais contra o schema
+- Manutenção contínua quando o provider atualiza o XSD
+
+Um serializer manual típico tem ~900 linhas de código com 19 métodos de build. Multiplicado por dezenas de providers, isso se torna um problema de escala insustentável.
+
+## A solução: Engine schema-driven
+
+O SemanaIA resolve esse problema com uma **engine que analisa XSDs em runtime**. Em vez de escrever código por provider, a engine:
+
+1. **Lê o XSD** do provider e constrói um modelo canônico (`SchemaModel`)
+2. **Resolve regras tipadas** que mapeiam campos do domínio para elementos do schema
+3. **Serializa o XML** dinamicamente, respeitando a estrutura definida pelo XSD
+4. **Valida o resultado** contra o schema original
+
+Onboarding de um novo provider requer apenas:
+- Upload dos arquivos XSD
+- Configuração mínima de regras (quando necessário)
+- Nenhuma alteração de código
+
+## Quem usa
+
+| Perfil | Como usa |
+|--------|---------|
+| **Desenvolvedor** | Evolui a engine, cria regras complexas, investiga gaps |
+| **Suporte técnico** | Onboarda novos providers via API, ajusta regras de configuração |
+| **Operação** | Monitora status dos providers, identifica gaps de cobertura |
+
+## Capacidades atuais
+
+- Análise automática de XSD em runtime com suporte a tipos inline, multi-namespace e xs:attribute
+- Serialização dinâmica de XML a partir de `DpsDocument` (modelo canônico de domínio)
+- Validação automática do XML gerado contra o XSD do provider
+- DSL de regras tipadas com auto-geração a partir do schema
+- Resolução de provider por código de município (IBGE)
+- API REST para geração de XML, onboarding e gestão de providers
+- Persistência de providers e regras em MongoDB
+- Diagnóstico enriquecido com classificação de gaps (ConfigurationGap, EngineGap)
+- 7 providers configurados, 5 totalmente operacionais
+- 727 testes automatizados (611 unitários + 116 integração)
+
+---
+
+**Páginas relacionadas:**
+- [Evolução da Solução](Evolucao-da-Solucao.md)
+- [Arquitetura](Arquitetura.md)
+- [Providers Suportados](Providers-Suportados.md)


### PR DESCRIPTION
Wiki documentation organized as navigable knowledge base:
- Product: overview, evolution (6 phases/34 commits), providers, roadmap
- Architecture: pipeline, E2E flow, XSD engine, validation, gap classification
- Provider management: registration, rules (6 types), API (18 endpoints), examples
- Support: onboarding step-by-step, troubleshooting, escalation criteria
- AI journey: 10 themes (Terminal, Docker, Assistant, Agent, Multi-agents, Skills, MCP/LSP, Tools, Commands, Scheduling) with real project examples
- Presentation: 60min structure, demo scripts, FAQ

README updated to executive format pointing to docs/wiki/Home.md