### PR TITLE
fix(tests): correct cleanup prefix mismatch in ManualVsEngineApiComparisonTests

### DIFF
--- a/tests/SemanaIA.ServiceInvoice.IntegrationsTests/ManualVsEngineApiComparisonTests.cs
+++ b/tests/SemanaIA.ServiceInvoice.IntegrationsTests/ManualVsEngineApiComparisonTests.cs
@@ -208,7 +208,7 @@ public class ManualVsEngineApiComparisonTests : IClassFixture<WebApplicationFact
             {
                 var id = provider.GetProperty("id").GetString();
                 var name = provider.GetProperty("name").GetString() ?? "";
-                if (id is not null && name.StartsWith("compare-", StringComparison.OrdinalIgnoreCase))
+                if (id is not null && name.StartsWith("e2e-cmp-", StringComparison.OrdinalIgnoreCase))
                     await _client.DeleteAsync($"{ProvidersEndpoint}/{id}");
             }
         }


### PR DESCRIPTION
## Summary
Cleanup usava prefixo `compare-` mas o teste cria providers com `e2e-cmp-`. Corrige para `e2e-cmp-`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)