### PR TITLE
test(issnet): add comprehensive XML generation tests with XSD validation

### DIFF
--- a/tests/SemanaIA.ServiceInvoice.UnitTests/SchemaEngine/IssnetXmlSerializationTests.cs
+++ b/tests/SemanaIA.ServiceInvoice.UnitTests/SchemaEngine/IssnetXmlSerializationTests.cs
@@ -45,6 +45,7 @@ public class IssnetXmlSerializationTests
 
         // Assert
         result.Xml.ShouldNotBeNull($"Errors: {FormatErrors(result)}");
+        result.Errors.ShouldBeEmpty(FormatErrors(result));
         result.Xml.ShouldBeValidAgainstProviderSchema(TestProviderPaths.FindXsdDir("issnet"));
 
         result.Xml.ShouldContain("11222333000181"); // Provider CNPJ
@@ -69,6 +70,7 @@ public class IssnetXmlSerializationTests
 
         // Assert
         result.Xml.ShouldNotBeNull($"Errors: {FormatErrors(result)}");
+        result.Errors.ShouldBeEmpty(FormatErrors(result));
         result.Xml.ShouldBeValidAgainstProviderSchema(TestProviderPaths.FindXsdDir("issnet"));
 
         var root = XDocument.Parse(result.Xml!).Root!;
@@ -102,6 +104,7 @@ public class IssnetXmlSerializationTests
 
         // Assert
         result.Xml.ShouldNotBeNull($"Errors: {FormatErrors(result)}");
+        result.Errors.ShouldBeEmpty(FormatErrors(result));
         result.Xml.ShouldBeValidAgainstProviderSchema(TestProviderPaths.FindXsdDir("issnet"));
 
         var root = XDocument.Parse(result.Xml!).Root!;
@@ -131,12 +134,14 @@ public class IssnetXmlSerializationTests
 
         // Assert
         result.Xml.ShouldNotBeNull($"Errors: {FormatErrors(result)}");
+        result.Errors.ShouldBeEmpty(FormatErrors(result));
         result.Xml.ShouldBeValidAgainstProviderSchema(TestProviderPaths.FindXsdDir("issnet"));
 
         var root = XDocument.Parse(result.Xml!).Root!;
 
         // Bindings are prefixed with LoteDps.ListaDps.DPS, so infDPS lives inside DPS
-        var dps = root.Descendants().First(e => e.Name.LocalName == "DPS");
+        var dps = root.Descendants().FirstOrDefault(e => e.Name.LocalName == "DPS");
+        dps.ShouldNotBeNull("DPS element should exist in envelope");
         var infDps = dps.Element(Ns + "infDPS");
         infDps.ShouldNotBeNull("infDPS should exist under DPS (bindingPathPrefix = LoteDps.ListaDps.DPS)");
 
@@ -184,7 +189,7 @@ public class IssnetXmlSerializationTests
         // Arrange - document without Borrower, Location, IssRate, SpecialTaxRegime, etc.
         // CityServiceCode is kept because cTribMun is required in the XSD (minOccurs=1).
         var document = CreateIssnetMinimalDocument();
-        document.Borrower = new Borrower();
+        document.Borrower = null;
         document.Location = null;
         document.Values.IssRate = null;
         document.Provider.SpecialTaxRegime = null;
@@ -194,6 +199,7 @@ public class IssnetXmlSerializationTests
 
         // Assert
         result.Xml.ShouldNotBeNull($"Errors: {FormatErrors(result)}");
+        result.Errors.ShouldBeEmpty(FormatErrors(result));
         result.Xml.ShouldBeValidAgainstProviderSchema(TestProviderPaths.FindXsdDir("issnet"));
     }
 


### PR DESCRIPTION
## Summary

7 testes cobrindo geração XML do provider ISSNet com validação XSD via `ShouldBeValidAgainstProviderSchema`.

Closes #59

## Tests

| Test | Validates |
|------|-----------|
| MinimalDocument | XML mínimo valida contra XSD |
| CompleteDocument | Todos os bindings + XSD valid |
| EnvelopeStructure | EnviarLoteDpsEnvio > LoteDps > ListaDps > DPS > infDPS |
| WrapperBindingValues | versao=1.01, NumeroLote, QuantidadeDps, Prestador |
| BindingPathPrefix | infDPS fields under DPS via bindingPathPrefix |
| BorrowerCnpj | Borrower presente, XSD válido |
| OptionalFieldsAbsent | Sem borrower/location, XSD válido |

## Test plan
- [x] 820 testes passando (698 unit + 122 integration)
- [x] Zero regressões
- [x] Todos os testes usam ShouldBeValidAgainstProviderSchema

🤖 Generated with [Claude Code](https://claude.com/claude-code)