### PR TITLE
fix(ci): add workflow_dispatch trigger for manual CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [master, main, "feature/**", "feat/**", "fix/**", "chore/**"]
   pull_request:
     branches: [master, main]
+  workflow_dispatch:
 
 env:
   SONAR_ENABLED: ${{ secrets.SONAR_TOKEN != '' && vars.SONAR_ORGANIZATION != '' }}


### PR DESCRIPTION
## Summary
Adiciona `workflow_dispatch` ao CI para permitir trigger manual via GitHub UI ou `gh workflow run`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)